### PR TITLE
Extract reply/forward header creation code in their own use case file

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/DraftController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/DraftController.kt
@@ -39,7 +39,7 @@ import javax.inject.Inject
 class DraftController @Inject constructor(
     private val mailboxContentRealm: RealmDatabase.MailboxContent,
     private val mailboxController: MailboxController,
-    private val replyForwardHeaderManager: ReplyForwardHeaderManager,
+    private val replyForwardFooterManager: ReplyForwardFooterManager,
 ) {
 
     //region Get data
@@ -88,7 +88,7 @@ class DraftController @Inject constructor(
                 draft.to = toList.toRealmList()
                 draft.cc = ccList.toRealmList()
 
-                draft.body += replyForwardHeaderManager.createReplyFooter(previousMessage)
+                draft.body += replyForwardFooterManager.createReplyFooter(previousMessage)
             }
             DraftMode.FORWARD -> {
                 draft.forwardedUid = previousMessage.uid
@@ -100,7 +100,7 @@ class DraftController @Inject constructor(
                     }
                 }
 
-                draft.body += replyForwardHeaderManager.createForwardFooter(previousMessage, draft.attachments)
+                draft.body += replyForwardFooterManager.createForwardFooter(previousMessage, draft.attachments)
             }
             DraftMode.NEW_MAIL -> Unit
         }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardFooterManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardFooterManager.kt
