### PR TITLE
Fix Draft with bad connection

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/draft/Draft.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/draft/Draft.kt
@@ -27,10 +27,8 @@ import com.infomaniak.mail.data.cache.mailboxContent.SignatureController
 import com.infomaniak.mail.data.models.Attachment
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.utils.MessageBodyUtils
-import com.infomaniak.mail.utils.toRealmInstant
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.ext.realmListOf
-import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.annotations.Ignore
@@ -48,8 +46,6 @@ class Draft : RealmObject {
     //region API data
     @SerialName("uuid")
     var remoteUuid: String? = null
-
-    var date: RealmInstant = Date().toRealmInstant()
 
     var to: RealmList<Recipient> = realmListOf()
     var cc: RealmList<Recipient> = realmListOf()

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -169,7 +169,7 @@ object SentryDebug {
                     "orphanDrafts", "${
                         orphanDrafts.map {
                             if (it.messageUid == null) {
-                                "${Draft::date.name}: [${it.date}] | ${Draft::subject.name}: [${it.subject}]"
+                                "${Draft::subject.name}: [${it.subject}]"
                             } else {
                                 "${Draft::messageUid.name}: ${it.messageUid}"
                             }


### PR DESCRIPTION
A bug is remaining but we can't do anything about it : if the network is sufficent for a  send or save request to reach the server, but too weak to bring us the answer without a timeout, we don't have data to delete or update a draft. 
So it will be re-send or saved multiple times

Depends on #1052 