### PR TITLE
Fix longpress on webview that makes the recyclerview jump on ThreadFragment

### DIFF
--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -472,12 +472,14 @@
                 android:id="@+id/bodyWebView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:focusableInTouchMode="false"
                 android:scrollbars="horizontal" />
 
             <WebView
                 android:id="@+id/fullMessageWebView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:focusableInTouchMode="false"
                 android:scrollbars="horizontal"
                 android:visibility="gone" />
 


### PR DESCRIPTION
Setting the default style attribute to 0 solves the problem