### PR TITLE
Use `reload()` when changing screen size to rerender emails instead of `loadUrl()`

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
@@ -135,12 +135,11 @@ class NewMessageFragment : Fragment() {
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
-        // TODO : Try to undo js script and recall the method to fix rendering
-        newMessageViewModel.draft.uiSignature?.let { html ->
-            binding.signatureWebView.loadContent(html)
+        newMessageViewModel.draft.uiSignature?.let { _ ->
+            binding.signatureWebView.reload()
         }
-        newMessageViewModel.draft.uiQuote?.let { html ->
-            binding.quoteWebView.loadContent(html)
+        newMessageViewModel.draft.uiQuote?.let { _ ->
+            binding.quoteWebView.reload()
         }
         super.onConfigurationChanged(newConfig)
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -109,20 +109,21 @@ class ThreadAdapter(
     }
 
     override fun onBindViewHolder(holder: ThreadViewHolder, position: Int, payloads: MutableList<Any>) = with(holder.binding) {
+        val payload = payloads.firstOrNull()
+        if (payload !is NotificationType) {
+            super.onBindViewHolder(holder, position, payloads)
+            return
+        }
+
         val message = messages[position]
 
-        val payload = payloads.firstOrNull()
-        if (payload is NotificationType) {
-            when (payload) {
-                NotificationType.AVATAR -> if (!message.isDraft) userAvatar.loadAvatar(message.from.first(), contacts)
-                NotificationType.TOGGLE_LIGHT_MODE -> {
-                    isThemeTheSameMap[message.uid] = !isThemeTheSameMap[message.uid]!!
-                    holder.toggleBodyAndQuoteTheme(message)
-                }
-                NotificationType.RERENDER -> holder.loadBodyAndQuote(message) // TODO : Try to undo js script and recall the method to fix rendering
+        when (payload) {
+            NotificationType.AVATAR -> if (!message.isDraft) userAvatar.loadAvatar(message.from.first(), contacts)
+            NotificationType.TOGGLE_LIGHT_MODE -> {
+                isThemeTheSameMap[message.uid] = !isThemeTheSameMap[message.uid]!!
+                holder.toggleBodyAndQuoteTheme(message)
             }
-        } else {
-            super.onBindViewHolder(holder, position, payloads)
+            NotificationType.RERENDER -> if (bodyWebView.isVisible) bodyWebView.reload() else fullMessageWebView.reload()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -89,7 +89,7 @@ class ThreadFragment : Fragment() {
     private var shouldScrollToBottom = AtomicBoolean(true)
 
     override fun onConfigurationChanged(newConfig: Configuration) {
-        threadAdapter.rerenderMails() // TODO : Try to undo js script and recall the method to fix rendering
+        threadAdapter.rerenderMails()
         super.onConfigurationChanged(newConfig)
     }
 


### PR DESCRIPTION
I did not undo the rendering modifications to redo them because it increased the code complexity but did not seem to grant any speed increase compared to a simple load or reload