### PR TITLE
Fix render long lines for selection or copy

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -96,10 +96,10 @@ class HtmlFormatter(private val html: String) {
 
     // When displaying emails that have very long strings that are hard to break (mostly URLs), sometimes using
     // 'overflow-wrap: break-word' doesn't help softwrapping the line. This results in very wide emails that need to be zoomed out
-    private fun Node.breakLongStrings() {
-        childNodes().forEach { parent ->
-            if (parent is Element && parent.textNodes().isNotEmpty()) {
     // excessively. To fix this issue, we add <wbr> tags in optimal places to help 'overflow-wrap: break-word' wrap correctly
+    private fun Element.breakLongStrings() {
+        children().forEach { parent ->
+            if (parent.textNodes().isNotEmpty()) {
                 for (textNode in parent.textNodes()) {
                     val text = textNode.text()
                     if (text.length <= BREAK_LIMIT) continue
@@ -108,7 +108,7 @@ class HtmlFormatter(private val html: String) {
                 }
             }
 
-            if (parent is Element) parent.breakLongStrings()
+            parent.breakLongStrings()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -98,22 +98,20 @@ class HtmlFormatter(private val html: String) {
     private fun Element.breakLongStrings() {
         children().forEach { parent ->
             val textNodes = parent.textNodes()
-            if (textNodes.isNotEmpty()) { // TODO : Remove
-                for (textNode in textNodes) {
-                    val text = textNode.text()
-                    if (text.length <= BREAK_LIMIT) continue
+            for (textNode in textNodes) {
+                val text = textNode.text()
+                if (text.length <= BREAK_LIMIT) continue
 
-                    parent.replaceChildWithNodes(textNode, breakString(text))
-                }
+                parent.replaceChildWithNodes(child = textNode, breakString(text))
             }
 
             parent.breakLongStrings()
         }
     }
 
-    private fun Element.replaceChildWithNodes(textNode: TextNode, nodes: List<Node>) {
-        val index = textNode.siblingIndex()
-        textNode.remove()
+    private fun Element.replaceChildWithNodes(child: Node, nodes: List<Node>) {
+        val index = child.siblingIndex()
+        child.remove()
         insertChildren(index, nodes)
     }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -171,7 +171,7 @@ class HtmlFormatter(private val html: String) {
         // Across a few handpicked representative emails, average text node length for text nodes bigger than 30 characters seems
         // to be centered between 60 and 120
         private const val OPTIMAL_STRING_LENGTH = 120
-        private val DETECT_BUT_DO_NOT_BREAK = setOf(' ', WBR)
+        private val DETECT_BUT_DO_NOT_BREAK = setOf(' ')
         private val BREAK_CHARACTERS = setOf(':', '/', '~', '.', ',', '-', '_', '?', '#', '%', '=', '&')
 
         private fun Context.loadCss(@RawRes cssResId: Int, customColors: List<Pair<String, Int>> = emptyList()): String {

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -96,10 +96,10 @@ class HtmlFormatter(private val html: String) {
 
     // When displaying emails that have very long strings that are hard to break (mostly URLs), sometimes using
     // 'overflow-wrap: break-word' doesn't help softwrapping the line. This results in very wide emails that need to be zoomed out
-    // excessively. To fix this issue, we add zero width spaces in optimal places to help this css attribute wrap correctly
     private fun Node.breakLongStrings() {
         childNodes().forEach { parent ->
             if (parent is Element && parent.textNodes().isNotEmpty()) {
+    // excessively. To fix this issue, we add <wbr> tags in optimal places to help 'overflow-wrap: break-word' wrap correctly
                 for (textNode in parent.textNodes()) {
                     val text = textNode.text()
                     if (text.length <= BREAK_LIMIT) continue

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -99,8 +99,9 @@ class HtmlFormatter(private val html: String) {
     // excessively. To fix this issue, we add <wbr> tags in optimal places to help 'overflow-wrap: break-word' wrap correctly
     private fun Element.breakLongStrings() {
         children().forEach { parent ->
-            if (parent.textNodes().isNotEmpty()) {
-                for (textNode in parent.textNodes()) {
+            val textNodes = parent.textNodes()
+            if (textNodes.isNotEmpty()) {
+                for (textNode in textNodes) {
                     val text = textNode.text()
                     if (text.length <= BREAK_LIMIT) continue
 


### PR DESCRIPTION
Use `<wbr>` instead of zero width spaces because they do not get copied to the clipboard and do not interfere with URL detection by the Android system when selecting a url inside plain text