### PR TITLE
Fix HTML interpretation when editing a Draft

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
@@ -350,7 +350,7 @@ class NewMessageViewModel @Inject constructor(
             return if (index == -1) Int.MAX_VALUE else index
         }
 
-        val doc = Jsoup.parse(draft.body)
+        val doc = Jsoup.parse(draft.body).also { it.outputSettings().prettyPrint(false) }
 
         val (bodyWithQuote, signature) = doc.split(MessageBodyUtils.INFOMANIAK_SIGNATURE_HTML_CLASS_NAME, draft.body)
 


### PR DESCRIPTION
Because Jsoup used to pretty print all of the HTML, the `wholeText()` method believed some of the tabs of the pretty print to be spaces. It added unwanted spaces at the start of each HTML tag, especially visible when using the webmail WYSIWYG because it wraps most lines inside a `<div>`.