### PR TITLE
Cancel ThreadsAlgo in Search

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -45,11 +45,13 @@ import kotlin.math.max
 @Singleton
 class RefreshController @Inject constructor() {
 
+    private const val FORCE_CANCEL = "this_is_a_forced_cancellation_of_the_threads_algorithm"
+
     private var refreshThreadsJob: Job? = null
 
     //region Fetch Messages
     fun cancelRefresh() {
-        refreshThreadsJob?.cancel()
+        refreshThreadsJob?.cancel(CancellationException(FORCE_CANCEL))
     }
 
     suspend fun refreshThreads(
@@ -70,7 +72,7 @@ class RefreshController @Inject constructor() {
             }
         }.getOrElse {
             // It failed, but not because we cancelled it. Something bad happened, so we call the `stopped` callback.
-            if (it !is CancellationException || isFromService) stopped?.invoke()
+            if (it !is CancellationException || it.message == FORCE_CANCEL || isFromService) stopped?.invoke()
             if (it is ApiErrorException) it.handleApiErrors()
             return@getOrElse null
         }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -71,9 +71,15 @@ class RefreshController @Inject constructor() {
                 return@withContext realm.handleRefreshMode(refreshMode, scope = this, mailbox, folder, okHttpClient).toList()
             }
         }.getOrElse {
+
+            // We force-cancelled, so we need to call the `stopped` callback.
+            if (it is CancellationException && (it.message == FORCE_CANCEL || isFromService)) stopped?.invoke()
+
             // It failed, but not because we cancelled it. Something bad happened, so we call the `stopped` callback.
-            if (it !is CancellationException || it.message == FORCE_CANCEL || isFromService) stopped?.invoke()
+            if (it !is CancellationException) stopped?.invoke()
+
             if (it is ApiErrorException) it.handleApiErrors()
+
             return@getOrElse null
         }
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -45,13 +45,11 @@ import kotlin.math.max
 @Singleton
 class RefreshController @Inject constructor() {
 
-    private const val FORCE_CANCEL = "this_is_a_forced_cancellation_of_the_threads_algorithm"
-
     private var refreshThreadsJob: Job? = null
 
     //region Fetch Messages
     fun cancelRefresh() {
-        refreshThreadsJob?.cancel(CancellationException(FORCE_CANCEL))
+        refreshThreadsJob?.cancel(ForcedCancellationException())
     }
 
     suspend fun refreshThreads(
@@ -73,7 +71,7 @@ class RefreshController @Inject constructor() {
         }.getOrElse {
 
             // We force-cancelled, so we need to call the `stopped` callback.
-            if (it is CancellationException && (it.message == FORCE_CANCEL || isFromService)) stopped?.invoke()
+            if (it is ForcedCancellationException || isFromService) stopped?.invoke()
 
             // It failed, but not because we cancelled it. Something bad happened, so we call the `stopped` callback.
             if (it !is CancellationException) stopped?.invoke()
@@ -688,4 +686,6 @@ class RefreshController @Inject constructor() {
         val offsetUid: Int,
         val direction: String,
     )
+
+    private class ForcedCancellationException : CancellationException()
 }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -48,6 +48,10 @@ class RefreshController @Inject constructor() {
     private var refreshThreadsJob: Job? = null
 
     //region Fetch Messages
+    fun cancelRefresh() {
+        refreshThreadsJob?.cancel()
+    }
+
     suspend fun refreshThreads(
         refreshMode: RefreshMode,
         mailbox: Mailbox,

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -58,7 +58,6 @@ class RefreshController @Inject constructor() {
         folder: Folder,
         okHttpClient: OkHttpClient? = null,
         realm: Realm,
-        isFromService: Boolean = false,
         started: (() -> Unit)? = null,
         stopped: (() -> Unit)? = null,
     ): List<Thread>? {
@@ -71,7 +70,7 @@ class RefreshController @Inject constructor() {
         }.getOrElse {
 
             // We force-cancelled, so we need to call the `stopped` callback.
-            if (it is ForcedCancellationException || isFromService) stopped?.invoke()
+            if (it is ForcedCancellationException) stopped?.invoke()
 
             // It failed, but not because we cancelled it. Something bad happened, so we call the `stopped` callback.
             if (it !is CancellationException) stopped?.invoke()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -29,6 +29,7 @@ import com.infomaniak.lib.core.utils.SingleLiveEvent
 import com.infomaniak.mail.MatomoMail.trackSearchEvent
 import com.infomaniak.mail.data.api.ApiRepository
 import com.infomaniak.mail.data.cache.mailboxContent.MessageController
+import com.infomaniak.mail.data.cache.mailboxContent.RefreshController
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
 import com.infomaniak.mail.data.models.Folder
@@ -167,6 +168,8 @@ class SearchViewModel @Inject constructor(
         searchJob?.cancel()
         searchJob = launch {
             delay(SEARCH_DEBOUNCE_DURATION)
+
+            RefreshController.cancelRefresh()
 
             if (!shouldGetNextPage) resetPaginationData()
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -49,8 +49,9 @@ import javax.inject.Inject
 class SearchViewModel @Inject constructor(
     application: Application,
     private val globalCoroutineScope: CoroutineScope,
-    private val messageController: MessageController,
     private val searchUtils: SearchUtils,
+    private val messageController: MessageController,
+    private val refreshController: RefreshController,
     private val threadController: ThreadController,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : AndroidViewModel(application) {
@@ -169,7 +170,7 @@ class SearchViewModel @Inject constructor(
         searchJob = launch {
             delay(SEARCH_DEBOUNCE_DURATION)
 
-            RefreshController.cancelRefresh()
+            refreshController.cancelRefresh()
 
             if (!shouldGetNextPage) resetPaginationData()
 

--- a/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
@@ -63,7 +63,6 @@ class FetchMessagesManager @Inject constructor(
             folder = folder,
             okHttpClient = okHttpClient,
             realm = realm,
-            isFromService = true,
         ) ?: return
 
         Log.d(TAG, "launchWork: ${mailbox.email} has ${newMessagesThreads.count()} Threads with new Messages")


### PR DESCRIPTION
When starting a Search, if the ThreadsAlgo is currently running, we cancel it to avoid overlap with Realm writings.