### PR TITLE
Fix crash in `computeInitials()` if Correspondent has only ponctuations in its name

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/correspondent/Correspondent.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/correspondent/Correspondent.kt
@@ -37,7 +37,7 @@ interface Correspondent : Parcelable {
 
     fun computeInitials(): String {
         val (firstName, lastName) = computeFirstAndLastName()
-        val first = firstName.removeControlAndPunctuation().first()
+        val first = firstName.removeControlAndPunctuation().ifBlank { firstName }.first()
         val last = lastName.removeControlAndPunctuation().firstOrEmpty()
 
         return "$first$last".uppercase()


### PR DESCRIPTION
Fixes SENTRY-114589
Fix #820