### PR TITLE
Allow folder creation whose name is same as a subfolder

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/MenuFoldersFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/MenuFoldersFragment.kt
@@ -60,7 +60,9 @@ abstract class MenuFoldersFragment : Fragment() {
 
         return when {
             folderName.length > 255 -> getString(R.string.errorNewFolderNameTooLong)
-            allFolders.any { it.name == folderName.toString() } -> context?.getString(R.string.errorNewFolderAlreadyExists)
+            allFolders.any { it.parent == null && it.name == folderName.toString() } -> {
+                context?.getString(R.string.errorNewFolderAlreadyExists)
+            }
             else -> null
         }
     }


### PR DESCRIPTION
The Api allow to create a folder with the same name as another as long as it's not in the same parent folder.
As we can only create first level folder, we check name of all folders that don't have a parent.