### PR TITLE
Now displays the missing "saving draft" toast when putting the app in the background

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
@@ -26,7 +26,6 @@ import androidx.activity.viewModels
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.google.android.material.button.MaterialButton
-import com.infomaniak.lib.core.utils.showToast
 import com.infomaniak.mail.BuildConfig
 import com.infomaniak.mail.MatomoMail.ACTION_POSTPONE_NAME
 import com.infomaniak.mail.MatomoMail.trackEvent
@@ -84,7 +83,7 @@ class NewMessageActivity : ThemedActivity() {
 
     private fun handleOnBackPressed() = with(newMessageViewModel) {
         onBackPressedDispatcher.addCallback(this@NewMessageActivity) {
-            if (isAutoCompletionOpened) newMessageFragment.closeAutoCompletion() else saveDraftAndShowToast(DraftAction.SAVE)
+            if (isAutoCompletionOpened) newMessageFragment.closeAutoCompletion() else saveDraftLocallyAndFinish(DraftAction.SAVE)
         }
     }
 
@@ -103,7 +102,7 @@ class NewMessageActivity : ThemedActivity() {
     private fun tryToSendEmail() {
 
         fun sendEmail() {
-            saveDraftAndShowToast(DraftAction.SEND)
+            saveDraftLocallyAndFinish(DraftAction.SEND)
         }
 
         if (newMessageViewModel.draft.subject.isNullOrBlank()) {
@@ -130,16 +129,8 @@ class NewMessageActivity : ThemedActivity() {
         }
     }
 
-    private fun saveDraftAndShowToast(action: DraftAction) {
-        newMessageViewModel.saveToLocalAndFinish(action) {
-            displayDraftActionToast(action)
-        }
-    }
-
-    private fun displayDraftActionToast(action: DraftAction) {
-        if (isTaskRoot) {
-            showToast(title = if (action == DraftAction.SAVE) R.string.snackbarDraftSaving else R.string.snackbarEmailSending)
-        }
+    private fun saveDraftLocallyAndFinish(action: DraftAction) {
+        newMessageViewModel.saveToLocalAndFinish(action)
     }
 
     private fun observeCloseActivity() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
@@ -54,7 +54,7 @@ import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.data.models.Attachment.AttachmentDisposition.INLINE
 import com.infomaniak.mail.data.models.correspondent.MergedContact
 import com.infomaniak.mail.data.models.correspondent.Recipient
-import com.infomaniak.mail.data.models.draft.Draft.DraftMode
+import com.infomaniak.mail.data.models.draft.Draft.*
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.databinding.FragmentNewMessageBinding
 import com.infomaniak.mail.ui.main.newMessage.NewMessageActivity.EditorAction
@@ -516,12 +516,30 @@ class NewMessageFragment : Fragment() {
         //  Realm, and we'll lost some Draft data. A quick fix to get rid of the current bugs is
         //  to wait the end of Draft composition before starting DraftsActionsWorker.
         if (shouldHandleDraftActionWhenLeaving) {
+            showDraftFeedbackToUser()
             draftsActionsWorkerScheduler.scheduleWork(draftLocalUuid = newMessageViewModel.draft.localUuid)
         } else {
             shouldHandleDraftActionWhenLeaving = true
         }
 
         super.onStop()
+    }
+
+    private fun showDraftFeedbackToUser() = with(requireActivity()) {
+        when (newMessageViewModel.draft.action) {
+            DraftAction.SAVE -> {
+                if (isFinishing) {
+                    if (isTaskRoot) showToast(R.string.snackbarDraftSaving)
+                } else {
+                    // TODO : Only show if draft was modified since last save. Else we don't need to save it again
+                    showToast(R.string.snackbarDraftSaving)
+                }
+            }
+            DraftAction.SEND -> {
+                if (isTaskRoot) showToast(R.string.snackbarEmailSending)
+            }
+            null -> Unit
+        }
     }
 
     fun closeAutoCompletion() = with(binding) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
@@ -51,7 +51,10 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.ext.copyFromRealm
 import io.realm.kotlin.ext.realmListOf
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import javax.inject.Inject
@@ -265,13 +268,12 @@ class NewMessageViewModel @Inject constructor(
         }
     }
 
-    fun saveToLocalAndFinish(action: DraftAction, displayToast: () -> Unit) = viewModelScope.launch(ioDispatcher) {
+    fun saveToLocalAndFinish(action: DraftAction) = viewModelScope.launch(ioDispatcher) {
         autoSaveJob?.cancel()
 
         if (shouldExecuteAction(action)) {
             context.trackSendingDraftEvent(action, draft)
             saveDraftToLocal(action)
-            withContext(mainDispatcher) { displayToast() }
         } else if (isNewMessage) {
             RealmDatabase.mailboxContent().writeBlocking {
                 DraftController.getDraft(draft.localUuid, realm = this)?.let(::delete)


### PR DESCRIPTION
This modification decorrelates the toast from the actual saving of the data in realm for now. But in the next PR, the save will happen right there in the `onStop()` which will make it so the toasts makes sens again