### PR TITLE
`IllegalArgumentException` when navigating from Thread fragment to DownloadAttachment dialog

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -261,7 +261,7 @@ class ThreadFragment : Fragment() {
         if (hasUsableCache(requireContext()) || isInlineCachedFile(requireContext())) {
             startActivity(openWithIntent(requireContext()))
         } else {
-            findNavController().navigate(
+            safeNavigate(
                 ThreadFragmentDirections.actionThreadFragmentToDownloadAttachmentProgressDialog(
                     attachmentResource = resource!!,
                     attachmentName = name,


### PR DESCRIPTION
Fix #861