### PR TITLE
Expand the fab when we enter a folder

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -474,6 +474,8 @@ class ThreadListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                 updateFolderRole(folder.role)
                 updateLoadMore(shouldDisplayLoadMore = false)
             }
+
+            binding.newMessageFab.extend()
         }
     }
 


### PR DESCRIPTION
If we don't expand it, it will stay shrunk when entering a new folder. If the folder is empty, we cannot scroll so it will stay shrunk for ever in this folder