### PR TITLE
Fix unread chip visibility when LiveData's value is null

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListMultiSelection.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListMultiSelection.kt
@@ -152,8 +152,8 @@ class ThreadListMultiSelection {
     }
 
     private fun hideUnreadChip(isMultiSelectOn: Boolean) {
-        val noUnread = mainViewModel.currentFolderLive.value?.let { it.unreadCount == 0 } == true
-        binding.unreadCountChip.isGone = isMultiSelectOn || noUnread
+        val thereAreUnread = mainViewModel.currentFolderLive.value?.let { it.unreadCount > 0 } == true
+        binding.unreadCountChip.isVisible = thereAreUnread && !isMultiSelectOn
     }
 
     private fun displayMultiSelectActions(isMultiSelectOn: Boolean) = with(binding) {


### PR DESCRIPTION
When booting the app with empty realm, the unread chip was displayed when it should not have