@@ -35,7 +35,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ReplyForwardHeaderManager @Inject constructor(private val appContext: Context) {
+class ReplyForwardFooterManager @Inject constructor(private val appContext: Context) {
 
     fun createForwardFooter(message: Message, attachmentsToForward: List<Attachment>): String {
         val previousBody = getHtmlDocument(message)?.let { document ->

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardFooterManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardFooterManager.kt
@@ -90,9 +90,7 @@ class ReplyForwardFooterManager @Inject constructor(private val appContext: Cont
         }
     }
 
-    private fun Message.fromName(): String {
-        return sender?.quotedDisplay() ?: appContext.getString(R.string.unknownRecipientTitle)
-    }
+    private fun Message.fromName(): String = sender?.quotedDisplay() ?: appContext.getString(R.string.unknownRecipientTitle)
 
     private fun getHtmlDocument(message: Message): Document? {
         val html = message.body?.let { body ->
@@ -121,7 +119,7 @@ class ReplyForwardFooterManager @Inject constructor(private val appContext: Cont
 
     private fun assembleForwardHtmlFooter(
         message: Message,
-        previousFullBody: String
+        previousFullBody: String,
     ): String = with(appContext) {
         val messageForwardHeader = getString(R.string.messageForwardHeader)
         val fromTitle = getString(R.string.fromTitle)

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardFooterManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardFooterManager.kt
@@ -38,8 +38,8 @@ import javax.inject.Singleton
 class ReplyForwardFooterManager @Inject constructor(private val appContext: Context) {
 
     fun createForwardFooter(message: Message, attachmentsToForward: List<Attachment>): String {
-        val previousBody = getHtmlDocument(message)?.apply {
-            processCids(
+        val previousBody = getHtmlDocument(message)?.let { document ->
+            document.processCids(
                 message = message,
                 associateDataToCid = { oldAttachment ->
                     val newAttachment = attachmentsToForward.find { it.originalContentId == oldAttachment.contentId }
@@ -47,9 +47,11 @@ class ReplyForwardFooterManager @Inject constructor(private val appContext: Cont
                 },
                 applyAssociatedDataToImage = { newContentId, imageElement ->
                     imageElement.attr(SRC_ATTRIBUTE, "${CID_PROTOCOL}$newContentId")
-                }
+                },
             )
-        }?.outerHtml() ?: ""
+
+            document.outerHtml()
+        } ?: ""
 
         val previousFullBody = computePreviousFullBody(previousBody, message)
         return assembleForwardHtmlFooter(message, previousFullBody)
@@ -60,15 +62,17 @@ class ReplyForwardFooterManager @Inject constructor(private val appContext: Cont
         val from = message.fromName()
         val messageReplyHeader = appContext.getString(R.string.messageReplyHeader, date, from)
 
-        val previousBody = getHtmlDocument(message)?.apply {
-            processCids(
+        val previousBody = getHtmlDocument(message)?.let { document ->
+            document.processCids(
                 message = message,
                 associateDataToCid = Attachment::name,
                 applyAssociatedDataToImage = { name, imageElement ->
                     imageElement.replaceWith(TextNode("<$name>"))
-                }
+                },
             )
-        }?.outerHtml() ?: ""
+
+            document.outerHtml()
+        } ?: ""
 
         val previousFullBody = computePreviousFullBody(previousBody, message)
         return assembleReplyHtmlFooter(messageReplyHeader, previousFullBody)

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardHeaderManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardHeaderManager.kt
@@ -37,14 +37,7 @@ import javax.inject.Singleton
 @Singleton
 class ReplyForwardHeaderManager @Inject constructor(private val appContext: Context) {
 
-    fun createForwardFooter(message: Message, attachmentsToForward: List<Attachment>): String = with(appContext) {
-        val messageForwardHeader = getString(R.string.messageForwardHeader)
-        val fromTitle = getString(R.string.fromTitle)
-        val dateTitle = getString(R.string.dateTitle)
-        val subjectTitle = getString(R.string.subjectTitle)
-        val toTitle = getString(R.string.toTitle)
-        val ccTitle = getString(R.string.ccTitle)
-
+    fun createForwardFooter(message: Message, attachmentsToForward: List<Attachment>): String {
         val previousBody = getHtmlDocument(message)?.let { document ->
             val attachmentsMap = message.attachments.associate { oldAttachment ->
                 val newAttachment = attachmentsToForward.find { it.originalContentId == oldAttachment.contentId }
@@ -63,16 +56,7 @@ class ReplyForwardHeaderManager @Inject constructor(private val appContext: Cont
 
         val previousFullBody = computePreviousFullBody(previousBody, message)
 
-        return assembleForwardHtmlFooter(
-            messageForwardHeader,
-            fromTitle,
-            message,
-            dateTitle,
-            subjectTitle,
-            toTitle,
-            ccTitle,
-            previousFullBody
-        )
+        return assembleForwardHtmlFooter(message, previousFullBody)
     }
 
     fun createReplyFooter(message: Message): String {
@@ -127,15 +111,16 @@ class ReplyForwardHeaderManager @Inject constructor(private val appContext: Cont
     private fun Recipient.quotedDisplay(): String = "${("$name ").ifBlank { "" }}<$email>"
 
     private fun assembleForwardHtmlFooter(
-        messageForwardHeader: String,
-        fromTitle: String,
         message: Message,
-        dateTitle: String,
-        subjectTitle: String,
-        toTitle: String,
-        ccTitle: String,
         previousFullBody: String
-    ): String {
+    ): String = with(appContext) {
+        val messageForwardHeader = getString(R.string.messageForwardHeader)
+        val fromTitle = getString(R.string.fromTitle)
+        val dateTitle = getString(R.string.dateTitle)
+        val subjectTitle = getString(R.string.subjectTitle)
+        val toTitle = getString(R.string.toTitle)
+        val ccTitle = getString(R.string.ccTitle)
+
         val forwardRoot = "<div class=\"${MessageBodyUtils.INFOMANIAK_FORWARD_QUOTE_HTML_CLASS_NAME}\" />"
         return parseAndWrapElementInNewDocument(forwardRoot).apply {
             addAndEscapeTextLine("---------- $messageForwardHeader ---------")

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardHeaderManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardHeaderManager.kt
@@ -1,0 +1,198 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2023 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.cache.mailboxContent
+
+import android.content.Context
+import com.infomaniak.mail.R
+import com.infomaniak.mail.data.models.Attachment
+import com.infomaniak.mail.data.models.correspondent.Recipient
+import com.infomaniak.mail.data.models.message.Message
+import com.infomaniak.mail.ui.main.thread.MessageWebViewClient
+import com.infomaniak.mail.utils.MessageBodyUtils
+import com.infomaniak.mail.utils.SharedUtils
+import com.infomaniak.mail.utils.Utils
+import com.infomaniak.mail.utils.toDate
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.TextNode
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReplyForwardHeaderManager @Inject constructor(private val appContext: Context) {
+
+    fun createForwardFooter(message: Message, attachmentsToForward: List<Attachment>): String = with(appContext) {
+        val messageForwardHeader = getString(R.string.messageForwardHeader)
+        val fromTitle = getString(R.string.fromTitle)
+        val dateTitle = getString(R.string.dateTitle)
+        val subjectTitle = getString(R.string.subjectTitle)
+        val toTitle = getString(R.string.toTitle)
+        val ccTitle = getString(R.string.ccTitle)
+
+        val previousBody = getHtmlDocument(message)?.let { document ->
+            val attachmentsMap = message.attachments.associate { oldAttachment ->
+                val newAttachment = attachmentsToForward.find { it.originalContentId == oldAttachment.contentId }
+
+                oldAttachment.contentId to newAttachment?.contentId
+            }
+
+            document.doOnHtmlImage { imageElement ->
+                attachmentsMap[getCid(imageElement)]?.let { newContentId ->
+                    imageElement.attr(SRC_ATTRIBUTE, "${CID_PROTOCOL}$newContentId")
+                }
+            }
+
+            return@let document.outerHtml()
+        } ?: ""
+
+        val previousFullBody = computePreviousFullBody(previousBody, message)
+
+        return assembleForwardHtmlFooter(
+            messageForwardHeader,
+            fromTitle,
+            message,
+            dateTitle,
+            subjectTitle,
+            toTitle,
+            ccTitle,
+            previousFullBody
+        )
+    }
+
+    fun createReplyFooter(message: Message): String {
+        val date = message.date.toDate()
+        val from = message.fromName()
+        val messageReplyHeader = appContext.getString(R.string.messageReplyHeader, date, from)
+
+        val previousBody = getHtmlDocument(message)?.let { document ->
+            val attachmentsMap = message.attachments.associate { it.contentId to it.name }
+
+            document.doOnHtmlImage { imageElement ->
+                attachmentsMap[getCid(imageElement)]?.let { name ->
+                    imageElement.replaceWith(TextNode("<$name>"))
+                }
+            }
+
+            return@let document.outerHtml()
+        } ?: ""
+
+        val previousFullBody = computePreviousFullBody(previousBody, message)
+
+        return assembleReplyHtmlFooter(messageReplyHeader, previousFullBody)
+    }
+
+    private fun Message.fromName(): String {
+        return sender?.quotedDisplay() ?: appContext.getString(R.string.unknownRecipientTitle)
+    }
+
+    private fun getHtmlDocument(message: Message): Document? {
+        val html = message.body?.let { body ->
+            when (body.type) {
+                Utils.TEXT_PLAIN -> SharedUtils.createHtmlForPlainText(body.value)
+                else -> body.value
+            }
+        }
+
+        return html?.let(Jsoup::parse)
+    }
+
+    private fun Document.doOnHtmlImage(actionOnImage: (Element) -> Unit) {
+        select(CID_IMAGE_CSS_QUERY).forEach { imageElement -> actionOnImage(imageElement) }
+    }
+
+    private fun getCid(imageElement: Element) = imageElement.attr(SRC_ATTRIBUTE).removePrefix(CID_PROTOCOL)
+
+    private fun computePreviousFullBody(previousBody: String, message: Message): String {
+        return message.body?.let { body ->
+            MessageBodyUtils.mergeSplitBodyAndSubBodies(previousBody, body.subBodies, message.uid)
+        } ?: previousBody
+    }
+
+    private fun Recipient.quotedDisplay(): String = "${("$name ").ifBlank { "" }}<$email>"
+
+    private fun assembleForwardHtmlFooter(
+        messageForwardHeader: String,
+        fromTitle: String,
+        message: Message,
+        dateTitle: String,
+        subjectTitle: String,
+        toTitle: String,
+        ccTitle: String,
+        previousFullBody: String
+    ): String {
+        val forwardRoot = "<div class=\"${MessageBodyUtils.INFOMANIAK_FORWARD_QUOTE_HTML_CLASS_NAME}\" />"
+        return parseAndWrapElementInNewDocument(forwardRoot).apply {
+            addAndEscapeTextLine("---------- $messageForwardHeader ---------")
+            addAndEscapeTextLine("$fromTitle ${message.fromName()}")
+            addAndEscapeTextLine("$dateTitle ${message.date.toDate()}")
+            addAndEscapeTextLine("$subjectTitle ${message.subject}")
+            addAndEscapeRecipientLine(toTitle, message.to)
+            addAndEscapeRecipientLine(ccTitle, message.cc)
+            addAndEscapeTextLine("")
+            addAndEscapeTextLine("")
+
+            addAlreadyEscapedBody(previousFullBody)
+        }.outerHtml()
+    }
+
+    private fun assembleReplyHtmlFooter(messageReplyHeader: String, previousFullBody: String): String {
+        val replyRoot = """<div id="answerContentMessage" class="${MessageBodyUtils.INFOMANIAK_REPLY_QUOTE_HTML_CLASS_NAME}" />"""
+        return parseAndWrapElementInNewDocument(replyRoot).apply {
+            addAndEscapeTextLine(messageReplyHeader, endWithBr = false)
+            addReplyBlockQuote {
+                addAlreadyEscapedBody(previousFullBody)
+            }
+        }.outerHtml()
+    }
+
+    private fun parseAndWrapElementInNewDocument(elementHtml: String): Element {
+        val doc = Jsoup.parseBodyFragment(elementHtml)
+        return doc.body().firstElementChild()!!
+    }
+
+    private fun Element.addAndEscapeTextLine(content: String, endWithBr: Boolean = true) {
+        appendElement("div").apply {
+            text(content)
+            if (endWithBr) appendElement("br")
+        }
+    }
+
+    private fun Element.addAndEscapeRecipientLine(prefix: String, recipientList: List<Recipient>) {
+        formatRecipientList(recipientList)?.let { recipients -> addAndEscapeTextLine("$prefix $recipients") }
+    }
+
+    private fun Element.addAlreadyEscapedBody(previousFullBody: String) {
+        append(previousFullBody)
+    }
+
+    private fun Element.addReplyBlockQuote(addInnerElements: Element.() -> Unit) {
+        val blockQuote = appendElement("blockquote").addClass("ws-ng-quote")
+        blockQuote.addInnerElements()
+    }
+
+    private fun formatRecipientList(recipientList: List<Recipient>): String? {
+        return if (recipientList.isNotEmpty()) recipientList.joinToString { it.quotedDisplay() } else null
+    }
+
+    companion object {
+        private const val CID_PROTOCOL = "${MessageWebViewClient.CID_SCHEME}:"
+        private const val SRC_ATTRIBUTE = "src"
+        private const val CID_IMAGE_CSS_QUERY = "img[${SRC_ATTRIBUTE}^='${CID_PROTOCOL}']"
+    }
+}


### PR DESCRIPTION
Cleaning this code up made me realize how little our processing of emails' html is centralized. This needs to be fixed in a following PR. We access the field `value` from `Body` objects way too often when we never should access it raw like this but rather have the final html be:
* created with subbodies 
* wrapped if it was a text/plain
* sanitized

This result should be the only value we ever access

Depends on #1602