### PR TITLE
Remove class and id that were copied from the webmail but are actually useless

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardFooterManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardFooterManager.kt
@@ -148,7 +148,7 @@ class ReplyForwardFooterManager @Inject constructor(private val appContext: Cont
     }
 
     private fun assembleReplyHtmlFooter(messageReplyHeader: String, previousFullBody: String): String {
-        val replyRoot = """<div id="answerContentMessage" class="${MessageBodyUtils.INFOMANIAK_REPLY_QUOTE_HTML_CLASS_NAME}" />"""
+        val replyRoot = """<div class="${MessageBodyUtils.INFOMANIAK_REPLY_QUOTE_HTML_CLASS_NAME}" />"""
         return parseAndWrapElementInNewDocument(replyRoot).apply {
             addAndEscapeTextLine(messageReplyHeader, endWithBr = false)
             addReplyBlockQuote {
@@ -178,7 +178,7 @@ class ReplyForwardFooterManager @Inject constructor(private val appContext: Cont
     }
 
     private fun Element.addReplyBlockQuote(addInnerElements: Element.() -> Unit) {
-        val blockQuote = appendElement("blockquote").addClass("ws-ng-quote")
+        val blockQuote = appendElement("blockquote")
         blockQuote.addInnerElements()
     }
 


### PR DESCRIPTION
As explained by the webmail team, we can remove these values

Depends on #1603