### PR TITLE
Fix mailbox switcher bug when only 1 mailbox

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/user/SwitchUserFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/user/SwitchUserFragment.kt
@@ -24,19 +24,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import com.infomaniak.lib.core.utils.context
 import com.infomaniak.mail.MatomoMail.trackAccountEvent
-import com.infomaniak.mail.data.cache.RealmDatabase
-import com.infomaniak.mail.data.models.AppSettings
 import com.infomaniak.mail.databinding.FragmentSwitchUserBinding
-import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.ui.login.LoginActivity
 import com.infomaniak.mail.utils.AccountUtils
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class SwitchUserFragment : Fragment() {
@@ -44,20 +37,8 @@ class SwitchUserFragment : Fragment() {
     private lateinit var binding: FragmentSwitchUserBinding
     private val switchUserViewModel: SwitchUserViewModel by viewModels()
 
-    @Inject
-    @IoDispatcher
-    lateinit var ioDispatcher: CoroutineDispatcher
-
     private val accountsAdapter = SwitchUserAdapter(AccountUtils.currentUserId) { user ->
-        lifecycleScope.launch(ioDispatcher) {
-            if (user.id != AccountUtils.currentUserId) {
-                requireContext().trackAccountEvent("switch")
-                AccountUtils.currentUser = user
-                AccountUtils.currentMailboxId = AppSettings.DEFAULT_ID
-                AccountUtils.reloadApp?.invoke()
-                RealmDatabase.close()
-            }
-        }
+        switchUserViewModel.switchAccount(user)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {


### PR DESCRIPTION
Switching to an account with only one mailbox would display the mailbox switcher with this mailbox, because of a query that would be trigger with -1 (for the current mailbox) as exceptedIds. Thus the true currentMailbox would not be excluded and the observe would think there is more than 1 mailbox.
To fix this, we need to change the currentMailboxId before reloading the app, so the mailbox query won't be triggered with -1