### PR TITLE
fix: Notification actions doesn't work sometimes

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -178,11 +178,17 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.deleteMessages(mailboxUuid), POST, mapOf("uids" to messageUids))
     }
 
-    fun moveMessages(mailboxUuid: String, messagesUids: List<String>, destinationId: String): ApiResponse<MoveResult> {
+    fun moveMessages(
+        mailboxUuid: String,
+        messagesUids: List<String>,
+        destinationId: String,
+        okHttpClient: OkHttpClient = HttpClient.okHttpClient,
+    ): ApiResponse<MoveResult> {
         return callApi(
             url = ApiRoutes.moveMessages(mailboxUuid),
             method = POST,
             body = mapOf("uids" to messagesUids, "to" to destinationId),
+            okHttpClient = okHttpClient
         )
     }
 

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -188,7 +188,7 @@ object ApiRepository : ApiRepositoryCore() {
             url = ApiRoutes.moveMessages(mailboxUuid),
             method = POST,
             body = mapOf("uids" to messagesUids, "to" to destinationId),
-            okHttpClient = okHttpClient
+            okHttpClient = okHttpClient,
         )
     }
 

--- a/app/src/main/java/com/infomaniak/mail/receivers/NotificationActionsReceiver.kt
+++ b/app/src/main/java/com/infomaniak/mail/receivers/NotificationActionsReceiver.kt
@@ -149,7 +149,6 @@ class NotificationActionsReceiver : BroadcastReceiver() {
             context.trackNotificationActionEvent(matomoValue)
 
             with(ApiRepository.moveMessages(mailbox.uuid, messages.getUids(), destinationId, okHttpClient)) {
-
                 if (isSuccess()) {
                     dismissNotification(context, mailbox, notificationId)
                 } else {


### PR DESCRIPTION
**Description**
Sometimes notifications don't work because they're based on the application token, which is only available when the app is foreground, but if you're in the background you may not get the current user info.

**Fixes**
- Now we avoid using the current user's token, but just pass him his own `httpClient` so we don't have to worry about it.
- In a second step, we reset the notification in case of error, as a temporary solution (see if you want to do it differently).