### PR TITLE
fix: The `swipeRefresh` layout lags too much in Threads list

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
@@ -112,7 +112,7 @@ class FolderAdapter(
 
     @SuppressLint("NotifyDataSetChanged")
     fun setFolders(newFolders: List<Folder>, newCurrentFolderId: String?) {
-        // TODO: Temporary fix, we use a DiffUtil while waiting to realize it with realm or in async
+        // TODO: Temporary fix, we use a DiffUtil while waiting to do it with Realm or asynchronously.
         val diffResult = DiffUtil.calculateDiff(FolderDiffCallback(newFolders))
         currentFolderId = newCurrentFolderId
         folders = newFolders
@@ -149,13 +149,11 @@ class FolderAdapter(
 
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
             val (oldFolder, newFolder) = folders[oldItemPosition] to newFolders[newItemPosition]
-            return oldFolder.isFavorite == newFolder.isFavorite &&
-                    oldFolder.path.count() == newFolder.path.count() &&
-                    oldFolder.role == newFolder.role &&
-                    oldFolder.threads.count() == newFolder.threads.count() &&
+            return oldFolder.name == newFolder.name &&
+                    oldFolder.isFavorite == newFolder.isFavorite &&
+                    oldFolder.path == newFolder.path &&
                     oldFolder.unreadCount == newFolder.unreadCount &&
-                    oldFolder.name == newFolder.name
+                    oldFolder.threads.count() == newFolder.threads.count()
         }
-
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.infomaniak.lib.core.utils.context
 import com.infomaniak.mail.MatomoMail.trackMenuDrawerEvent
@@ -111,9 +112,11 @@ class FolderAdapter(
 
     @SuppressLint("NotifyDataSetChanged")
     fun setFolders(newFolders: List<Folder>, newCurrentFolderId: String?) {
+        // TODO: Temporary fix, we use a DiffUtil while waiting to realize it with realm or in async
+        val diffResult = DiffUtil.calculateDiff(FolderDiffCallback(newFolders))
         currentFolderId = newCurrentFolderId
         folders = newFolders
-        notifyDataSetChanged()
+        diffResult.dispatchUpdatesTo(this)
     }
 
     fun updateSelectedState(newCurrentFolderId: String) {
@@ -133,4 +136,26 @@ class FolderAdapter(
     }
 
     class FolderViewHolder(val binding: ItemFolderMenuDrawerBinding) : RecyclerView.ViewHolder(binding.root)
+
+    inner class FolderDiffCallback(private val newFolders: List<Folder>) : DiffUtil.Callback() {
+
+        override fun getOldListSize() = folders.count()
+
+        override fun getNewListSize() = newFolders.count()
+
+        override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            return folders[oldItemPosition].id == newFolders[newItemPosition].id
+        }
+
+        override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+            val (oldFolder, newFolder) = folders[oldItemPosition] to newFolders[newItemPosition]
+            return oldFolder.isFavorite == newFolder.isFavorite &&
+                    oldFolder.path.count() == newFolder.path.count() &&
+                    oldFolder.role == newFolder.role &&
+                    oldFolder.threads.count() == newFolder.threads.count() &&
+                    oldFolder.unreadCount == newFolder.unreadCount &&
+                    oldFolder.name == newFolder.name
+        }
+
+    }
 }


### PR DESCRIPTION
With stable ids:
[Stable ids.webm](https://user-images.githubusercontent.com/28200274/228893957-06ce9256-a199-4963-868f-abb6db8b7587.webm)

With DiffUtils
[With DiffUtils.webm](https://user-images.githubusercontent.com/28200274/228895045-408ff144-cc98-40ad-adb5-a2783d4587c1.webm)


