### PR TITLE
fix: DownloadManager for API below 29 need write permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,10 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28"
+        tools:ignore="ScopedStorage" />
+    <uses-permission
         android:name="android.permission.POST_NOTIFICATIONS"
         android:minSdkVersion="33" />
 

--- a/app/src/main/java/com/infomaniak/mail/utils/PermissionUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/PermissionUtils.kt
@@ -76,7 +76,7 @@ class PermissionUtils {
     private var downloadCallback: (() -> Unit)? = null
 
     /**
-     * Register storage permission only for android Api below 29.
+     * Register storage permission only for Android API below 29.
      */
     fun registerDownloadManagerPermission() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
@@ -87,7 +87,7 @@ class PermissionUtils {
     }
 
     /**
-     * Request storage permission only for android Api below 29.
+     * Request storage permission only for Android API below 29.
      */
     fun requestDownloadManagerPermission(downloadCallback: () -> Unit) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) storageForActivityResult?.launch(storagePermission)
@@ -97,7 +97,7 @@ class PermissionUtils {
 
     private companion object {
 
-        @get:DeprecatedSinceApi(Build.VERSION_CODES.Q, "Only used for downloadManager below api 29")
+        @get:DeprecatedSinceApi(Build.VERSION_CODES.Q, "Only used for DownloadManager below API 29")
         const val storagePermission = Manifest.permission.WRITE_EXTERNAL_STORAGE
 
         /**

--- a/app/src/main/java/com/infomaniak/mail/utils/PermissionUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/PermissionUtils.kt
@@ -20,7 +20,9 @@ package com.infomaniak.mail.utils
 import android.Manifest
 import android.os.Build
 import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.contract.ActivityResultContracts.RequestMultiplePermissions
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.annotation.DeprecatedSinceApi
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.infomaniak.lib.core.utils.hasPermissions
@@ -29,20 +31,27 @@ import com.infomaniak.mail.data.LocalSettings
 class PermissionUtils {
 
     private var activity: FragmentActivity
+    private var fragment: Fragment? = null
     private var localSettings: LocalSettings
 
     private lateinit var mainForActivityResult: ActivityResultLauncher<Array<String>>
+    private var storageForActivityResult: ActivityResultLauncher<String>? = null
+
+    val hasDownloadManagerPermission
+        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q || activity.hasPermissions(arrayOf(storagePermission))
 
     constructor(activity: FragmentActivity) {
         this.activity = activity
         localSettings = LocalSettings.getInstance(activity)
     }
 
-    constructor(fragment: Fragment) : this(fragment.requireActivity())
+    constructor(fragment: Fragment) : this(fragment.requireActivity()) {
+        this.fragment = fragment
+    }
 
     fun registerMainPermissions(onPermissionResult: ((permissions: Map<String, Boolean>) -> Unit)? = null) {
         mainForActivityResult =
-            activity.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { authorizedPermissions ->
+            activity.registerForActivityResult(RequestMultiplePermissions()) { authorizedPermissions ->
                 onPermissionResult?.invoke(authorizedPermissions)
                 updateNotificationPermissionSetting()
             }
@@ -63,7 +72,33 @@ class PermissionUtils {
         if (!activity.hasPermissions(mainPermissions)) mainForActivityResult.launch(mainPermissions)
     }
 
+    //region DownloadManager permissions
+    private var downloadCallback: (() -> Unit)? = null
+
+    /**
+     * Register storage permission only for android Api below 29.
+     */
+    fun registerDownloadManagerPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            storageForActivityResult = fragment?.registerForActivityResult(RequestPermission()) { hasPermission ->
+                if (hasPermission) downloadCallback?.invoke()
+            }
+        }
+    }
+
+    /**
+     * Request storage permission only for android Api below 29.
+     */
+    fun requestDownloadManagerPermission(downloadCallback: () -> Unit) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) storageForActivityResult?.launch(storagePermission)
+        this.downloadCallback = downloadCallback
+    }
+    //endregion
+
     private companion object {
+
+        @get:DeprecatedSinceApi(Build.VERSION_CODES.Q, "Only used for downloadManager below api 29")
+        const val storagePermission = Manifest.permission.WRITE_EXTERNAL_STORAGE
 
         /**
          * If the user has manually disabled notifications permissions, stop requesting it.


### PR DESCRIPTION
- [fix: Download manager for api below 29 need write permission](https://github.com/Infomaniak/android-kMail/commit/42a9a681ade9222522ff0e4859eb5768c94e2dfd)

**Stacktrace**
```
java.lang.SecurityException: No permission to write to /storage/emulated/0/Download/kMail-attachments-2023 0407 Article DauBé supplém.zip: Neither user 10176 nor current process has android.permission.WRITE_EXTERNAL_STORAGE.
    at android.os.Parcel.createException(Parcel.java:1966)
    at android.os.Parcel.readException(Parcel.java:1934)
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:183)
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:135)
    at android.content.ContentProviderProxy.insert(ContentProviderNative.java:476)
    at android.content.ContentResolver.insert(ContentResolver.java:1594)
    at android.app.DownloadManager.enqueue(DownloadManager.java:1479)
    at com.infomaniak.lib.core.utils.DownloadManagerUtils.scheduleDownload(DownloadManagerUtils.kt:49)
    at com.infomaniak.mail.ui.main.thread.ThreadFragment.downloadAllAttachments(ThreadFragment.kt:327)
    at com.infomaniak.mail.ui.main.thread.ThreadFragment.access$downloadAllAttachments(ThreadFragment.kt:74)
    at com.infomaniak.mail.ui.main.thread.ThreadFragment$setupAdapter$1$2$5.invoke(ThreadFragment.kt:254)
    at com.infomaniak.mail.ui.main.thread.ThreadFragment$setupAdapter$1$2$5.invoke(ThreadFragment.kt:252)
    at com.infomaniak.mail.ui.main.thread.ThreadAdapter.bindAttachment$lambda$20$lambda$19(ThreadAdapter.kt:316)
    at com.infomaniak.mail.ui.main.thread.ThreadAdapter.$r8$lambda$YowpGaowEVIUthc43JaDiEINJ4E
    at com.infomaniak.mail.ui.main.thread.ThreadAdapter$$ExternalSyntheticLambda4.onClick
    at android.view.View.performClick(View.java:7339)
    at android.widget.TextView.performClick(TextView.java:14275)
    at com.google.android.material.button.MaterialButton.performClick(MaterialButton.java:1202)
    at android.view.View.performClickInternal(View.java:7305)
    at android.view.View.access$3200(View.java:846)
    at android.view.View$PerformClick.run(View.java:27787)
    at android.os.Handler.handleCallback(Handler.java:873)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:214)
    at android.app.ActivityThread.main(ActivityThread.java:7078)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:494)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:964)
```

Depends on #828 