### PR TITLE
Stop notif permission requesting

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
@@ -79,10 +79,10 @@ class LocalSettings private constructor(context: Context) {
         set(value) = sharedPreferences.transaction { putBoolean(ASK_EMAIL_ACKNOWLEDGMENT_KEY, value) }
     //endregion
 
-    //region Enabled notifications
-    var hasEnabledNotifications: Boolean
-        get() = sharedPreferences.getBoolean(HAS_ENABLED_NOTIFICATIONS_KEY, DEFAULT_HAS_ENABLED_NOTIFICATIONS)
-        set(value) = sharedPreferences.transaction { putBoolean(HAS_ENABLED_NOTIFICATIONS_KEY, value) }
+    //region Already enabled notifications
+    var hasAlreadyEnabledNotifications: Boolean
+        get() = sharedPreferences.getBoolean(HAS_ALREADY_ENABLED_NOTIFICATIONS_KEY, DEFAULT_HAS_ALREADY_ENABLED_NOTIFICATIONS)
+        set(value) = sharedPreferences.transaction { putBoolean(HAS_ALREADY_ENABLED_NOTIFICATIONS_KEY, value) }
     //endregion
 
     //region App lock
@@ -278,7 +278,7 @@ class LocalSettings private constructor(context: Context) {
         private val DEFAULT_EMAIL_FORWARDING = EmailForwarding.IN_BODY
         private const val DEFAULT_INCLUDE_MESSAGE_IN_REPLY = true
         private const val DEFAULT_ASK_EMAIL_ACKNOWLEDGMENT = false
-        private const val DEFAULT_HAS_ENABLED_NOTIFICATIONS = false
+        private const val DEFAULT_HAS_ALREADY_ENABLED_NOTIFICATIONS = false
         private const val DEFAULT_IS_APP_LOCKED = false
         private const val DEFAULT_UPDATE_LATER = false
         private val DEFAULT_THREAD_DENSITY = ThreadDensity.LARGE
@@ -298,7 +298,7 @@ class LocalSettings private constructor(context: Context) {
         private const val EMAIL_FORWARDING_KEY = "emailForwardingKey"
         private const val INCLUDE_MESSAGE_IN_REPLY_KEY = "includeMessageInReplyKey"
         private const val ASK_EMAIL_ACKNOWLEDGMENT_KEY = "askEmailAcknowledgmentKey"
-        private const val HAS_ENABLED_NOTIFICATIONS_KEY = "hasEnabledNotificationsKey"
+        private const val HAS_ALREADY_ENABLED_NOTIFICATIONS_KEY = "hasAlreadyEnabledNotificationsKey"
         private const val IS_APP_LOCKED_KEY = "isAppLockedKey"
         private const val UPDATE_LATER_KEY = "updateLaterKey"
         private const val THREAD_DENSITY_KEY = "threadDensityKey"

--- a/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
@@ -79,6 +79,12 @@ class LocalSettings private constructor(context: Context) {
         set(value) = sharedPreferences.transaction { putBoolean(ASK_EMAIL_ACKNOWLEDGMENT_KEY, value) }
     //endregion
 
+    //region Notification system settings
+    var hasOpenedNotifSettings: Boolean
+        get() = sharedPreferences.getBoolean(HAS_OPENED_NOTIF_SETTINGS_KEY, DEFAULT_HAS_OPENED_NOTIF_SETTINGS)
+        set(value) = sharedPreferences.transaction { putBoolean(HAS_OPENED_NOTIF_SETTINGS_KEY, value) }
+    //endregion
+
     //region App lock
     var isAppLocked: Boolean
         get() = sharedPreferences.getBoolean(IS_APP_LOCKED_KEY, DEFAULT_IS_APP_LOCKED)
@@ -272,6 +278,7 @@ class LocalSettings private constructor(context: Context) {
         private val DEFAULT_EMAIL_FORWARDING = EmailForwarding.IN_BODY
         private const val DEFAULT_INCLUDE_MESSAGE_IN_REPLY = true
         private const val DEFAULT_ASK_EMAIL_ACKNOWLEDGMENT = false
+        private const val DEFAULT_HAS_OPENED_NOTIF_SETTINGS = false
         private const val DEFAULT_IS_APP_LOCKED = false
         private const val DEFAULT_UPDATE_LATER = false
         private val DEFAULT_THREAD_DENSITY = ThreadDensity.LARGE
@@ -291,6 +298,7 @@ class LocalSettings private constructor(context: Context) {
         private const val EMAIL_FORWARDING_KEY = "emailForwardingKey"
         private const val INCLUDE_MESSAGE_IN_REPLY_KEY = "includeMessageInReplyKey"
         private const val ASK_EMAIL_ACKNOWLEDGMENT_KEY = "askEmailAcknowledgmentKey"
+        private const val HAS_OPENED_NOTIF_SETTINGS_KEY = "hasOpenedNotifSettings"
         private const val IS_APP_LOCKED_KEY = "isAppLockedKey"
         private const val UPDATE_LATER_KEY = "updateLaterKey"
         private const val THREAD_DENSITY_KEY = "threadDensityKey"

--- a/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
@@ -79,10 +79,10 @@ class LocalSettings private constructor(context: Context) {
         set(value) = sharedPreferences.transaction { putBoolean(ASK_EMAIL_ACKNOWLEDGMENT_KEY, value) }
     //endregion
 
-    //region Enabled notifications settings
-    var hasEnabledNotifSettings: Boolean
-        get() = sharedPreferences.getBoolean(HAS_ENABLED_NOTIF_SETTINGS_KEY, DEFAULT_HAS_ENABLED_NOTIF_SETTINGS)
-        set(value) = sharedPreferences.transaction { putBoolean(HAS_ENABLED_NOTIF_SETTINGS_KEY, value) }
+    //region Enabled notifications
+    var hasEnabledNotifications: Boolean
+        get() = sharedPreferences.getBoolean(HAS_ENABLED_NOTIFICATIONS_KEY, DEFAULT_HAS_ENABLED_NOTIFICATIONS)
+        set(value) = sharedPreferences.transaction { putBoolean(HAS_ENABLED_NOTIFICATIONS_KEY, value) }
     //endregion
 
     //region App lock
@@ -278,7 +278,7 @@ class LocalSettings private constructor(context: Context) {
         private val DEFAULT_EMAIL_FORWARDING = EmailForwarding.IN_BODY
         private const val DEFAULT_INCLUDE_MESSAGE_IN_REPLY = true
         private const val DEFAULT_ASK_EMAIL_ACKNOWLEDGMENT = false
-        private const val DEFAULT_HAS_ENABLED_NOTIF_SETTINGS = false
+        private const val DEFAULT_HAS_ENABLED_NOTIFICATIONS = false
         private const val DEFAULT_IS_APP_LOCKED = false
         private const val DEFAULT_UPDATE_LATER = false
         private val DEFAULT_THREAD_DENSITY = ThreadDensity.LARGE
@@ -298,7 +298,7 @@ class LocalSettings private constructor(context: Context) {
         private const val EMAIL_FORWARDING_KEY = "emailForwardingKey"
         private const val INCLUDE_MESSAGE_IN_REPLY_KEY = "includeMessageInReplyKey"
         private const val ASK_EMAIL_ACKNOWLEDGMENT_KEY = "askEmailAcknowledgmentKey"
-        private const val HAS_ENABLED_NOTIF_SETTINGS_KEY = "hasOpenedNotifSettings"
+        private const val HAS_ENABLED_NOTIFICATIONS_KEY = "hasEnabledNotificationsKey"
         private const val IS_APP_LOCKED_KEY = "isAppLockedKey"
         private const val UPDATE_LATER_KEY = "updateLaterKey"
         private const val THREAD_DENSITY_KEY = "threadDensityKey"

--- a/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
@@ -79,10 +79,10 @@ class LocalSettings private constructor(context: Context) {
         set(value) = sharedPreferences.transaction { putBoolean(ASK_EMAIL_ACKNOWLEDGMENT_KEY, value) }
     //endregion
 
-    //region Notification system settings
-    var hasOpenedNotifSettings: Boolean
-        get() = sharedPreferences.getBoolean(HAS_OPENED_NOTIF_SETTINGS_KEY, DEFAULT_HAS_OPENED_NOTIF_SETTINGS)
-        set(value) = sharedPreferences.transaction { putBoolean(HAS_OPENED_NOTIF_SETTINGS_KEY, value) }
+    //region Enabled notifications settings
+    var hasEnabledNotifSettings: Boolean
+        get() = sharedPreferences.getBoolean(HAS_ENABLED_NOTIF_SETTINGS_KEY, DEFAULT_HAS_ENABLED_NOTIF_SETTINGS)
+        set(value) = sharedPreferences.transaction { putBoolean(HAS_ENABLED_NOTIF_SETTINGS_KEY, value) }
     //endregion
 
     //region App lock
@@ -278,7 +278,7 @@ class LocalSettings private constructor(context: Context) {
         private val DEFAULT_EMAIL_FORWARDING = EmailForwarding.IN_BODY
         private const val DEFAULT_INCLUDE_MESSAGE_IN_REPLY = true
         private const val DEFAULT_ASK_EMAIL_ACKNOWLEDGMENT = false
-        private const val DEFAULT_HAS_OPENED_NOTIF_SETTINGS = false
+        private const val DEFAULT_HAS_ENABLED_NOTIF_SETTINGS = false
         private const val DEFAULT_IS_APP_LOCKED = false
         private const val DEFAULT_UPDATE_LATER = false
         private val DEFAULT_THREAD_DENSITY = ThreadDensity.LARGE
@@ -298,7 +298,7 @@ class LocalSettings private constructor(context: Context) {
         private const val EMAIL_FORWARDING_KEY = "emailForwardingKey"
         private const val INCLUDE_MESSAGE_IN_REPLY_KEY = "includeMessageInReplyKey"
         private const val ASK_EMAIL_ACKNOWLEDGMENT_KEY = "askEmailAcknowledgmentKey"
-        private const val HAS_OPENED_NOTIF_SETTINGS_KEY = "hasOpenedNotifSettings"
+        private const val HAS_ENABLED_NOTIF_SETTINGS_KEY = "hasOpenedNotifSettings"
         private const val IS_APP_LOCKED_KEY = "isAppLockedKey"
         private const val UPDATE_LATER_KEY = "updateLaterKey"
         private const val THREAD_DENSITY_KEY = "threadDensityKey"

--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -211,7 +211,7 @@ class MainActivity : ThemedActivity() {
     private fun registerMainPermissions(permissionUtils: PermissionUtils) {
         permissionUtils.registerMainPermissions { permissionsResults ->
             if (permissionsResults[Manifest.permission.READ_CONTACTS] == true) mainViewModel.updateUserInfo()
-            if (permissionsResults[Manifest.permission.POST_NOTIFICATIONS] == true) localSettings.hasEnabledNotifSettings = true
+            if (permissionsResults[Manifest.permission.POST_NOTIFICATIONS] == true) localSettings.hasEnabledNotifications = true
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -119,7 +119,7 @@ class MainActivity : ThemedActivity() {
         loadCurrentMailbox()
 
         mainViewModel.observeMergedContactsLive()
-        permissionUtils.requestMainPermissionsIfNeeded()
+        permissionUtils.requestMainPermissionsIfNeeded(localSettings.hasOpenedNotifSettings)
     }
 
     private fun loadCurrentMailbox() {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -119,7 +119,11 @@ class MainActivity : ThemedActivity() {
         loadCurrentMailbox()
 
         mainViewModel.observeMergedContactsLive()
-        permissionUtils.requestMainPermissionsIfNeeded()
+
+        with(permissionUtils) {
+            requestMainPermissionsIfNeeded()
+            checkNotificationPermissionStatus()
+        }
     }
 
     private fun loadCurrentMailbox() {
@@ -211,7 +215,7 @@ class MainActivity : ThemedActivity() {
     private fun registerMainPermissions(permissionUtils: PermissionUtils) {
         permissionUtils.registerMainPermissions { permissionsResults ->
             if (permissionsResults[Manifest.permission.READ_CONTACTS] == true) mainViewModel.updateUserInfo()
-            if (permissionsResults[Manifest.permission.POST_NOTIFICATIONS] == true) localSettings.hasEnabledNotifications = true
+            permissionUtils.checkNotificationPermissionStatus()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -120,10 +120,7 @@ class MainActivity : ThemedActivity() {
 
         mainViewModel.observeMergedContactsLive()
 
-        with(permissionUtils) {
-            requestMainPermissionsIfNeeded()
-            checkNotificationPermissionStatus()
-        }
+        permissionUtils.requestMainPermissionsIfNeeded()
     }
 
     private fun loadCurrentMailbox() {
@@ -215,7 +212,6 @@ class MainActivity : ThemedActivity() {
     private fun registerMainPermissions(permissionUtils: PermissionUtils) {
         permissionUtils.registerMainPermissions { permissionsResults ->
             if (permissionsResults[Manifest.permission.READ_CONTACTS] == true) mainViewModel.updateUserInfo()
-            permissionUtils.checkNotificationPermissionStatus()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -119,7 +119,7 @@ class MainActivity : ThemedActivity() {
         loadCurrentMailbox()
 
         mainViewModel.observeMergedContactsLive()
-        permissionUtils.requestMainPermissionsIfNeeded(localSettings.hasOpenedNotifSettings)
+        permissionUtils.requestMainPermissionsIfNeeded()
     }
 
     private fun loadCurrentMailbox() {
@@ -211,6 +211,7 @@ class MainActivity : ThemedActivity() {
     private fun registerMainPermissions(permissionUtils: PermissionUtils) {
         permissionUtils.registerMainPermissions { permissionsResults ->
             if (permissionsResults[Manifest.permission.READ_CONTACTS] == true) mainViewModel.updateUserInfo()
+            if (permissionsResults[Manifest.permission.POST_NOTIFICATIONS] == true) localSettings.hasEnabledNotifSettings = true
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/SettingsFragment.kt
@@ -90,7 +90,7 @@ class SettingsFragment : Fragment() {
 
         settingsNotifications.setOnClickListener {
             trackEvent("settingsNotifications", "openNotificationSettings")
-            if (requireActivity().hasNotificationPermission()) localSettings.hasEnabledNotifSettings = true
+            if (requireActivity().hasNotificationPermission()) localSettings.hasEnabledNotifications = true
             requireContext().openAppNotificationSettings()
         }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/SettingsFragment.kt
@@ -31,6 +31,7 @@ import com.infomaniak.mail.MatomoMail.trackEvent
 import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.databinding.FragmentSettingsBinding
 import com.infomaniak.mail.ui.MainViewModel
+import com.infomaniak.mail.utils.PermissionUtils.Companion.hasNotificationPermission
 import com.infomaniak.mail.utils.animatedNavigation
 import com.infomaniak.mail.utils.notYetImplemented
 
@@ -89,7 +90,7 @@ class SettingsFragment : Fragment() {
 
         settingsNotifications.setOnClickListener {
             trackEvent("settingsNotifications", "openNotificationSettings")
-            localSettings.hasOpenedNotifSettings = true
+            if (requireActivity().hasNotificationPermission()) localSettings.hasEnabledNotifSettings = true
             requireContext().openAppNotificationSettings()
         }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/SettingsFragment.kt
@@ -89,6 +89,7 @@ class SettingsFragment : Fragment() {
 
         settingsNotifications.setOnClickListener {
             trackEvent("settingsNotifications", "openNotificationSettings")
+            localSettings.hasOpenedNotifSettings = true
             requireContext().openAppNotificationSettings()
         }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/SettingsFragment.kt
@@ -31,7 +31,6 @@ import com.infomaniak.mail.MatomoMail.trackEvent
 import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.databinding.FragmentSettingsBinding
 import com.infomaniak.mail.ui.MainViewModel
-import com.infomaniak.mail.utils.PermissionUtils.Companion.hasNotificationPermission
 import com.infomaniak.mail.utils.animatedNavigation
 import com.infomaniak.mail.utils.notYetImplemented
 
@@ -90,7 +89,6 @@ class SettingsFragment : Fragment() {
 
         settingsNotifications.setOnClickListener {
             trackEvent("settingsNotifications", "openNotificationSettings")
-            if (requireActivity().hasNotificationPermission()) localSettings.hasEnabledNotifications = true
             requireContext().openAppNotificationSettings()
         }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/PermissionUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/PermissionUtils.kt
@@ -44,10 +44,11 @@ class PermissionUtils {
         mainForActivityResult =
             activity.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { authorizedPermissions ->
                 onPermissionResult?.invoke(authorizedPermissions)
+                updateNotificationPermissionSetting()
             }
     }
 
-    fun checkNotificationPermissionStatus() {
+    private fun updateNotificationPermissionSetting() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             activity.hasPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS))
         ) {
@@ -56,20 +57,22 @@ class PermissionUtils {
     }
 
     fun requestMainPermissionsIfNeeded() {
-        val mainPermissions = getMainPermissions(localSettings)
+        updateNotificationPermissionSetting()
+
+        val mainPermissions = getMainPermissions(mustRequireNotification = !localSettings.hasAlreadyEnabledNotifications)
         if (!activity.hasPermissions(mainPermissions)) mainForActivityResult.launch(mainPermissions)
     }
 
-    companion object {
+    private companion object {
 
         /**
          * If the user has manually disabled notifications permissions, stop requesting it.
          * Manually disabled means the permission was granted at one point, but is no more.
          */
-        private fun getMainPermissions(localSettings: LocalSettings): Array<String> {
+        fun getMainPermissions(mustRequireNotification: Boolean): Array<String> {
             val mainPermissions = mutableListOf(Manifest.permission.READ_CONTACTS)
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !localSettings.hasAlreadyEnabledNotifications) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && mustRequireNotification) {
                 mainPermissions.add(Manifest.permission.POST_NOTIFICATIONS)
             }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/PermissionUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/PermissionUtils.kt
@@ -46,9 +46,16 @@ class PermissionUtils {
             }
     }
 
-    fun requestMainPermissionsIfNeeded() {
+    fun requestMainPermissionsIfNeeded(isNotifSystemSettingsOpened: Boolean) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !activity.hasPermissions(mainPermissions)) {
-            mainForActivityResult.launch(mainPermissions)
+            val permissions = if (isNotifSystemSettingsOpened &&
+                !activity.hasPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS))
+            ) {
+                mainPermissions.filterNot { it == Manifest.permission.POST_NOTIFICATIONS }.toTypedArray()
+            } else {
+                mainPermissions
+            }
+            mainForActivityResult.launch(permissions)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/PermissionUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/PermissionUtils.kt
@@ -58,12 +58,12 @@ class PermissionUtils {
     }
 
     /**
-     * If the user has manually disabled notifications permissions, stop requesting it
-     * Manually disabled means the permission was granted at one point, but is no more
+     * If the user has manually disabled notifications permissions, stop requesting it.
+     * Manually disabled means the permission was granted at one point, but is no more.
      */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     private fun getTiramisuPermissions(): Array<String> {
-        return if (activity.hasNotificationPermission() || LocalSettings.getInstance(activity).hasEnabledNotifSettings) {
+        return if (activity.hasNotificationPermission() || LocalSettings.getInstance(activity).hasEnabledNotifications) {
             mainPermissions.filterNot { permission -> permission == Manifest.permission.POST_NOTIFICATIONS }.toTypedArray()
         } else {
             mainPermissions


### PR DESCRIPTION
Stop requesting notif permissions if the user has manually disabled it by any means.

Fix bug where permissions are not requested for Api < 33