### PR TITLE
Mail detailed informations UI fixes

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -242,6 +242,8 @@ class ThreadAdapter : RecyclerView.Adapter<ThreadViewHolder>(), RealmChangesBind
             onContactClicked?.invoke(message.from.first())
         }
 
+        setDetailedFieldsVisibility(message)
+
         initWebViewClientIfNeeded(message.attachments)
 
         handleHeaderClick(message)
@@ -274,6 +276,12 @@ class ThreadAdapter : RecyclerView.Adapter<ThreadViewHolder>(), RealmChangesBind
         )
     }
 
+    private fun ItemMessageBinding.setDetailedFieldsVisibility(message: Message) {
+        toGroup.isVisible = message.to.isNotEmpty()
+        ccGroup.isVisible = message.cc.isNotEmpty()
+        bccGroup.isVisible = message.bcc.isNotEmpty()
+    }
+
     private fun ItemMessageBinding.handleHeaderClick(message: Message) {
         messageHeader.setOnClickListener {
             if (isExpandedMap[message.uid] == true) {
@@ -295,9 +303,7 @@ class ThreadAdapter : RecyclerView.Adapter<ThreadViewHolder>(), RealmChangesBind
             message.detailsAreExpanded = !message.detailsAreExpanded
             val isExpanded = message.detailsAreExpanded
             recipientChevron.toggleChevron(!isExpanded)
-            detailedFieldsGroup.isVisible = isExpanded
-            ccGroup.isVisible = isExpanded && message.cc.isNotEmpty()
-            bccGroup.isVisible = isExpanded && message.bcc.isNotEmpty()
+            messageDetails.isVisible = isExpanded
             context.trackMessageEvent("openDetails", isExpanded)
         }
     }
@@ -386,9 +392,7 @@ class ThreadAdapter : RecyclerView.Adapter<ThreadViewHolder>(), RealmChangesBind
 
     private fun ItemMessageBinding.collapseMessageDetails(message: Message) {
         message.detailsAreExpanded = false
-        ccGroup.isGone = true
-        bccGroup.isGone = true
-        detailedFieldsGroup.isGone = true
+        messageDetails.isGone = true
         recipientChevron.rotation = 0.0f
     }
 

--- a/app/src/main/res/layout/item_detailed_contact.xml
+++ b/app/src/main/res/layout/item_detailed_contact.xml
@@ -28,6 +28,7 @@
         style="@style/TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:gravity="start"
         android:insetTop="0dp"
         android:insetBottom="0dp"
         android:minWidth="0dp"

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -173,140 +173,174 @@
 
     </com.google.android.material.card.MaterialCardView>
 
-    <TextView
-        android:id="@+id/fromPrefix"
-        style="@style/BodySmall.Secondary"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/messageDetails"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/marginStandardMedium"
-        android:text="@string/fromTitle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/messageHeader" />
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/fromRecyclerView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/marginStandardSmall"
-        android:paddingStart="@dimen/marginStandardVerySmall"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        android:paddingBottom="@dimen/marginStandardMedium"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/prefixBarrier"
-        app:layout_constraintTop_toTopOf="@id/fromPrefix"
-        tools:ignore="RtlSymmetry"
-        tools:itemCount="2"
-        tools:listitem="@layout/item_detailed_contact" />
-
-    <TextView
-        android:id="@+id/toPrefix"
-        style="@style/BodySmall.Secondary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/marginStandardMedium"
-        android:layout_marginTop="@dimen/marginStandardSmall"
-        android:text="@string/toTitle"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/fromRecyclerView" />
+        app:layout_constraintTop_toBottomOf="@id/messageHeader">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/toRecyclerView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/marginStandardSmall"
-        android:paddingStart="@dimen/marginStandardVerySmall"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/prefixBarrier"
-        app:layout_constraintTop_toTopOf="@id/toPrefix"
-        tools:ignore="RtlSymmetry"
-        tools:itemCount="3"
-        tools:listitem="@layout/item_detailed_contact" />
+        <TextView
+            android:id="@+id/fromPrefix"
+            style="@style/BodySmall.Secondary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/marginStandardMedium"
+            android:text="@string/fromTitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/ccPrefix"
-        style="@style/BodySmall.Secondary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/marginStandardMedium"
-        android:layout_marginTop="@dimen/marginStandardSmall"
-        android:text="@string/ccTitle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toRecyclerView" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/fromRecyclerView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/marginStandardSmall"
+            android:paddingStart="@dimen/marginStandardVerySmall"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/prefixBarrier"
+            app:layout_constraintTop_toTopOf="@id/fromPrefix"
+            tools:ignore="RtlSymmetry"
+            tools:itemCount="2"
+            tools:listitem="@layout/item_detailed_contact" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/ccRecyclerView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/marginStandardSmall"
-        android:paddingStart="@dimen/marginStandardVerySmall"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/prefixBarrier"
-        app:layout_constraintTop_toTopOf="@id/ccPrefix"
-        tools:ignore="RtlSymmetry"
-        tools:itemCount="2"
-        tools:listitem="@layout/item_detailed_contact" />
+        <TextView
+            android:id="@+id/toPrefix"
+            style="@style/BodySmall.Secondary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/marginStandardMedium"
+            android:layout_marginTop="@dimen/marginStandardSmall"
+            android:text="@string/toTitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/fromRecyclerView" />
 
-    <TextView
-        android:id="@+id/bccPrefix"
-        style="@style/BodySmall.Secondary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/marginStandardMedium"
-        android:layout_marginTop="@dimen/marginStandardSmall"
-        android:text="@string/bccTitle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/ccRecyclerView" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/toRecyclerView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/marginStandardSmall"
+            android:paddingStart="@dimen/marginStandardVerySmall"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/prefixBarrier"
+            app:layout_constraintTop_toTopOf="@id/toPrefix"
+            tools:ignore="RtlSymmetry"
+            tools:itemCount="3"
+            tools:listitem="@layout/item_detailed_contact" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/bccRecyclerView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/marginStandardSmall"
-        android:paddingStart="@dimen/marginStandardVerySmall"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/prefixBarrier"
-        app:layout_constraintTop_toTopOf="@id/bccPrefix"
-        tools:ignore="RtlSymmetry"
-        tools:itemCount="1"
-        tools:listitem="@layout/item_detailed_contact" />
+        <TextView
+            android:id="@+id/ccPrefix"
+            style="@style/BodySmall.Secondary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/marginStandardMedium"
+            android:layout_marginTop="@dimen/marginStandardSmall"
+            android:text="@string/ccTitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toRecyclerView" />
 
-    <ImageView
-        android:id="@+id/detailedMessagePrefix"
-        android:layout_width="18dp"
-        android:layout_height="18dp"
-        android:layout_marginStart="@dimen/marginStandardMedium"
-        android:layout_marginTop="@dimen/marginStandardSmall"
-        android:src="@drawable/ic_calendar"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/bccRecyclerView"
-        app:tint="@color/iconColor"
-        tools:ignore="ContentDescription" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/ccRecyclerView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/marginStandardSmall"
+            android:paddingStart="@dimen/marginStandardVerySmall"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/prefixBarrier"
+            app:layout_constraintTop_toTopOf="@id/ccPrefix"
+            tools:ignore="RtlSymmetry"
+            tools:itemCount="2"
+            tools:listitem="@layout/item_detailed_contact" />
 
-    <TextView
-        android:id="@+id/detailedMessageDate"
-        style="@style/BodySmall.Secondary"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/marginStandardMedium"
-        app:layout_constraintBottom_toBottomOf="@id/detailedMessagePrefix"
-        app:layout_constraintStart_toEndOf="@id/prefixBarrier"
-        app:layout_constraintTop_toTopOf="@id/detailedMessagePrefix"
-        tools:text="10 juin 2022, 16:36" />
+        <TextView
+            android:id="@+id/bccPrefix"
+            style="@style/BodySmall.Secondary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/marginStandardMedium"
+            android:layout_marginTop="@dimen/marginStandardSmall"
+            android:text="@string/bccTitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ccRecyclerView" />
 
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/prefixBarrier"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="right"
-        app:constraint_referenced_ids="fromPrefix,toPrefix,ccPrefix,bccPrefix,detailedMessagePrefix" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/bccRecyclerView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/marginStandardSmall"
+            android:paddingStart="@dimen/marginStandardVerySmall"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/prefixBarrier"
+            app:layout_constraintTop_toTopOf="@id/bccPrefix"
+            tools:ignore="RtlSymmetry"
+            tools:itemCount="1"
+            tools:listitem="@layout/item_detailed_contact" />
+
+        <ImageView
+            android:id="@+id/detailedMessagePrefix"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:layout_marginStart="@dimen/marginStandardMedium"
+            android:layout_marginTop="@dimen/marginStandardSmall"
+            android:src="@drawable/ic_calendar"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/bccRecyclerView"
+            app:tint="@color/iconColor"
+            tools:ignore="ContentDescription" />
+
+        <TextView
+            android:id="@+id/detailedMessageDate"
+            style="@style/BodySmall.Secondary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/marginStandardMedium"
+            app:layout_constraintBottom_toBottomOf="@id/detailedMessagePrefix"
+            app:layout_constraintStart_toEndOf="@id/prefixBarrier"
+            app:layout_constraintTop_toTopOf="@id/detailedMessagePrefix"
+            tools:text="10 juin 2022, 16:36" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/prefixBarrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="right"
+            app:constraint_referenced_ids="fromPrefix,toPrefix,ccPrefix,bccPrefix,detailedMessagePrefix" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/toGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:constraint_referenced_ids="toRecyclerView,toPrefix"
+            tools:visibility="visible" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/ccGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:constraint_referenced_ids="ccRecyclerView,ccPrefix"
+            tools:visibility="visible" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/bccGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:constraint_referenced_ids="bccRecyclerView,bccPrefix"
+            tools:visibility="visible" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/attachmentsRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/marginStandardMedium"
         android:clipToPadding="false"
         android:orientation="horizontal"
         android:paddingHorizontal="@dimen/alternativeMargin"
@@ -314,7 +348,7 @@
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/detailedMessageDate"
+        app:layout_constraintTop_toBottomOf="@id/messageDetails"
         app:layout_goneMarginTop="@dimen/marginStandardSmall"
         tools:listitem="@layout/item_attachment" />
 
@@ -466,30 +500,6 @@
         android:layout_height="wrap_content"
         android:visibility="gone"
         app:constraint_referenced_ids="attachmentsIcon,attachmentsSizeText,attachmentsDownloadAllButton"
-        tools:visibility="visible" />
-
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/ccGroup"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:constraint_referenced_ids="ccRecyclerView,ccPrefix"
-        tools:visibility="visible" />
-
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/bccGroup"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:constraint_referenced_ids="bccRecyclerView,bccPrefix"
-        tools:visibility="visible" />
-
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/detailedFieldsGroup"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:constraint_referenced_ids="fromPrefix,fromRecyclerView,toPrefix,toRecyclerView,detailedMessagePrefix,detailedMessageDate"
         tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
* Fix margin below Detailed Informations of a Message.
* Fix margin above Body of a Message.
* Hide `To:` field in Detailed Informations when it's empty the same way it was already done for `Cc:` and `Bcc:`.
* If a name is too long to fit on a single line and needs to be wrapped, left align the name rather than horizontally center it.