### PR TITLE
fix: Application with hilt doesn't work in fdroid flavor

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ApplicationMain.kt
+++ b/app/src/main/java/com/infomaniak/mail/ApplicationMain.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import androidx.work.WorkManager
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import com.facebook.stetho.Stetho
@@ -43,7 +44,6 @@ import com.infomaniak.lib.core.utils.showToast
 import com.infomaniak.lib.login.ApiToken
 import com.infomaniak.mail.MatomoMail.buildTracker
 import com.infomaniak.mail.data.LocalSettings
-import com.infomaniak.mail.firebase.ProcessMessageNotificationsWorker
 import com.infomaniak.mail.ui.LaunchActivity
 import com.infomaniak.mail.ui.LaunchActivityArgs
 import com.infomaniak.mail.utils.AccountUtils
@@ -67,7 +67,7 @@ import java.util.UUID
 import javax.inject.Inject
 
 @HiltAndroidApp
-class ApplicationMain : Application(), ImageLoaderFactory, DefaultLifecycleObserver {
+open class ApplicationMain : Application(), ImageLoaderFactory, DefaultLifecycleObserver {
 
     val matomoTracker: Tracker by lazy { buildTracker() }
     var isAppInBackground = true
@@ -75,10 +75,12 @@ class ApplicationMain : Application(), ImageLoaderFactory, DefaultLifecycleObser
 
     @Inject
     lateinit var syncMailboxesWorkerScheduler: SyncMailboxesWorker.Scheduler
-    @Inject
-    lateinit var processMessageNotificationsWorkerScheduler: ProcessMessageNotificationsWorker.Scheduler
+
     @Inject
     lateinit var notificationManagerCompat: NotificationManagerCompat
+
+    @Inject
+    lateinit var workManager: WorkManager // Only used in the standard flavor
 
     override fun onCreate() {
         super<Application>.onCreate()
@@ -97,7 +99,6 @@ class ApplicationMain : Application(), ImageLoaderFactory, DefaultLifecycleObser
 
     override fun onStart(owner: LifecycleOwner) {
         isAppInBackground = false
-        processMessageNotificationsWorkerScheduler.cancelFirebaseProcessWorks()
         syncMailboxesWorkerScheduler.cancelWork()
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
@@ -35,8 +35,10 @@ import com.infomaniak.mail.databinding.ActivityNewMessageBinding
 import com.infomaniak.mail.ui.LaunchActivity
 import com.infomaniak.mail.ui.ThemedActivity
 import com.infomaniak.mail.utils.*
+import dagger.hilt.android.AndroidEntryPoint
 import com.google.android.material.R as RMaterial
 
+@AndroidEntryPoint
 class NewMessageActivity : ThemedActivity() {
 
     private val binding by lazy { ActivityNewMessageBinding.inflate(layoutInflater) }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
@@ -63,9 +63,11 @@ import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.Utils
 import com.infomaniak.mail.utils.WebViewUtils.Companion.setupNewMessageWebViewSettings
 import com.infomaniak.mail.workers.DraftsActionsWorker
+import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import com.google.android.material.R as RMaterial
 
+@AndroidEntryPoint
 class NewMessageFragment : Fragment() {
 
     private lateinit var binding: FragmentNewMessageBinding

--- a/app/src/main/java/com/infomaniak/mail/workers/BaseProcessMessageNotificationsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/BaseProcessMessageNotificationsWorker.kt
@@ -15,11 +15,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.infomaniak.mail
+package com.infomaniak.mail.workers
 
 import android.content.Context
-import androidx.fragment.app.FragmentActivity
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
 
-fun FragmentActivity.checkPlayServices() = Unit
+abstract class BaseProcessMessageNotificationsWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : BaseCoroutineWorker(appContext, params) {
 
-fun Context.isGooglePlayServicesNotAvailable(): Boolean = true
+    companion object {
+        const val TAG = "ProcessMessageNotificationsWorker"
+
+        fun cancelWorks(workManager: WorkManager) {
+            workManager.cancelAllWorkByTag(TAG)
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/workers/BaseProcessMessageNotificationsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/BaseProcessMessageNotificationsWorker.kt
@@ -23,7 +23,7 @@ import androidx.work.WorkerParameters
 
 abstract class BaseProcessMessageNotificationsWorker(
     appContext: Context,
-    params: WorkerParameters
+    params: WorkerParameters,
 ) : BaseCoroutineWorker(appContext, params) {
 
     companion object {

--- a/app/src/standard/AndroidManifest.xml
+++ b/app/src/standard/AndroidManifest.xml
@@ -18,7 +18,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <application tools:ignore="MissingApplicationIcon">
+    <application
+        android:name=".StandardApplicationMain"
+        tools:ignore="MissingApplicationIcon"
+        tools:replace="android:name">
 
         <service
             android:name=".firebase.KMailFirebaseMessagingService"

--- a/app/src/standard/java/com/infomaniak/mail/GplayExtensions.kt
+++ b/app/src/standard/java/com/infomaniak/mail/GplayExtensions.kt
@@ -26,7 +26,6 @@ import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.messaging.FirebaseMessaging
 import com.infomaniak.lib.core.utils.showToast
 import com.infomaniak.mail.data.LocalSettings
-import com.infomaniak.mail.firebase.ProcessMessageNotificationsWorker
 import com.infomaniak.mail.firebase.RegisterUserDeviceWorker
 import com.infomaniak.mail.utils.AccountUtils
 import kotlinx.coroutines.Dispatchers
@@ -43,10 +42,6 @@ fun FragmentActivity.checkPlayServices(): Unit = with(GoogleApiAvailability.getI
 
 fun Context.isGooglePlayServicesNotAvailable(): Boolean = with(GoogleApiAvailability.getInstance()) {
     return isGooglePlayServicesAvailable(this@isGooglePlayServicesNotAvailable) != ConnectionResult.SUCCESS
-}
-
-fun ProcessMessageNotificationsWorker.Scheduler.cancelFirebaseProcessWorks() {
-    cancelWorks()
 }
 
 private fun FragmentActivity.checkFirebaseRegistration() {

--- a/app/src/standard/java/com/infomaniak/mail/StandardApplicationMain.kt
+++ b/app/src/standard/java/com/infomaniak/mail/StandardApplicationMain.kt
@@ -17,9 +17,14 @@
  */
 package com.infomaniak.mail
 
-import android.content.Context
-import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.LifecycleOwner
+import com.infomaniak.mail.workers.BaseProcessMessageNotificationsWorker
 
-fun FragmentActivity.checkPlayServices() = Unit
+class StandardApplicationMain : ApplicationMain() {
 
-fun Context.isGooglePlayServicesNotAvailable(): Boolean = true
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
+        BaseProcessMessageNotificationsWorker.cancelWorks(workManager)
+    }
+}
+

--- a/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
+++ b/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
@@ -25,7 +25,7 @@ import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.cache.mailboxContent.MessageController
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
 import com.infomaniak.mail.utils.FetchMessagesManager
-import com.infomaniak.mail.workers.BaseCoroutineWorker
+import com.infomaniak.mail.workers.BaseProcessMessageNotificationsWorker
 import io.sentry.Sentry
 import kotlinx.coroutines.Dispatchers
 import javax.inject.Inject
@@ -36,7 +36,7 @@ class ProcessMessageNotificationsWorker @Inject constructor(
     appContext: Context,
     params: WorkerParameters,
     private val fetchMessagesManager: FetchMessagesManager,
-) : BaseCoroutineWorker(appContext, params) {
+) : BaseProcessMessageNotificationsWorker(appContext, params) {
 
     private val mailboxInfoRealm by lazy { RealmDatabase.newMailboxInfoInstance }
 
@@ -86,13 +86,9 @@ class ProcessMessageNotificationsWorker @Inject constructor(
             workManager.enqueueUniqueWork(workName, ExistingWorkPolicy.APPEND_OR_REPLACE, workRequest)
         }
 
-        fun cancelWorks() {
-            workManager.cancelAllWorkByTag(TAG)
-        }
     }
 
     companion object {
-        private const val TAG = "ProcessMessageNotificationsWorker"
         private const val USER_ID_KEY = "userIdKey"
         private const val MAILBOX_ID_KEY = "mailboxIdKey"
         private const val MESSAGE_UID_KEY = "messageUidKey"


### PR DESCRIPTION
**Changes**
ApplicationMain has been separated, so that each flavor can do its processing in its own applicationMain instance

- fix: fdroid flavor with hilt
- fix: draft injection with hilt