### PR TITLE
Handle Draft actions API errors

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/Exceptions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Exceptions.kt
@@ -20,7 +20,9 @@ package com.infomaniak.mail.utils
 class ApiErrorException(override val message: String?) : Exception() {
 
     object ErrorCodes {
-        const val FOLDER_DOES_NOT_EXIST = "folder__not_exists"
+        const val DRAFT_DOES_NOT_EXIST = "draft__not_found"
+        const val DRAFT_HAS_MANY_RECIPIENTS = "draft__to_many_recipients"
         const val FOLDER_ALREADY_EXISTS = "folder__destination_already_exists"
+        const val FOLDER_DOES_NOT_EXIST = "folder__not_exists"
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/utils/Exceptions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Exceptions.kt
@@ -27,7 +27,7 @@ class ApiErrorException(override val message: String?) : Exception() {
 
     object ErrorCodes {
         const val DRAFT_DOES_NOT_EXIST = "draft__not_found"
-        const val DRAFT_HAS_MANY_RECIPIENTS = "draft__to_many_recipients"
+        const val DRAFT_HAS_TOO_MANY_RECIPIENTS = "draft__to_many_recipients"
         const val FOLDER_ALREADY_EXISTS = "folder__destination_already_exists"
         const val FOLDER_DOES_NOT_EXIST = "folder__not_exists"
     }

--- a/app/src/main/java/com/infomaniak/mail/utils/Exceptions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Exceptions.kt
@@ -17,7 +17,13 @@
  */
 package com.infomaniak.mail.utils
 
+import com.infomaniak.lib.core.api.ApiController
+import com.infomaniak.lib.core.models.ApiResponse
+import kotlinx.serialization.decodeFromString
+
 class ApiErrorException(override val message: String?) : Exception() {
+
+    inline val apiResponse get() = ApiController.json.decodeFromString<ApiResponse<Any>>(message!!)
 
     object ErrorCodes {
         const val DRAFT_DOES_NOT_EXIST = "draft__not_found"

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -41,7 +41,7 @@ import com.infomaniak.mail.data.models.draft.Draft
 import com.infomaniak.mail.data.models.draft.Draft.DraftAction
 import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.ApiErrorException.ErrorCodes.DRAFT_DOES_NOT_EXIST
-import com.infomaniak.mail.utils.ApiErrorException.ErrorCodes.DRAFT_HAS_MANY_RECIPIENTS
+import com.infomaniak.mail.utils.ApiErrorException.ErrorCodes.DRAFT_HAS_TOO_MANY_RECIPIENTS
 import com.infomaniak.mail.utils.NotificationUtils.showDraftActionsNotification
 import io.realm.kotlin.MutableRealm
 import io.sentry.Sentry
@@ -138,7 +138,7 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : BaseC
 
     private fun ApiErrorException.handleApiErrors(realm: MutableRealm, draft: Draft) {
         when (apiResponse.error?.code) {
-            DRAFT_DOES_NOT_EXIST, DRAFT_HAS_MANY_RECIPIENTS -> realm.delete(draft)
+            DRAFT_DOES_NOT_EXIST, DRAFT_HAS_TOO_MANY_RECIPIENTS -> realm.delete(draft)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -137,7 +137,7 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : BaseC
     }
 
     private fun ApiErrorException.handleApiErrors(realm: MutableRealm, draft: Draft) {
-        when (ApiController.json.decodeFromString<ApiResponse<Any>>(message!!).error?.code) {
+        when (apiResponse.error?.code) {
             DRAFT_DOES_NOT_EXIST, DRAFT_HAS_MANY_RECIPIENTS -> realm.delete(draft)
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -40,6 +40,8 @@ import com.infomaniak.mail.data.models.Mailbox
 import com.infomaniak.mail.data.models.draft.Draft
 import com.infomaniak.mail.data.models.draft.Draft.DraftAction
 import com.infomaniak.mail.utils.*
+import com.infomaniak.mail.utils.ApiErrorException.ErrorCodes.DRAFT_DOES_NOT_EXIST
+import com.infomaniak.mail.utils.ApiErrorException.ErrorCodes.DRAFT_HAS_MANY_RECIPIENTS
 import com.infomaniak.mail.utils.NotificationUtils.showDraftActionsNotification
 import io.realm.kotlin.MutableRealm
 import io.sentry.Sentry
@@ -114,8 +116,11 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : BaseC
                     draft.uploadAttachments(realm = this)
                     executeDraftAction(draft, mailbox.uuid, realm = this, okHttpClient)?.also(scheduledDates::add)
                 }.onFailure { exception ->
+                    when (exception) {
+                        is ApiController.NetworkException -> throw exception
+                        is ApiErrorException -> exception.handleApiErrors(realm = this, draft = draft)
+                    }
                     exception.printStackTrace()
-                    if (exception is ApiController.NetworkException) throw exception
                     Sentry.captureException(exception)
                     hasRemoteException = true
                 }
@@ -129,6 +134,12 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : BaseC
         SentryDebug.sendOrphanDrafts(mailboxContentRealm)
 
         return if (isFailure) Result.failure() else Result.success()
+    }
+
+    private fun ApiErrorException.handleApiErrors(realm: MutableRealm, draft: Draft) {
+        when (ApiController.json.decodeFromString<ApiResponse<Any>>(message!!).error?.code) {
+            DRAFT_DOES_NOT_EXIST, DRAFT_HAS_MANY_RECIPIENTS -> realm.delete(draft)
+        }
     }
 
     private suspend fun updateFolderAfterDelay(scheduledDates: MutableList<String>) {


### PR DESCRIPTION
- feat: Known errors management, which will make the service always restart them