### PR TITLE
fix: Realm is still in operation even though it is closed

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -91,17 +91,14 @@ object RealmDatabase {
     class MailboxContent {
         operator fun invoke() = runBlocking(Dispatchers.IO) {
             mailboxContentMutex.withLock {
-                _mailboxContent ?: newMailboxContentInstance.also {
-                    closeOldRealms()
-                    _mailboxContent = it
-                }
+                _mailboxContent ?: newMailboxContentInstance.also { _mailboxContent = it }
             }
         }
     }
     //endregion
 
     //region Close Realms
-    private fun closeOldRealms() {
+    fun closeOldRealms() {
         oldMailboxContent.get()?.close()
         oldUserInfo.get()?.close()
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -162,6 +162,11 @@ class MainViewModel @Inject constructor(
         addSource(currentFilter) { value = value?.first to it }
     }.asFlow()
 
+    override fun onCleared() {
+        super.onCleared()
+        RealmDatabase.closeOldRealms()
+    }
+
     /**
      * Force update the `currentFilter` to its current value.
      * The sole effect will be to force the `currentThreadsLive` to trigger immediately.


### PR DESCRIPTION
We make sure to close realm cash only when we're sure everything's finished, based on the global ViewModel