### PR TITLE
Improve email rendering by breaking wide lines

### DIFF
--- a/HtmlCleaner/src/main/java/com/infomaniak/html/cleaner/BodyCleaner.kt
+++ b/HtmlCleaner/src/main/java/com/infomaniak/html/cleaner/BodyCleaner.kt
@@ -30,7 +30,23 @@ internal class BodyCleaner {
 
     init {
         val allowList = Safelist.relaxed()
-            .addTags("area", "button", "center", "del", "font", "hr", "ins", "kbd", "map", "samp", "style", "title", "tt", "var")
+            .addTags(
+                "area",
+                "button",
+                "center",
+                "del",
+                "font",
+                "hr",
+                "ins",
+                "kbd",
+                "map",
+                "samp",
+                "style",
+                "title",
+                "tt",
+                "var",
+                "wbr",
+            )
             .addAttributes(":all", "class", "dir", "id", "style")
             .addAttributes("a", "name")
             // Allow all URI schemes in links. Removing all protocols makes the list of protocols empty which means allow all protocols

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -23,6 +23,8 @@ import com.infomaniak.html.cleaner.HtmlSanitizer
 import com.infomaniak.mail.R
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
 import com.google.android.material.R as RMaterial
 
 class HtmlFormatter(private val html: String) {
@@ -54,8 +56,22 @@ class HtmlFormatter(private val html: String) {
             injectMetaViewPort()
             injectScript()
         }
+        body().breakLongStrings()
         if (needsBodyEncapsulation) body().encapsulateElementInDiv()
         html()
+    }
+
+    private fun Node.breakLongStrings() {
+        childNodes().forEach { child ->
+            if (child is TextNode) {
+                if (!child.isBlank) {
+                    val chunkedText = child.text().chunked(30).joinToString(separator = 0x200B.toChar().toString())
+                    child.text(chunkedText)
+                }
+            } else {
+                child.breakLongStrings()
+            }
+        }
     }
 
     private fun Element.injectCss() {

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -92,6 +92,9 @@ class HtmlFormatter(private val html: String) {
         }
     }
 
+    // When displaying emails that have very long strings that are hard to break (mostly URLs), sometimes using
+    // 'overflow-wrap: break-word' doesn't help softwrapping the line. This results in very wide emails that need to be zoomed out
+    // excessively. To fix this issue, we add zero width spaces in optimal places to help this css attribute wrap correctly
     private fun Node.breakLongStrings() {
         for (child in childNodes()) {
             if (child is TextNode) {

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -153,13 +153,13 @@ class HtmlFormatter(private val html: String) {
         private const val PRIMARY_COLOR_CODE = "--kmail-primary-color"
         private const val KMAIL_MESSAGE_ID = "kmail-message-content"
 
-        private val DETECT_BUT_DO_NOT_BREAK = setOf(' ')
-        private val BREAK_CHARACTERS = setOf(':', '/', '~', '.', ',', '-', '_', '?', '#', '%', '=', '&')
         private const val ZERO_WIDTH_SPACE = 0x200B.toChar()
         private const val BREAK_LIMIT = 30
         // Across a few handpicked representative emails, average text node length for text nodes bigger than 30 characters seems
         // to be centered between 60 and 120
         private const val OPTIMAL_STRING_LENGTH = 120
+        private val DETECT_BUT_DO_NOT_BREAK = setOf(' ', ZERO_WIDTH_SPACE) // ZWSP could already be present in the original html
+        private val BREAK_CHARACTERS = setOf(':', '/', '~', '.', ',', '-', '_', '?', '#', '%', '=', '&')
 
         private fun Context.loadCss(@RawRes cssResId: Int, customColors: List<Pair<String, Int>> = emptyList()): String {
             var css = readRawResource(cssResId)

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -98,8 +98,6 @@ class HtmlFormatter(private val html: String) {
     private fun Node.breakLongStrings() {
         for (child in childNodes()) {
             if (child is TextNode) {
-                if (child.isBlank) continue
-
                 val text = child.text()
                 if (text.length <= 30) continue
 

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -122,23 +122,18 @@ class HtmlFormatter(private val html: String) {
             }
 
             when (char) {
-                in DETECT_BUT_DO_NOT_BREAK -> {
-                    counter = 0
-                    stringBuilder.append(char)
-                }
-                in BREAK_CHARACTERS -> {
-                    stringBuilder.append(char)
-                    previousCharIsBreakable = true
-                }
+                in DETECT_BUT_DO_NOT_BREAK -> counter = 0
+                in BREAK_CHARACTERS -> previousCharIsBreakable = true
                 else -> {
                     if (previousCharIsBreakable) {
                         counter = 0
                         stringBuilder.append(ZERO_WIDTH_SPACE)
+                        previousCharIsBreakable = false
                     }
-                    stringBuilder.append(char)
-                    previousCharIsBreakable = false
                 }
             }
+
+            stringBuilder.append(char)
         }
 
         return stringBuilder.toString()

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -99,7 +99,7 @@ class HtmlFormatter(private val html: String) {
         for (child in childNodes()) {
             if (child is TextNode) {
                 val text = child.text()
-                if (text.length <= 30) continue
+                if (text.length <= BREAK_LIMIT) continue
 
                 child.text(breakString(text))
             } else {
@@ -110,7 +110,7 @@ class HtmlFormatter(private val html: String) {
 
     private fun breakString(text: String): String {
         var counter = 0
-        var lastCharIsBreakable = false
+        var previousCharIsBreakable = false
         val stringBuilder = StringBuilder(OPTIMAL_STRING_LENGTH)
 
         for (char in text) {
@@ -123,17 +123,20 @@ class HtmlFormatter(private val html: String) {
 
             when (char) {
                 in DETECT_BUT_DO_NOT_BREAK -> {
-                    stringBuilder.append(char)
                     counter = 0
+                    stringBuilder.append(char)
                 }
                 in BREAK_CHARACTERS -> {
                     stringBuilder.append(char)
-                    lastCharIsBreakable = true
+                    previousCharIsBreakable = true
                 }
                 else -> {
-                    if (lastCharIsBreakable) stringBuilder.append(ZERO_WIDTH_SPACE)
+                    if (previousCharIsBreakable) {
+                        counter = 0
+                        stringBuilder.append(ZERO_WIDTH_SPACE)
+                    }
                     stringBuilder.append(char)
-                    lastCharIsBreakable = false
+                    previousCharIsBreakable = false
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/mail/utils/WebViewUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/WebViewUtils.kt
@@ -64,6 +64,7 @@ class WebViewUtils(context: Context) {
         registerScript(fixStyleScript)
         registerScript(jsBridgeScript)
         registerBodyEncapsulation()
+        registerBreakLongWords()
     }
 
     class JavascriptBridge {


### PR DESCRIPTION
A not so uncommonly occurring issue with our mail rendering is that some really wide continuous lines of text (mostly URLs) are not softwrapped correctly. This results in excessively zoomed out emails which become hard too read or even completely unreadable for the most extreme cases. 

This PR solves this issue by adding "zero width spaces" inside long strings which will enable softwrapping at these key positions. This strategy is inspired by what Google seems to be doing in its webmail and it seems very likely to also be the comportment they have on their mobile app.