### PR TITLE
Improve Realm usage

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -105,24 +105,9 @@ object RealmDatabase {
     //endregion
 
     //region Close Realms
-    fun reset() {
-        resetMailboxContent()
-        resetUserInfo()
-        _appSettings = null // TODO: To be removed when the injection is done
-        _mailboxInfo = null // TODO: To be removed when the injection is done
-    }
-
     fun closeOldRealms() {
         oldMailboxContent.get()?.close()
         oldUserInfo.get()?.close()
-    }
-
-    fun resetUserInfo() {
-        _userInfo = null
-    }
-
-    fun resetMailboxContent() {
-        _mailboxContent = null
     }
 
     private fun closeUserInfo() {
@@ -133,6 +118,23 @@ object RealmDatabase {
     fun closeMailboxContent() {
         _mailboxContent?.close()
         resetMailboxContent()
+    }
+    //endregion
+
+    //region Reset Realms
+    fun reset() {
+        resetMailboxContent()
+        resetUserInfo()
+        _mailboxInfo = null // TODO: To be removed when the injection is done
+        _appSettings = null // TODO: To be removed when the injection is done
+    }
+
+    fun resetUserInfo() {
+        _userInfo = null
+    }
+
+    fun resetMailboxContent() {
+        _mailboxContent = null
     }
     //endregion
 

--- a/app/src/main/java/com/infomaniak/mail/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/LaunchActivity.kt
@@ -28,6 +28,7 @@ import com.infomaniak.mail.MainApplication.Companion.firstLaunchTime
 import com.infomaniak.mail.MatomoMail.trackUserId
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
+import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.models.AppSettings
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.di.MainDispatcher
@@ -61,6 +62,7 @@ class LaunchActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        RealmDatabase.closeOldRealms()
         handleNotificationDestinationIntent()
 
         lifecycleScope.launch(ioDispatcher) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/user/SwitchUserViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/user/SwitchUserViewModel.kt
@@ -49,7 +49,7 @@ class SwitchUserViewModel @Inject constructor(
             AccountUtils.currentUser = user
             AccountUtils.currentMailboxId = MailboxController.getFirstValidMailbox(user.id)?.mailboxId ?: AppSettings.DEFAULT_ID
             AccountUtils.reloadApp?.invoke()
-            RealmDatabase.close()
+            RealmDatabase.reset()
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/utils/AccountUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/AccountUtils.kt
@@ -63,14 +63,14 @@ object AccountUtils : CredentialManager() {
     override var currentUserId: Int = AppSettingsController.getAppSettings().currentUserId
         set(userId) {
             field = userId
-            RealmDatabase.closeUserInfo()
+            RealmDatabase.resetUserInfo()
             AppSettingsController.updateAppSettings { appSettings -> appSettings.currentUserId = userId }
         }
 
     var currentMailboxId: Int = AppSettingsController.getAppSettings().currentMailboxId
         set(mailboxId) {
             field = mailboxId
-            RealmDatabase.closeMailboxContent()
+            RealmDatabase.resetMailboxContent()
             AppSettingsController.updateAppSettings { appSettings -> appSettings.currentMailboxId = mailboxId }
         }
 
@@ -78,7 +78,7 @@ object AccountUtils : CredentialManager() {
 
     suspend fun switchToMailbox(mailboxId: Int) {
         currentMailboxId = mailboxId
-        RealmDatabase.close()
+        RealmDatabase.reset()
         reloadApp?.invoke()
     }
 


### PR DESCRIPTION
Most of the realm problems we have are due to the fact that we close the realm a little before switching accounts, so the coroutines in progress often come up against exceptions.
Realm instances are now managed differently to ensure that we only close instances when the new account is started.