### PR TITLE
Fix draft saving when putting app in the background

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/di/ApplicationModule.kt
+++ b/app/src/main/java/com/infomaniak/mail/di/ApplicationModule.kt
@@ -1,3 +1,20 @@
+/*
+ * Infomaniak kMail - Android
+ * Copyright (C) 2023 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.infomaniak.mail.di
 
 import android.content.Context
@@ -8,6 +25,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import javax.inject.Singleton
 
 @Module
@@ -25,4 +44,10 @@ object ApplicationModule {
 
     @Provides
     fun providesWorkManager(appContext: Context) = WorkManager.getInstance(appContext)
+
+    @Singleton
+    @Provides
+    fun providesGlobalCoroutineScope(@DefaultDispatcher defaultDispatcher: CoroutineDispatcher): CoroutineScope {
+        return CoroutineScope(defaultDispatcher)
+    }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
@@ -36,7 +36,10 @@ import com.infomaniak.mail.data.models.draft.Draft.DraftAction
 import com.infomaniak.mail.databinding.ActivityNewMessageBinding
 import com.infomaniak.mail.ui.LaunchActivity
 import com.infomaniak.mail.ui.ThemedActivity
-import com.infomaniak.mail.utils.*
+import com.infomaniak.mail.utils.AccountUtils
+import com.infomaniak.mail.utils.createDescriptionDialog
+import com.infomaniak.mail.utils.getAttributeColor
+import com.infomaniak.mail.utils.updateNavigationBarColor
 import dagger.hilt.android.AndroidEntryPoint
 import com.google.android.material.R as RMaterial
 
@@ -69,7 +72,6 @@ class NewMessageActivity : ThemedActivity() {
         setupSendButton()
         setupSystemBars()
 
-        // observeCloseActivity()
         observeInitSuccess()
     }
 
@@ -83,12 +85,7 @@ class NewMessageActivity : ThemedActivity() {
 
     private fun handleOnBackPressed() = with(newMessageViewModel) {
         onBackPressedDispatcher.addCallback(this@NewMessageActivity) {
-            if (isAutoCompletionOpened) {
-                newMessageFragment.closeAutoCompletion()
-            } else {
-                finish()
-                // saveDraftLocallyAndFinish(DraftAction.SAVE)
-            }
+            if (isAutoCompletionOpened) newMessageFragment.closeAutoCompletion() else finish()
         }
     }
 
@@ -109,7 +106,6 @@ class NewMessageActivity : ThemedActivity() {
         fun sendEmail() {
             newMessageFragment.recordedAction = DraftAction.SEND
             finish()
-            // saveDraftLocallyAndFinish(DraftAction.SEND)
         }
 
         if (newMessageViewModel.draft.subject.isNullOrBlank()) {
@@ -135,14 +131,6 @@ class NewMessageActivity : ThemedActivity() {
             updateNavigationBarColor(backgroundColor)
         }
     }
-
-    // private fun saveDraftLocallyAndFinish(action: DraftAction) {
-    //     newMessageViewModel.saveToLocalAndFinish(action)
-    // }
-
-    // private fun observeCloseActivity() {
-    //     newMessageViewModel.shouldCloseActivity.observeNotNull(this) { if (isTaskRoot) finishAndRemoveTask() else finish() }
-    // }
 
     private fun observeInitSuccess() {
         newMessageViewModel.isInitSuccess.observe(this) { isSuccess ->

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
@@ -84,8 +84,12 @@ class NewMessageActivity : ThemedActivity() {
 
     private fun handleOnBackPressed() = with(newMessageViewModel) {
         onBackPressedDispatcher.addCallback(this@NewMessageActivity) {
-            if (isAutoCompletionOpened) newMessageFragment.closeAutoCompletion() else finish()
+            if (isAutoCompletionOpened) newMessageFragment.closeAutoCompletion() else finishAppAndRemoveTaskIfNeeded()
         }
+    }
+
+    private fun finishAppAndRemoveTaskIfNeeded() {
+        if (isTaskRoot) finishAndRemoveTask() else finish()
     }
 
     private fun setupSnackBar() {
@@ -104,7 +108,7 @@ class NewMessageActivity : ThemedActivity() {
 
         fun sendEmail() {
             newMessageFragment.shouldSendInsteadOfSave = true
-            finish()
+            finishAppAndRemoveTaskIfNeeded()
         }
 
         if (newMessageViewModel.draft.subject.isNullOrBlank()) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
@@ -69,7 +69,7 @@ class NewMessageActivity : ThemedActivity() {
         setupSendButton()
         setupSystemBars()
 
-        observeCloseActivity()
+        // observeCloseActivity()
         observeInitSuccess()
     }
 
@@ -83,7 +83,12 @@ class NewMessageActivity : ThemedActivity() {
 
     private fun handleOnBackPressed() = with(newMessageViewModel) {
         onBackPressedDispatcher.addCallback(this@NewMessageActivity) {
-            if (isAutoCompletionOpened) newMessageFragment.closeAutoCompletion() else saveDraftLocallyAndFinish(DraftAction.SAVE)
+            if (isAutoCompletionOpened) {
+                newMessageFragment.closeAutoCompletion()
+            } else {
+                finish()
+                // saveDraftLocallyAndFinish(DraftAction.SAVE)
+            }
         }
     }
 
@@ -102,7 +107,9 @@ class NewMessageActivity : ThemedActivity() {
     private fun tryToSendEmail() {
 
         fun sendEmail() {
-            saveDraftLocallyAndFinish(DraftAction.SEND)
+            newMessageFragment.recordedAction = DraftAction.SEND
+            finish()
+            // saveDraftLocallyAndFinish(DraftAction.SEND)
         }
 
         if (newMessageViewModel.draft.subject.isNullOrBlank()) {
@@ -129,13 +136,13 @@ class NewMessageActivity : ThemedActivity() {
         }
     }
 
-    private fun saveDraftLocallyAndFinish(action: DraftAction) {
-        newMessageViewModel.saveToLocalAndFinish(action)
-    }
+    // private fun saveDraftLocallyAndFinish(action: DraftAction) {
+    //     newMessageViewModel.saveToLocalAndFinish(action)
+    // }
 
-    private fun observeCloseActivity() {
-        newMessageViewModel.shouldCloseActivity.observeNotNull(this) { if (isTaskRoot) finishAndRemoveTask() else finish() }
-    }
+    // private fun observeCloseActivity() {
+    //     newMessageViewModel.shouldCloseActivity.observeNotNull(this) { if (isTaskRoot) finishAndRemoveTask() else finish() }
+    // }
 
     private fun observeInitSuccess() {
         newMessageViewModel.isInitSuccess.observe(this) { isSuccess ->
@@ -151,7 +158,7 @@ class NewMessageActivity : ThemedActivity() {
         fun linkEditor(view: MaterialButton, action: EditorAction) {
             view.setOnClickListener {
                 // TODO: Don't forget to add in this `if` all actions that make the app go to background.
-                if (action == EditorAction.ATTACHMENT) newMessageViewModel.shouldHandleDraftActionWhenLeaving = false
+                if (action == EditorAction.ATTACHMENT) newMessageViewModel.shouldExecuteDraftActionWhenStopping = false
                 trackEvent("editorActions", action.matomoValue)
                 newMessageViewModel.editorAction.value = action to null
             }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageActivity.kt
@@ -32,7 +32,6 @@ import com.infomaniak.mail.MatomoMail.trackEvent
 import com.infomaniak.mail.MatomoMail.trackNewMessageEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.AppSettings
-import com.infomaniak.mail.data.models.draft.Draft.DraftAction
 import com.infomaniak.mail.databinding.ActivityNewMessageBinding
 import com.infomaniak.mail.ui.LaunchActivity
 import com.infomaniak.mail.ui.ThemedActivity
@@ -104,7 +103,7 @@ class NewMessageActivity : ThemedActivity() {
     private fun tryToSendEmail() {
 
         fun sendEmail() {
-            newMessageFragment.recordedAction = DraftAction.SEND
+            newMessageFragment.shouldSendInsteadOfSave = true
             finish()
         }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
@@ -518,7 +518,10 @@ class NewMessageFragment : Fragment() {
         if (shouldExecuteDraftActionWhenStopping) {
             val isFinishing = requireActivity().isFinishing
             val isTaskRoot = requireActivity().isTaskRoot
-            executeDraftActionWhenStopping(recordedAction, isFinishing, isTaskRoot, ::startWorker)
+            val shouldTargetDraftForSnackBar = isFinishing && !isTaskRoot
+            executeDraftActionWhenStopping(recordedAction, isFinishing, isTaskRoot) {
+                startWorker(shouldTargetDraftForSnackBar)
+            }
         } else {
             shouldExecuteDraftActionWhenStopping = true
         }
@@ -526,8 +529,9 @@ class NewMessageFragment : Fragment() {
         super.onStop()
     }
 
-    private fun startWorker() {
-        draftsActionsWorkerScheduler.scheduleWork(draftLocalUuid = newMessageViewModel.draft.localUuid)
+    private fun startWorker(shouldTargetDraftForSnackBar: Boolean) {
+        val draftLocalUuid = if (shouldTargetDraftForSnackBar) newMessageViewModel.draft.localUuid else null
+        draftsActionsWorkerScheduler.scheduleWork(draftLocalUuid)
     }
 
     fun closeAutoCompletion() = with(binding) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
@@ -90,7 +90,7 @@ class NewMessageFragment : Fragment() {
     private var mailboxes = emptyList<Mailbox>()
     private var selectedMailboxIndex = 0
     private var lastFieldToTakeFocus: FieldType? = TO
-    var recordedAction: DraftAction = DraftAction.SAVE
+    var shouldSendInsteadOfSave: Boolean = false
 
     private val localSettings by lazy { LocalSettings.getInstance(requireContext()) }
 
@@ -520,7 +520,8 @@ class NewMessageFragment : Fragment() {
             val isFinishing = requireActivity().isFinishing
             val isTaskRoot = requireActivity().isTaskRoot
             val shouldTrackDraftForSnackBar = isFinishing && !isTaskRoot
-            executeDraftActionWhenStopping(recordedAction, isFinishing, isTaskRoot) {
+            val action = if (shouldSendInsteadOfSave) DraftAction.SEND else DraftAction.SAVE
+            executeDraftActionWhenStopping(action, isFinishing, isTaskRoot) {
                 startWorker(shouldTrackDraftForSnackBar)
             }
         } else {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageFragment.kt
@@ -510,6 +510,7 @@ class NewMessageFragment : Fragment() {
     }
 
     override fun onStop() = with(newMessageViewModel) {
+
         // TODO:
         //  Currently, we don't handle the possibility to leave the App during Draft composition.
         //  If it happens and we do anything in Realm about that, it will desynchronize the UI &
@@ -518,9 +519,9 @@ class NewMessageFragment : Fragment() {
         if (shouldExecuteDraftActionWhenStopping) {
             val isFinishing = requireActivity().isFinishing
             val isTaskRoot = requireActivity().isTaskRoot
-            val shouldTargetDraftForSnackBar = isFinishing && !isTaskRoot
+            val shouldTrackDraftForSnackBar = isFinishing && !isTaskRoot
             executeDraftActionWhenStopping(recordedAction, isFinishing, isTaskRoot) {
-                startWorker(shouldTargetDraftForSnackBar)
+                startWorker(shouldTrackDraftForSnackBar)
             }
         } else {
             shouldExecuteDraftActionWhenStopping = true
@@ -529,8 +530,8 @@ class NewMessageFragment : Fragment() {
         super.onStop()
     }
 
-    private fun startWorker(shouldTargetDraftForSnackBar: Boolean) {
-        val draftLocalUuid = if (shouldTargetDraftForSnackBar) newMessageViewModel.draft.localUuid else null
+    private fun startWorker(shouldTrackDraftForSnackBar: Boolean) {
+        val draftLocalUuid = if (shouldTrackDraftForSnackBar) newMessageViewModel.draft.localUuid else null
         draftsActionsWorkerScheduler.scheduleWork(draftLocalUuid)
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
@@ -281,9 +281,12 @@ class NewMessageViewModel @Inject constructor(
             saveDraftToLocal(action)
             showDraftToastToUser(action, isFinishing, isTaskRoot)
             startWorkerCallback()
-            if (action == DraftAction.SAVE && !isFinishing) saveDraftSnapshot()
+            if (action == DraftAction.SAVE && !isFinishing) {
+                isNewMessage = false
+                saveDraftSnapshot()
+            }
         } else if (isNewMessage) {
-            removeNewBlankDraftFromRealm()
+            removeDraftFromRealm()
         }
     }
 
@@ -306,7 +309,7 @@ class NewMessageViewModel @Inject constructor(
         }
     }
 
-    private fun removeNewBlankDraftFromRealm() {
+    private fun removeDraftFromRealm() {
         RealmDatabase.mailboxContent().writeBlocking {
             DraftController.getDraft(draft.localUuid, realm = this)?.let(::delete)
         }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
@@ -81,7 +81,6 @@ class NewMessageViewModel @Inject constructor(
     // Boolean: For toggleable actions, `false` if the formatting has been removed and `true` if the formatting has been applied.
     val editorAction = SingleLiveEvent<Pair<EditorAction, Boolean?>>()
     val isInitSuccess = SingleLiveEvent<Boolean>()
-    // val shouldCloseActivity = SingleLiveEvent<Boolean>()
     val importedAttachments = MutableLiveData<Pair<MutableList<Attachment>, ImportationResult>>()
     val isSendingAllowed = MutableLiveData(false)
 
@@ -260,7 +259,7 @@ class NewMessageViewModel @Inject constructor(
         }
     }
 
-    // In case the app crashes, the battery dies or any other unexpected situation, we save every modifications locally in realm
+    // In case the app crashes, the battery dies or any other unexpected situation, we always save every modifications of the draft in realm
     fun saveDraftDebouncing() {
         autoSaveJob?.cancel()
         autoSaveJob = viewModelScope.launch(ioDispatcher) {
@@ -274,7 +273,7 @@ class NewMessageViewModel @Inject constructor(
         isFinishing: Boolean,
         isTaskRoot: Boolean,
         startWorkerCallback: () -> Unit,
-    ) = globalCoroutineScope.launch(ioDispatcher) { // in mainViewModel
+    ) = globalCoroutineScope.launch(ioDispatcher) {
         autoSaveJob?.cancel()
 
         if (shouldExecuteAction(action)) {
@@ -312,21 +311,6 @@ class NewMessageViewModel @Inject constructor(
             DraftController.getDraft(draft.localUuid, realm = this)?.let(::delete)
         }
     }
-
-// fun saveToLocalAndFinish(action: DraftAction) = viewModelScope.launch(ioDispatcher) {
-//     autoSaveJob?.cancel()
-//
-//     if (shouldExecuteAction(action)) {
-//         context.trackSendingDraftEvent(action, draft)
-//         saveDraftToLocal(action)
-//     } else if (isNewMessage) {
-//         RealmDatabase.mailboxContent().writeBlocking {
-//             DraftController.getDraft(draft.localUuid, realm = this)?.let(::delete)
-//         }
-//     }
-//
-//     // shouldCloseActivity.postValue(true)
-// }
 
     private fun saveDraftToLocal(action: DraftAction) {
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
@@ -281,6 +281,7 @@ class NewMessageViewModel @Inject constructor(
             saveDraftToLocal(action)
             showDraftToastToUser(action, isFinishing, isTaskRoot)
             startWorkerCallback()
+            if (action == DraftAction.SAVE && !isFinishing) saveDraftSnapshot()
         } else if (isNewMessage) {
             removeNewBlankDraftFromRealm()
         }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
@@ -26,8 +26,10 @@ import androidx.lifecycle.*
 import com.infomaniak.lib.core.utils.SingleLiveEvent
 import com.infomaniak.lib.core.utils.getFileNameAndSize
 import com.infomaniak.lib.core.utils.guessMimeType
+import com.infomaniak.lib.core.utils.showToast
 import com.infomaniak.mail.MatomoMail.trackNewMessageEvent
 import com.infomaniak.mail.MatomoMail.trackSendingDraftEvent
+import com.infomaniak.mail.R
 import com.infomaniak.mail.data.api.ApiRepository
 import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.cache.mailboxContent.DraftController
@@ -51,10 +53,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.ext.copyFromRealm
 import io.realm.kotlin.ext.realmListOf
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import javax.inject.Inject
@@ -62,6 +61,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NewMessageViewModel @Inject constructor(
     application: Application,
+    private val globalCoroutineScope: CoroutineScope,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
 ) : AndroidViewModel(application) {
@@ -81,12 +81,12 @@ class NewMessageViewModel @Inject constructor(
     // Boolean: For toggleable actions, `false` if the formatting has been removed and `true` if the formatting has been applied.
     val editorAction = SingleLiveEvent<Pair<EditorAction, Boolean?>>()
     val isInitSuccess = SingleLiveEvent<Boolean>()
-    val shouldCloseActivity = SingleLiveEvent<Boolean>()
+    // val shouldCloseActivity = SingleLiveEvent<Boolean>()
     val importedAttachments = MutableLiveData<Pair<MutableList<Attachment>, ImportationResult>>()
     val isSendingAllowed = MutableLiveData(false)
 
     val snackBarManager by lazy { SnackBarManager() }
-    var shouldHandleDraftActionWhenLeaving = true
+    var shouldExecuteDraftActionWhenStopping = true
 
     private var snapshot: DraftSnapshot? = null
 
@@ -268,20 +268,63 @@ class NewMessageViewModel @Inject constructor(
         }
     }
 
-    fun saveToLocalAndFinish(action: DraftAction) = viewModelScope.launch(ioDispatcher) {
+    fun executeDraftActionWhenStopping(
+        action: DraftAction,
+        isFinishing: Boolean,
+        isTaskRoot: Boolean,
+        startWorkerCallback: () -> Unit,
+    ) = globalCoroutineScope.launch(ioDispatcher) { // in mainViewModel
         autoSaveJob?.cancel()
 
         if (shouldExecuteAction(action)) {
             context.trackSendingDraftEvent(action, draft)
             saveDraftToLocal(action)
+            showDraftToastToUser(action, isFinishing, isTaskRoot)
+            startWorkerCallback()
         } else if (isNewMessage) {
-            RealmDatabase.mailboxContent().writeBlocking {
-                DraftController.getDraft(draft.localUuid, realm = this)?.let(::delete)
+            removeNewBlankDraftFromRealm()
+        }
+    }
+
+    private suspend fun showDraftToastToUser(
+        action: DraftAction,
+        isFinishing: Boolean,
+        isTaskRoot: Boolean,
+    ) = withContext(mainDispatcher) {
+        when (action) {
+            DraftAction.SAVE -> {
+                if (isFinishing) {
+                    if (isTaskRoot) context.showToast(R.string.snackbarDraftSaving)
+                } else {
+                    context.showToast(R.string.snackbarDraftSaving)
+                }
+            }
+            DraftAction.SEND -> {
+                if (isTaskRoot) context.showToast(R.string.snackbarEmailSending)
             }
         }
-
-        shouldCloseActivity.postValue(true)
     }
+
+    private fun removeNewBlankDraftFromRealm() {
+        RealmDatabase.mailboxContent().writeBlocking {
+            DraftController.getDraft(draft.localUuid, realm = this)?.let(::delete)
+        }
+    }
+
+// fun saveToLocalAndFinish(action: DraftAction) = viewModelScope.launch(ioDispatcher) {
+//     autoSaveJob?.cancel()
+//
+//     if (shouldExecuteAction(action)) {
+//         context.trackSendingDraftEvent(action, draft)
+//         saveDraftToLocal(action)
+//     } else if (isNewMessage) {
+//         RealmDatabase.mailboxContent().writeBlocking {
+//             DraftController.getDraft(draft.localUuid, realm = this)?.let(::delete)
+//         }
+//     }
+//
+//     // shouldCloseActivity.postValue(true)
+// }
 
     private fun saveDraftToLocal(action: DraftAction) {
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
@@ -260,6 +260,7 @@ class NewMessageViewModel @Inject constructor(
         }
     }
 
+    // In case the app crashes, the battery dies or any other unexpected situation, we save every modifications locally in realm
     fun saveDraftDebouncing() {
         autoSaveJob?.cancel()
         autoSaveJob = viewModelScope.launch(ioDispatcher) {
@@ -411,7 +412,7 @@ class NewMessageViewModel @Inject constructor(
     }
 
     private companion object {
-        const val DELAY_BEFORE_AUTO_SAVING_DRAFT = 3_000L
+        const val DELAY_BEFORE_AUTO_SAVING_DRAFT = 1_000L
         const val FILE_SIZE_25_MB = 25L * 1_024L * 1_024L
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -339,15 +339,14 @@ class DraftsActionsWorker @AssistedInject constructor(
 
         when (draft.action) {
             DraftAction.SAVE -> with(ApiRepository.saveDraft(mailboxUuid, draft, okHttpClient)) {
-                if (data == null) {
-                    throwErrorAsException()
-                } else {
-                    draft.remoteUuid = data?.draftRemoteUuid
-                    draft.messageUid = data?.messageUid
+                data?.let { data ->
+                    draft.remoteUuid = data.draftRemoteUuid
+                    draft.messageUid = data.messageUid
                     draft.action = null
                     scheduledDate = dateFormatWithTimezone.format(Date())
-                    savedDraftUuid = data?.draftRemoteUuid
-                }
+                    savedDraftUuid = data.draftRemoteUuid
+                    realm.delete(draft)
+                } ?: throwErrorAsException()
             }
             DraftAction.SEND -> with(ApiRepository.sendDraft(mailboxUuid, draft, okHttpClient)) {
                 when {

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -345,7 +345,6 @@ class DraftsActionsWorker @AssistedInject constructor(
                     draft.action = null
                     scheduledDate = dateFormatWithTimezone.format(Date())
                     savedDraftUuid = data.draftRemoteUuid
-                    realm.delete(draft)
                 } ?: throwErrorAsException()
             }
             DraftAction.SEND -> with(ApiRepository.sendDraft(mailboxUuid, draft, okHttpClient)) {


### PR DESCRIPTION
* Reuses the same draft id instead of creating a new one each time
* Only show the toast or the snackbar when modifications happened

Depends on #1007 