### PR TITLE
fix: Allowing non-ASCII attachment name in okhttp header

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -176,11 +176,13 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : BaseC
 
     private fun Attachment.startUpload(localDraftUuid: String, realm: MutableRealm) {
         val attachmentFile = getUploadLocalFile(applicationContext, localDraftUuid).also { if (!it.exists()) return }
+        val headers = HttpUtils.getHeaders(contentType = null).newBuilder()
+            .addUnsafeNonAscii("x-ws-attachment-filename", name)
+            .add("x-ws-attachment-mime-type", mimeType)
+            .add("x-ws-attachment-disposition", "attachment")
+            .build()
         val request = Request.Builder().url(ApiRoutes.createAttachment(mailbox.uuid))
-            .headers(HttpUtils.getHeaders(contentType = null))
-            .addHeader("x-ws-attachment-filename", name)
-            .addHeader("x-ws-attachment-mime-type", mimeType)
-            .addHeader("x-ws-attachment-disposition", "attachment")
+            .headers(headers)
             .post(attachmentFile.asRequestBody(mimeType.toMediaType()))
             .build()
 


### PR DESCRIPTION
Fix: Attachments with non-ASCII names are not allowed in the okhttp header - [Sentry link](https://sentry.infomaniak.com/share/issue/4da690da502649229dcc11120e12944b/)

**Exception**
```
java.lang.IllegalArgumentException: Unexpected char 0xe9 at 5 in x-ws-attachment-filename value: Relevé de compte 02.pdf
    at okhttp3.Headers$Companion.checkValue(Headers.kt:450)
    at okhttp3.Headers$Companion.access$checkValue(Headers.kt:362)
    at okhttp3.Headers$Builder.add(Headers.kt:261)
    at okhttp3.Request$Builder.addHeader(Request.kt:210)
    at com.infomaniak.mail.workers.DraftsActionsWorker.startUpload(DraftsActionsWorker.kt:170)
    at com.infomaniak.mail.workers.DraftsActionsWorker.uploadAttachments(DraftsActionsWorker.kt:153)
    at com.infomaniak.mail.workers.DraftsActionsWorker.access$uploadAttachments(DraftsActionsWorker.kt:61)
    at com.infomaniak.mail.workers.DraftsActionsWorker$handleDraftsActions$isFailure$1.invoke(DraftsActionsWorker.kt:114)
    at com.infomaniak.mail.workers.DraftsActionsWorker$handleDraftsActions$isFailure$1.invoke(DraftsActionsWorker.kt:104)
    at io.realm.kotlin.internal.SuspendableWriter$write$2.invokeSuspend(SuspendableWriter.kt:109)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at java.lang.Thread.run(Thread.java:919)
```