### PR TITLE
Fix issue 831 - IllegalArgumentException: Tmp detached view should be removed from RecyclerView 

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -24,6 +24,7 @@ import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import io.realm.kotlin.MutableRealm
+import io.realm.kotlin.Realm
 import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.UpdatePolicy
 import io.realm.kotlin.ext.query
@@ -117,8 +118,8 @@ object FolderController {
     //endregion
 
     //region Edit data
-    fun update(remoteFolders: List<Folder>) {
-        RealmDatabase.mailboxContent().writeBlocking {
+    fun update(remoteFolders: List<Folder>, realm: Realm) {
+        realm.writeBlocking {
 
             Log.d(RealmDatabase.TAG, "Folders: Delete outdated data")
             deleteOutdatedFolders(remoteFolders)

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -26,6 +26,7 @@ import com.infomaniak.lib.core.utils.SingleLiveEvent
 import com.infomaniak.mail.MatomoMail.trackMultiSelectionEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.api.ApiRepository
+import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.cache.mailboxContent.*
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
 import com.infomaniak.mail.data.cache.mailboxInfo.QuotasController
@@ -306,8 +307,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     private fun updateFolders(mailbox: Mailbox) {
+        val currentRealm = RealmDatabase.mailboxContent()
         ApiRepository.getFolders(mailbox.uuid).data?.let { folders ->
-            FolderController.update(folders)
+            if (!currentRealm.isClosed()) FolderController.update(folders, currentRealm)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/MenuDrawerFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/MenuDrawerFragment.kt
@@ -228,8 +228,12 @@ class MenuDrawerFragment : MenuFoldersFragment() {
             binding.noFolderText.isVisible = customFolders.isEmpty()
 
             val newCurrentFolderId = currentFolderId ?: return@observe
-            defaultFoldersAdapter.setFolders(defaultFolders, newCurrentFolderId)
-            customFoldersAdapter.setFolders(customFolders, newCurrentFolderId)
+            binding.defaultFoldersList.post {
+                defaultFoldersAdapter.setFolders(defaultFolders, newCurrentFolderId)
+            }
+            binding.customFoldersList.post {
+                customFoldersAdapter.setFolders(customFolders, newCurrentFolderId)
+            }
         }
     }
 


### PR DESCRIPTION
- Fix #831
- [fix: Update the folders of a realm already closed](https://github.com/Infomaniak/android-kMail/pull/832/commits/9eafe7fa4c9425397e65b509b1abc1dce1b804b4)

**Before fix**

[Menu with bug](https://user-images.githubusercontent.com/28200274/229840519-23e9c655-fbab-4080-b0cf-90b9ca16bcba.webm)

**After fix**

[menu without bug.webm](https://user-images.githubusercontent.com/28200274/229841179-53bb3929-4604-41b2-b02a-d0f8b220be47.webm)