### PR TITLE
Fix search v3

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -55,7 +55,11 @@ class ThreadController @Inject constructor(
     }
 
     fun getSearchThreadsAsync(): Flow<ResultsChange<Thread>> {
-        return mailboxContentRealm().query<Thread>("${Thread::isFromSearch.name} == true").asFlow()
+        return getSearchThreadsQuery(mailboxContentRealm()).asFlow()
+    }
+
+    fun getSearchThreadsCount(): Long {
+        return getSearchThreadsQuery(mailboxContentRealm()).count().find()
     }
 
     fun getThread(uid: String): Thread? {
@@ -147,6 +151,10 @@ class ThreadController @Inject constructor(
 
         private fun getOrphanThreadsQuery(realm: TypedRealm): RealmQuery<Thread> {
             return realm.query("${Thread::folderId.name} == ''")
+        }
+
+        private fun getSearchThreadsQuery(realm: TypedRealm): RealmQuery<Thread> {
+            return realm.query("${Thread::isFromSearch.name} == true")
         }
 
         private fun getUnreadThreadsCountQuery(folder: Folder): RealmScalarQuery<Long> {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -75,7 +75,6 @@ class MainViewModel @Inject constructor(
     private val mailboxContentRealm: RealmDatabase.MailboxContent,
     private val mergedContactController: MergedContactController,
     private val messageController: MessageController,
-    private val searchUtils: SearchUtils,
     private val sharedViewModelUtils: SharedViewModelUtils,
     private val threadController: ThreadController,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
@@ -256,9 +255,6 @@ class MainViewModel @Inject constructor(
                         refreshThreads(mailbox, folder.id)
                     }
                 }
-
-            // Delete Search data in case they couldn't be deleted at the end of the previous Search.
-            searchUtils.deleteRealmSearchData()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -116,6 +116,7 @@ class ThreadListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         super.onViewCreated(view, savedInstanceState)
 
         observeNoMailboxActivityTriggers()
+        threadListViewModel.deleteSearchData()
         setupDensityDependentUi()
         setupOnRefresh()
         setupAdapter()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.infomaniak.mail.di.IoDispatcher
+import com.infomaniak.mail.utils.SearchUtils
 import com.infomaniak.mail.utils.coroutineContext
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -32,6 +33,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ThreadListViewModel @Inject constructor(
+    private val searchUtils: SearchUtils,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -52,6 +54,11 @@ class ThreadListViewModel @Inject constructor(
                 updatedAtTrigger.postValue(Unit)
             }
         }
+    }
+
+    fun deleteSearchData() = viewModelScope.launch(ioCoroutineContext) {
+        // Delete Search data in case they couldn't be deleted at the end of the previous Search.
+        searchUtils.deleteRealmSearchData()
     }
 
     data class SelectedDraft(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
@@ -112,7 +112,7 @@ class SearchFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         searchViewModel.init(navigationArgs.dummyFolderId)
-        searchViewModel.launchWaitingSearch()
+        searchViewModel.executePendingSearch()
 
         setupListeners()
         setFoldersDropdownUi()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
@@ -112,6 +112,7 @@ class SearchFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         searchViewModel.init(navigationArgs.dummyFolderId)
+        searchViewModel.launchWaitingSearch()
 
         setupListeners()
         setFoldersDropdownUi()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
@@ -126,6 +126,11 @@ class SearchFragment : Fragment() {
         observeHistory()
     }
 
+    override fun onStop() {
+        searchViewModel.cancelSearch()
+        super.onStop()
+    }
+
     private fun setupListeners() = with(binding) {
         toolbar.setNavigationOnClickListener { findNavController().popBackStack() }
         swipeRefreshLayout.setOnRefreshListener { searchViewModel.refreshSearch() }
@@ -135,8 +140,8 @@ class SearchFragment : Fragment() {
         val popupMenu = createPopupMenu()
         binding.folderDropDown.setOnClickListener { popupMenu.show() }
         updateFolderDropDownUi(
-            folder = searchViewModel.selectedFolder,
-            title = requireContext().getLocalizedNameOrAllFolders(searchViewModel.selectedFolder),
+            folder = searchViewModel.currentFolder,
+            title = requireContext().getLocalizedNameOrAllFolders(searchViewModel.currentFolder),
         )
     }
 
@@ -212,7 +217,7 @@ class SearchFragment : Fragment() {
 
             doOnTextChanged { text, _, _, _ ->
                 val newQuery = text.toString()
-                if (searchViewModel.searchQuery != newQuery) {
+                if (searchViewModel.currentSearchQuery != newQuery) {
                     searchViewModel.searchQuery(newQuery)
                 }
             }
@@ -234,7 +239,7 @@ class SearchFragment : Fragment() {
             stateRestorationPolicy = StateRestorationPolicy.PREVENT_WHEN_EMPTY
             onThreadClicked = { thread ->
                 with(searchViewModel) {
-                    if (!isLengthTooShort(searchQuery)) history.value = searchQuery
+                    if (!isLengthTooShort(currentSearchQuery)) history.value = currentSearchQuery
                     navigateToThread(thread, mainViewModel)
                 }
             }
@@ -328,7 +333,7 @@ class SearchFragment : Fragment() {
     }
 
     private fun observeSearchResults() {
-        searchViewModel.searchResultsLiveData(lifecycle).bindResultsChangeToAdapter(viewLifecycleOwner, threadListAdapter)
+        searchViewModel.searchResults.bindResultsChangeToAdapter(viewLifecycleOwner, threadListAdapter)
     }
 
     private fun observeHistory() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -20,7 +20,10 @@ package com.infomaniak.mail.ui.main.search
 import android.app.Application
 import android.content.Context
 import android.util.Log
-import androidx.lifecycle.*
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.utils.SingleLiveEvent
 import com.infomaniak.mail.MatomoMail.trackSearchEvent
@@ -29,7 +32,6 @@ import com.infomaniak.mail.data.cache.mailboxContent.MessageController
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
 import com.infomaniak.mail.data.models.Folder
-import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.data.models.thread.Thread.ThreadFilter
 import com.infomaniak.mail.data.models.thread.ThreadResult
 import com.infomaniak.mail.di.IoDispatcher
@@ -38,19 +40,16 @@ import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.SearchUtils
 import com.infomaniak.mail.utils.coroutineContext
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.realm.kotlin.notifications.ResultsChange
 import io.sentry.Sentry
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     application: Application,
     private val globalCoroutineScope: CoroutineScope,
-    private val searchUtils: SearchUtils,
     private val messageController: MessageController,
+    private val searchUtils: SearchUtils,
     private val threadController: ThreadController,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : AndroidViewModel(application) {
@@ -59,21 +58,12 @@ class SearchViewModel @Inject constructor(
 
     private val ioCoroutineContext = viewModelScope.coroutineContext(ioDispatcher)
 
-    private val _searchQuery = MutableLiveData("" to false)
-    val searchQuery: String get() = _searchQuery.value!!.first
+    var currentFolder: Folder? = null
+        private set
+    var currentSearchQuery: String = ""
+        private set
 
-    private val _selectedFilters = MutableStateFlow(emptySet<ThreadFilter>())
-    private inline val selectedFilters get() = _selectedFilters.value.toMutableSet()
-
-    private val _selectedFolder = MutableStateFlow<Folder?>(null)
-    val selectedFolder: Folder? get() = _selectedFolder.value
-
-    /** `_onPaginationTrigger` & `shouldPaginate` are closely related. Modifying one will impact the other. Beware. */
-    private val _onPaginationTrigger = MutableStateFlow(0L)
-    private var shouldPaginate: Boolean = false
-
-    /** Refreshes the search each time the timestamp changes, so that it doesn't refresh when the timestamp hasn't changed. */
-    private val _onRefreshTrigger = MutableStateFlow(0L)
+    private var currentFilters = mutableSetOf<ThreadFilter>()
 
     val visibilityMode = MutableLiveData(VisibilityMode.RECENT_SEARCHES)
     val history = SingleLiveEvent<String>()
@@ -85,56 +75,47 @@ class SearchViewModel @Inject constructor(
     private var isFirstPage: Boolean = true
     private val isLastPage get() = resourceNext.isNullOrBlank()
 
-    val searchResults: Flow<ResultsChange<Thread>> = observeSearchAndFilters()
-        .flatMapLatest { (queryData, filters, folder, shouldGetNextPage) ->
-            val (query, saveInHistory) = queryData
-            if (!shouldGetNextPage) resetPaginationData()
-            searchThreads(
-                query = if (isLengthTooShort(query)) null else query,
-                saveInHistory,
-                shouldGetNextPage,
-                filters,
-                folder,
-            )
-        }
-
-    fun searchResultsLiveData(lifecycle: Lifecycle): LiveData<ResultsChange<Thread>> {
-        return searchResults.flowWithLifecycle(lifecycle).asLiveData(ioCoroutineContext)
-    }
-
-    private fun observeSearchAndFilters(): Flow<NewSearchInfo> {
-        return combine(
-            _searchQuery.asFlow(),
-            _selectedFilters,
-            _selectedFolder,
-            _onPaginationTrigger,
-            _onRefreshTrigger,
-        ) { queryData, filters, folder, paginationTime, refreshTime ->
-            NewSearchInfo(queryData, filters, folder, shouldPaginate, paginationTime, refreshTime)
-        }.distinctUntilChanged().debounce(SEARCH_DEBOUNCE_DURATION)
-    }
+    private var searchJob: Job? = null
+    val searchResults = threadController.getSearchThreadsAsync().asLiveData(ioCoroutineContext)
 
     fun init(dummyFolderId: String) {
         this.dummyFolderId = dummyFolderId
     }
 
-    fun refreshSearch() {
-        resetPaginationIntent()
-        _onRefreshTrigger.value = System.currentTimeMillis()
+    fun cancelSearch() {
+        searchJob?.cancel()
     }
 
-    fun searchQuery(query: String, saveInHistory: Boolean = false) {
-        resetPaginationIntent()
-        _searchQuery.value = query to saveInHistory
+    private suspend fun search(
+        query: String = currentSearchQuery,
+        saveInHistory: Boolean = false,
+        filters: Set<ThreadFilter> = currentFilters,
+        folder: Folder? = currentFolder,
+        shouldGetNextPage: Boolean = false
+    ) = withContext(ioCoroutineContext) {
+        searchJob?.cancel()
+        searchJob = launch {
+            delay(SEARCH_DEBOUNCE_DURATION)
+            if (!shouldGetNextPage) resetPaginationData()
+            searchThreads(query, saveInHistory, shouldGetNextPage, filters, folder)
+        }
     }
 
-    fun selectFolder(folder: Folder?) {
-        resetPaginationIntent()
-        _selectedFolder.value = folder
+    fun refreshSearch() = viewModelScope.launch(ioCoroutineContext) {
+        search()
     }
 
-    fun setFilter(filter: ThreadFilter, isEnabled: Boolean = true) {
-        resetPaginationIntent()
+    fun searchQuery(query: String, saveInHistory: Boolean = false) = viewModelScope.launch(ioCoroutineContext) {
+        if (query.isNotBlank() && isLengthTooShort(query)) return@launch
+        search(query.trim(), saveInHistory)
+    }
+
+    fun selectFolder(folder: Folder?) = viewModelScope.launch(ioCoroutineContext) {
+        search(folder = folder.also { currentFolder = it })
+    }
+
+    fun setFilter(filter: ThreadFilter, isEnabled: Boolean = true) = viewModelScope.launch(ioCoroutineContext) {
+        if (isEnabled && currentFilters.contains(filter)) return@launch
         if (isEnabled) {
             context.trackSearchEvent(filter.matomoValue)
             filter.select()
@@ -143,29 +124,24 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    fun unselectMutuallyExclusiveFilters() {
-        resetPaginationIntent()
-        _selectedFilters.value = selectedFilters.apply {
+    fun unselectMutuallyExclusiveFilters() = viewModelScope.launch(ioCoroutineContext) {
+        currentFilters.apply {
             removeAll(listOf(ThreadFilter.SEEN, ThreadFilter.UNSEEN, ThreadFilter.STARRED))
         }
+        search(filters = currentFilters)
     }
 
-    fun nextPage() {
-        if (isLastPage) return
-        shouldPaginate = true
-        _onPaginationTrigger.value = System.currentTimeMillis()
+    fun nextPage() = viewModelScope.launch(ioCoroutineContext) {
+        if (isLastPage) return@launch
+        search(shouldGetNextPage = true)
     }
 
-    private fun ThreadFilter.select() {
-        _selectedFilters.value = searchUtils.selectFilter(filter = this, selectedFilters)
+    private suspend fun ThreadFilter.select() {
+        search(filters = searchUtils.selectFilter(filter = this, currentFilters).also { currentFilters = it })
     }
 
-    private fun ThreadFilter.unselect() {
-        _selectedFilters.value = selectedFilters.apply { remove(this@unselect) }
-    }
-
-    private fun resetPaginationIntent() {
-        shouldPaginate = false
+    private suspend fun ThreadFilter.unselect() {
+        search(filters = currentFilters.apply { remove(this@unselect) }.also { currentFilters = it })
     }
 
     private fun resetPaginationData() {
@@ -174,6 +150,7 @@ class SearchViewModel @Inject constructor(
     }
 
     override fun onCleared() {
+        cancelSearch()
         globalCoroutineScope.launch(ioDispatcher) {
             searchUtils.deleteRealmSearchData()
             Log.i(TAG, "SearchViewModel>onCleared: called")
@@ -181,28 +158,31 @@ class SearchViewModel @Inject constructor(
         super.onCleared()
     }
 
-    fun isLengthTooShort(query: String?) = query == null || query.length < MIN_SEARCH_QUERY
+    fun isLengthTooShort(query: String) = query.length < MIN_SEARCH_QUERY
 
-    private fun searchThreads(
-        query: String?,
+    private suspend fun searchThreads(
+        query: String,
         saveInHistory: Boolean,
         shouldGetNextPage: Boolean,
         filters: Set<ThreadFilter>,
         folder: Folder?,
-    ): Flow<ResultsChange<Thread>> = flow {
+    ) {
         getReadyForNewSearch(folder, filters, query)?.let { newFilters ->
             fetchThreads(folder, newFilters, query, shouldGetNextPage)
-            emitThreads(saveInHistory, newFilters, query)
+            if (saveInHistory) query.let(history::postValue)
         }
     }
 
-    private suspend fun getReadyForNewSearch(folder: Folder?, filters: Set<ThreadFilter>, query: String?): Set<ThreadFilter>? {
+    private suspend fun getReadyForNewSearch(
+        folder: Folder?,
+        filters: Set<ThreadFilter>,
+        query: String?
+    ): Set<ThreadFilter>? {
 
         val newFilters = if (folder == null) filters else (filters + ThreadFilter.FOLDER)
 
-        if (isFirstPage && isLastPage) searchUtils.deleteRealmSearchData()
-
-        return if (newFilters.isEmpty() && query.isNullOrBlank()) {
+        return if (newFilters.isEmpty() && query.isNullOrBlank() && currentFolder == null) {
+            searchUtils.deleteRealmSearchData()
             visibilityMode.postValue(VisibilityMode.RECENT_SEARCHES)
             null
         } else {
@@ -213,7 +193,7 @@ class SearchViewModel @Inject constructor(
     private suspend fun fetchThreads(
         folder: Folder?,
         newFilters: Set<ThreadFilter>,
-        query: String?,
+        query: String,
         shouldGetNextPage: Boolean,
     ) {
 
@@ -239,6 +219,10 @@ class SearchViewModel @Inject constructor(
         val searchFilters = searchUtils.searchFilters(query, newFilters, resource)
         val apiResponse = ApiRepository.searchThreads(currentMailbox.uuid, folderId, searchFilters, resource)
 
+        searchJob?.ensureActive()
+
+        if (isFirstPage && isLastPage) searchUtils.deleteRealmSearchData()
+
         if (apiResponse.isSuccess()) with(apiResponse) {
             initSearchFolderThreads()
             resourceNext = data?.resourceNext
@@ -246,35 +230,16 @@ class SearchViewModel @Inject constructor(
         } else if (isLastPage) {
             threadController.saveThreads(searchMessages = messageController.searchMessages(query, newFilters, folderId))
         }
+        if (query != currentSearchQuery) currentSearchQuery = query
+
+        val resultsVisibilityMode = when {
+            newFilters.isEmpty() && isLengthTooShort(query) -> VisibilityMode.RECENT_SEARCHES
+            threadController.getSearchThreadsCount() == 0L -> VisibilityMode.NO_RESULTS
+            else -> VisibilityMode.RESULTS
+        }
+
+        visibilityMode.postValue(resultsVisibilityMode)
     }
-
-    private suspend fun FlowCollector<ResultsChange<Thread>>.emitThreads(
-        saveInHistory: Boolean,
-        newFilters: Set<ThreadFilter>,
-        query: String?,
-    ) {
-        emitAll(threadController.getSearchThreadsAsync().mapLatest {
-            if (saveInHistory) query?.let(history::postValue)
-
-            it.also {
-                val resultsVisibilityMode = when {
-                    newFilters.isEmpty() && isLengthTooShort(searchQuery) -> VisibilityMode.RECENT_SEARCHES
-                    it.list.isEmpty() -> VisibilityMode.NO_RESULTS
-                    else -> VisibilityMode.RESULTS
-                }
-                visibilityMode.postValue(resultsVisibilityMode)
-            }
-        })
-    }
-
-    private data class NewSearchInfo(
-        val queryData: Pair<String, Boolean>,
-        val filters: Set<ThreadFilter>,
-        val folder: Folder?,
-        val shouldGetNextPage: Boolean,
-        private val paginationTime: Long, // Used only to paginate when necessary due to `distinctUntilChanged`.
-        private val refreshTime: Long, // Used only to refresh when necessary due to `distinctUntilChanged`.
-    )
 
     private companion object {
 


### PR DESCRIPTION
**Fix all known bugs and improved research**
- [x] fix: When you open a thread and return to it, clicking immediately on a thread doesn't work. (`Already fixed previously`)
- [x] fix: When paging and opening a thread, the search is reset. (`Already fixed previously`)
- [x] fix: When the search is stopped on return, the data disappears (`Already fixed previously`)
- [x] fix: Clicking on a thread while a search is in progress doesn't work (`Already fixed previously`)
- [x] fix: When you return to the app after an `onStop`, a new search is performed, even though it's useless.
- [x] When you (answer/forward/display attachment) return to the app, the open thread is closed and you're back on the search list.
- [x] **enhancement**: The search is stopped when the user is no longer on the search and resumed when the user returns, so the user is free to do what he or she wants within the search.