### PR TITLE
Fix separate horizontal scroll

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -146,12 +146,17 @@ class ThreadAdapter : RecyclerView.Adapter<ThreadViewHolder>(), RealmChangesBind
         if (quote == null) return@with
 
         quoteButton.setOnClickListener {
-            val textId = if (quoteFrameLayout.isVisible) R.string.messageShowQuotedText else R.string.messageHideQuotedText
+            val textId = if (fullMessageWebView.isVisible) R.string.messageShowQuotedText else R.string.messageHideQuotedText
             quoteButton.text = context.getString(textId)
-            quoteFrameLayout.isVisible = !quoteFrameLayout.isVisible
+            toggleWebViews()
         }
 
-        quoteWebView.applyWebViewContent(uid, quote, type)
+        fullMessageWebView.applyWebViewContent(uid, quote, type)
+    }
+
+    private fun ItemMessageBinding.toggleWebViews() {
+        bodyWebView.isVisible = fullMessageWebView.isVisible
+        fullMessageWebView.isVisible = !fullMessageWebView.isVisible
     }
 
     private fun WebView.applyWebViewContent(uid: String, bodyWebView: String, type: String) {
@@ -343,14 +348,14 @@ class ThreadAdapter : RecyclerView.Adapter<ThreadViewHolder>(), RealmChangesBind
             quoteButtonFrameLayout.isGone = true
         }
 
-        quoteFrameLayout.isGone = true
+        fullMessageWebView.isGone = true
 
         if (message.body?.value == null) {
             messageLoader.isVisible = isExpanded
-            bodyFrameLayout.isGone = true
+            bodyWebView.isGone = true
         } else {
             messageLoader.isGone = true
-            bodyFrameLayout.isVisible = isExpanded
+            bodyWebView.isVisible = isExpanded
         }
     }
 
@@ -448,9 +453,10 @@ class ThreadAdapter : RecyclerView.Adapter<ThreadViewHolder>(), RealmChangesBind
             }
         }
 
-        fun initWebViewClientIfNeeded(attachments: List<Attachment>) {
+        fun initWebViewClientIfNeeded(attachments: List<Attachment>) = with(binding) {
             if (doesWebViewNeedInit) {
-                binding.bodyWebView.initWebViewClient(attachments)
+                bodyWebView.initWebViewClient(attachments)
+                fullMessageWebView.initWebViewClient(attachments)
                 doesWebViewNeedInit = false
             }
         }

--- a/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
@@ -51,7 +51,7 @@ object MessageBodyUtils {
     )
 
     fun splitBodyAndQuote(initialBody: Body): MessageBodyQuote {
-        if (initialBody.type == TEXT_PLAIN) return MessageBodyQuote(initialBody.value, null)
+        if (initialBody.type == TEXT_PLAIN) return MessageBodyQuote(initialBody.value)
 
         // The original parsed html document in full
         val originalHtmlDocument = Jsoup.parse(initialBody.value)
@@ -66,13 +66,14 @@ object MessageBodyUtils {
         }
 
         val (body, quote) = splitBodyAndQuote(originalHtmlDocument, currentQuoteDescriptor, blockquoteElement)
-        return MessageBodyQuote(messageBody = if (quote.isNullOrBlank()) initialBody.value else body, quote = quote)
+        return if (quote.isNullOrBlank()) MessageBodyQuote(initialBody.value) else MessageBodyQuote(body, initialBody.value)
     }
 
     private fun findAndRemoveLastParentBlockquote(htmlDocumentWithoutQuote: Document): Element? {
         fun Document.selectLastParentBlockquote(): Element? {
             return selectFirst("$blockquote:not($blockquote $blockquote):last-of-type")
         }
+
         return htmlDocumentWithoutQuote.selectLastParentBlockquote()?.also { it.remove() }
     }
 
@@ -85,6 +86,7 @@ object MessageBodyUtils {
                 currentQuoteDescriptor = quoteDescriptor
             }
         }
+
         return currentQuoteDescriptor
     }
 
@@ -134,6 +136,6 @@ object MessageBodyUtils {
 
     data class MessageBodyQuote(
         val messageBody: String,
-        val quote: String?,
+        val quote: String? = null,
     )
 }

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -442,7 +442,7 @@
     </androidx.appcompat.widget.LinearLayoutCompat>
 
     <FrameLayout
-        android:id="@+id/bodyFrameLayout"
+        android:id="@+id/webViewsFrameLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_constraintBottom_toTopOf="@id/quoteButtonFrameLayout"
@@ -456,6 +456,12 @@
             android:layout_height="wrap_content"
             android:scrollbars="horizontal" />
 
+        <WebView
+            android:id="@+id/fullMessageWebView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:scrollbars="horizontal"
+            android:visibility="gone" />
     </FrameLayout>
 
     <FrameLayout
@@ -463,10 +469,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@id/quoteFrameLayout"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/bodyFrameLayout"
+        app:layout_constraintTop_toBottomOf="@id/webViewsFrameLayout"
         tools:visibility="visible">
 
         <com.google.android.material.button.MaterialButton
@@ -482,24 +488,6 @@
             android:minHeight="0dp"
             android:padding="@dimen/marginStandardVerySmall"
             android:text="@string/messageShowQuotedText" />
-    </FrameLayout>
-
-    <FrameLayout
-        android:id="@+id/quoteFrameLayout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/quoteButtonFrameLayout"
-        tools:visibility="visible">
-
-        <WebView
-            android:id="@+id/quoteWebView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:scrollbars="horizontal" />
     </FrameLayout>
 
     <androidx.constraintlayout.widget.Group


### PR DESCRIPTION
Put the entire message (body + quoted content) in the formerly _quoteWebView_, to be able to have the same horizontal scroll between the body and the history.