### PR TITLE
Simplify and lower coupling of updating AvatarView avatars

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -203,7 +203,6 @@ class MainViewModel @Inject constructor(
     //endregion
 
     //region Merged Contacts
-    // Explanation of this Map: Map<Email, Map<Name, MergedContact>>
     val mergedContactsLive: LiveData<MergedContactDictionary> = avatarMergedContactData.mergedContactLiveData
     //endregion
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -57,6 +57,7 @@ import com.infomaniak.mail.utils.NotificationUtils.Companion.cancelNotification
 import com.infomaniak.mail.utils.SharedUtils.Companion.updateSignatures
 import com.infomaniak.mail.utils.Utils.isPermanentDeleteFolder
 import com.infomaniak.mail.utils.Utils.runCatchingRealm
+import com.infomaniak.mail.views.itemViews.AvatarMergedContactData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.kotlin.ext.copyFromRealm
 import io.realm.kotlin.notifications.ResultsChange
@@ -85,6 +86,7 @@ class MainViewModel @Inject constructor(
     private val refreshController: RefreshController,
     private val sharedUtils: SharedUtils,
     private val threadController: ThreadController,
+    private val avatarMergedContactData: AvatarMergedContactData,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : AndroidViewModel(application) {
 
@@ -202,10 +204,7 @@ class MainViewModel @Inject constructor(
 
     //region Merged Contacts
     // Explanation of this Map: Map<Email, Map<Name, MergedContact>>
-    val mergedContactsLive: LiveData<MergedContactDictionary?> = mergedContactController
-        .getMergedContactsAsync()
-        .mapLatest { ContactUtils.arrangeMergedContacts(it.list.copyFromRealm()) }
-        .asLiveData(ioCoroutineContext)
+    val mergedContactsLive: LiveData<MergedContactDictionary> = avatarMergedContactData.mergedContactLiveData
     //endregion
 
     fun updateUserInfo() = viewModelScope.launch(ioCoroutineContext) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/AvatarNameEmailView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/AvatarNameEmailView.kt
@@ -33,7 +33,6 @@ import com.infomaniak.mail.data.models.correspondent.Correspondent
 import com.infomaniak.mail.data.models.correspondent.MergedContact
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.databinding.ViewAvatarNameEmailBinding
-import com.infomaniak.mail.utils.MergedContactDictionary
 import com.infomaniak.mail.utils.UiUtils.fillInUserNameAndEmail
 import com.infomaniak.mail.utils.getAttributeColor
 import com.google.android.material.R as RMaterial
@@ -65,8 +64,8 @@ class AvatarNameEmailView @JvmOverloads constructor(
         }
     }
 
-    fun setRecipient(recipient: Recipient, contacts: MergedContactDictionary) = with(binding) {
-        userAvatar.loadAvatar(recipient, contacts)
+    fun setRecipient(recipient: Recipient) = with(binding) {
+        userAvatar.loadAvatar(recipient)
         setNameAndEmail(recipient)
     }
 
@@ -83,10 +82,6 @@ class AvatarNameEmailView @JvmOverloads constructor(
         userAvatar.loadUnknownUserAvatar()
         userName.text = context.getString(R.string.addUnknownRecipientTitle)
         userEmail.text = searchQuery
-    }
-
-    fun updateAvatar(recipient: Recipient, contacts: MergedContactDictionary) {
-        binding.userAvatar.loadAvatar(recipient, contacts)
     }
 
     override fun setOnClickListener(onClickListener: OnClickListener?) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2023 Infomaniak Network SA
+ * Copyright (C) 2022-2024 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -132,9 +132,7 @@ class ThreadListAdapter @Inject constructor(
             val binding = holder.binding as CardviewThreadItemBinding
             val thread = dataSet[position] as Thread
 
-            when (payload) {
-                NotificationType.SELECTED_STATE -> binding.updateSelectedState(thread)
-            }
+            binding.updateSelectedState(thread)
         } else {
             super.onBindViewHolder(holder, position, payloads)
         }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -91,7 +91,6 @@ class ThreadListAdapter @Inject constructor(
     var onLoadMoreClicked: (() -> Unit)? = null
 
     private var folderRole: FolderRole? = null
-    private lateinit var contacts: MergedContactDictionary
     private var onSwipeFinished: (() -> Unit)? = null
     private var multiSelection: MultiSelectionListener<Thread>? = null
 
@@ -101,12 +100,10 @@ class ThreadListAdapter @Inject constructor(
 
     operator fun invoke(
         folderRole: FolderRole?,
-        contacts: MergedContactDictionary,
         onSwipeFinished: (() -> Unit)? = null,
         multiSelection: MultiSelectionListener<Thread>? = null,
     ) {
         this.folderRole = folderRole
-        this.contacts = contacts
         this.onSwipeFinished = onSwipeFinished
         this.multiSelection = multiSelection
     }
@@ -136,7 +133,6 @@ class ThreadListAdapter @Inject constructor(
             val thread = dataSet[position] as Thread
 
             when (payload) {
-                NotificationType.AVATAR -> binding.displayAvatar(thread)
                 NotificationType.SELECTED_STATE -> binding.updateSelectedState(thread)
             }
         } else {
@@ -260,7 +256,7 @@ class ThreadListAdapter @Inject constructor(
     }
 
     private fun CardviewThreadItemBinding.displayAvatar(thread: Thread) {
-        expeditorAvatar.loadAvatar(thread.computeAvatarRecipient(), contacts)
+        expeditorAvatar.loadAvatar(thread.computeAvatarRecipient())
     }
 
     private fun CardviewThreadItemBinding.formatRecipientNames(recipients: List<Recipient>): String {
@@ -460,11 +456,6 @@ class ThreadListAdapter @Inject constructor(
         }
     }
 
-    fun updateContacts(newContacts: MergedContactDictionary) {
-        contacts = newContacts
-        notifyItemRangeChanged(0, itemCount, NotificationType.AVATAR)
-    }
-
     fun updateFolderRole(newRole: FolderRole?) {
         folderRole = newRole
     }
@@ -499,7 +490,6 @@ class ThreadListAdapter @Inject constructor(
     }
 
     private enum class NotificationType {
-        AVATAR,
         SELECTED_STATE,
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -157,7 +157,6 @@ class ThreadListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         observeCurrentFolder()
         observeCurrentFolderLive()
         observeUpdatedAtTriggers()
-        observeContacts()
         observerDraftsActionsCompletedWorks()
         observeFlushFolderTrigger()
         observeUpdateInstall()
@@ -241,7 +240,6 @@ class ThreadListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
 
         threadListAdapter(
             folderRole = mainViewModel.currentFolder.value?.role,
-            contacts = mainViewModel.mergedContactsLive.value ?: emptyMap(),
             onSwipeFinished = { threadListViewModel.isRecoveringFinished.value = true },
             multiSelection = object : MultiSelectionListener<Thread> {
                 override var isEnabled by mainViewModel::isMultiSelectOn
@@ -560,10 +558,6 @@ class ThreadListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
 
     private fun observeUpdatedAtTriggers() {
         threadListViewModel.updatedAtTrigger.observe(viewLifecycleOwner) { updateUpdatedAt() }
-    }
-
-    private fun observeContacts() {
-        mainViewModel.mergedContactsLive.observeNotNull(viewLifecycleOwner, threadListAdapter::updateContacts)
     }
 
     private fun observeFlushFolderTrigger() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
@@ -129,10 +129,7 @@ class SearchFragment : Fragment() {
     }
 
     private fun setupThreadListAdapter() {
-        threadListAdapter(
-            folderRole = null,
-            contacts = mainViewModel.mergedContactsLive.value ?: emptyMap(),
-        )
+        threadListAdapter(folderRole = null)
     }
 
     private fun setupListeners() = with(binding) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/DetailedContactBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/DetailedContactBottomSheetDialog.kt
@@ -30,7 +30,6 @@ import com.infomaniak.mail.ui.MainViewModel
 import com.infomaniak.mail.ui.main.thread.actions.ActionsBottomSheetDialog
 import com.infomaniak.mail.ui.newMessage.NewMessageActivityArgs
 import com.infomaniak.mail.utils.copyRecipientEmailToClipboard
-import com.infomaniak.mail.utils.observeNotNull
 import com.infomaniak.mail.utils.safeNavigateToNewMessageActivity
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -49,9 +48,8 @@ class DetailedContactBottomSheetDialog : ActionsBottomSheetDialog() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) = with(binding) {
         super.onViewCreated(view, savedInstanceState)
-        contactDetails.setRecipient(navigationArgs.recipient, mainViewModel.mergedContactsLive.value ?: emptyMap())
+        contactDetails.setRecipient(navigationArgs.recipient)
         setupListeners()
-        observeContacts()
     }
 
     private fun setupListeners() = with(binding) {
@@ -70,12 +68,6 @@ class DetailedContactBottomSheetDialog : ActionsBottomSheetDialog() {
         copyAddress.setClosingOnClickListener {
             trackContactActionsEvent("copyEmailAddress")
             copyRecipientEmailToClipboard(navigationArgs.recipient, mainViewModel.snackBarManager)
-        }
-    }
-
-    private fun observeContacts() {
-        mainViewModel.mergedContactsLive.observeNotNull(viewLifecycleOwner) {
-            binding.contactDetails.updateAvatar(navigationArgs.recipient, it)
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -82,7 +82,6 @@ class ThreadAdapter(
 
     private val manuallyAllowedMessageUids = mutableSetOf<String>()
     var isThemeTheSameMap = mutableMapOf<String, Boolean>()
-    var contacts: MergedContactDictionary = emptyMap()
 
     private var threadAdapterCallbacks: ThreadAdapterCallbacks? = null
 
@@ -143,7 +142,6 @@ class ThreadAdapter(
             val message = messages[position]
 
             when (payload) {
-                NotifyType.AVATAR -> if (!message.isDraft) userAvatar.loadAvatar(message.sender, contacts)
                 NotifyType.TOGGLE_LIGHT_MODE -> {
                     isThemeTheSameMap[message.uid] = !isThemeTheSameMap[message.uid]!!
                     holder.toggleContentAndQuoteTheme(message.uid)
@@ -266,7 +264,7 @@ class ThreadAdapter(
             shortMessageDate.text = ""
         } else {
             val firstSender = message.sender
-            userAvatar.loadAvatar(firstSender, contacts)
+            userAvatar.loadAvatar(firstSender)
             expeditorName.apply {
                 text = firstSender?.let { context.getPrettyNameAndEmail(it).first }
                     ?: run { context.getString(R.string.unknownRecipientTitle) }
@@ -529,11 +527,6 @@ class ThreadAdapter(
 
     fun isMessageUidManuallyAllowed(messageUid: String) = manuallyAllowedMessageUids.contains(messageUid)
 
-    fun updateContacts(newContacts: MergedContactDictionary) {
-        contacts = newContacts
-        notifyItemRangeChanged(0, itemCount, NotifyType.AVATAR)
-    }
-
     fun toggleLightMode(message: Message) {
         val index = messages.indexOf(message)
         notifyItemChanged(index, NotifyType.TOGGLE_LIGHT_MODE)
@@ -555,7 +548,6 @@ class ThreadAdapter(
     }
 
     private enum class NotifyType {
-        AVATAR,
         TOGGLE_LIGHT_MODE,
         RE_RENDER,
         FAILED_MESSAGE,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -144,7 +144,6 @@ class ThreadFragment : Fragment() {
 
             observeMessagesLive()
             observeFailedMessages()
-            observeContacts()
             observeQuickActionBarClicks()
             observeOpenAttachment()
             observeSubjectUpdateTriggers()
@@ -345,7 +344,6 @@ class ThreadFragment : Fragment() {
             isThemeTheSameMap = result.isThemeTheSameMap
 
             stateRestorationPolicy = StateRestorationPolicy.PREVENT_WHEN_EMPTY
-            contacts = mainViewModel.mergedContactsLive.value ?: emptyMap()
         }
     }
 
@@ -440,10 +438,6 @@ class ThreadFragment : Fragment() {
                 messagesListNestedScrollView.scrollY = targetChild.top
             }
         }
-    }
-
-    private fun observeContacts() {
-        mainViewModel.mergedContactsLive.observeNotNull(viewLifecycleOwner, threadAdapter::updateContacts)
     }
 
     private fun downloadAllAttachments(message: Message) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -95,10 +95,8 @@ class ThreadViewModel @Inject constructor(
         AccountUtils.currentMailboxId,
     ).map { it.obj }.asLiveData(ioCoroutineContext)
 
-    fun assembleSubjectData(mergedContactsLive: LiveData<MergedContactDictionary?>): LiveData<SubjectDataResult> {
-
+    fun assembleSubjectData(mergedContactsLive: LiveData<MergedContactDictionary>): LiveData<SubjectDataResult> {
         return MediatorLiveData<SubjectDataResult>().apply {
-
             addSource(threadLive) { thread ->
                 value = SubjectDataResult(thread, value?.mergedContacts, value?.mailbox)
             }

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageRecipientFieldsManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageRecipientFieldsManager.kt
@@ -21,12 +21,10 @@ import android.view.View
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.infomaniak.lib.core.utils.showKeyboard
-import com.infomaniak.mail.data.models.correspondent.MergedContact
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.data.models.draft.Draft
 import com.infomaniak.mail.databinding.FragmentNewMessageBinding
 import com.infomaniak.mail.ui.newMessage.NewMessageRecipientFieldsManager.FieldType.*
-import com.infomaniak.mail.utils.MergedContactDictionary
 import com.infomaniak.mail.utils.copyRecipientEmailToClipboard
 import dagger.hilt.android.scopes.FragmentScoped
 import javax.inject.Inject
@@ -142,19 +140,12 @@ class NewMessageRecipientFieldsManager @Inject constructor() : NewMessageManager
         binding.toField.showKeyboardInTextInput()
     }
 
-    fun observeContacts() {
-        newMessageViewModel.mergedContacts.observe(viewLifecycleOwner) { (sortedContactList, contactMap) ->
-            updateRecipientFieldsContacts(sortedContactList, contactMap)
+    fun observeContacts() = with(binding) {
+        newMessageViewModel.mergedContacts.observe(viewLifecycleOwner) { (sortedContactList, _) ->
+            toField.updateContacts(sortedContactList)
+            ccField.updateContacts(sortedContactList)
+            bccField.updateContacts(sortedContactList)
         }
-    }
-
-    private fun updateRecipientFieldsContacts(
-        sortedContactList: List<MergedContact>,
-        contactMap: MergedContactDictionary,
-    ) = with(binding) {
-        toField.updateContacts(sortedContactList, contactMap)
-        ccField.updateContacts(sortedContactList, contactMap)
-        bccField.updateContacts(sortedContactList, contactMap)
     }
 
     fun initRecipients(draft: Draft) = with(binding) {

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/RecipientFieldView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/RecipientFieldView.kt
@@ -61,7 +61,6 @@ class RecipientFieldView @JvmOverloads constructor(
     private var contactAdapter: ContactAdapter
     private var contactChipAdapter: ContactChipAdapter
 
-    private var contactMap: MergedContactDictionary = emptyMap()
     private lateinit var popupRecipient: Recipient
     private var popupDeletesTheCollapsedChip = false
 
@@ -294,9 +293,8 @@ class RecipientFieldView @JvmOverloads constructor(
         textInputLayout.isVisible = isTextInputAccessible
     }
 
-    fun updateContacts(allContacts: List<MergedContact>, newContactMap: MergedContactDictionary) {
+    fun updateContacts(allContacts: List<MergedContact>) {
         contactAdapter.updateContacts(allContacts)
-        contactMap = newContactMap
     }
 
     private fun openAutoCompletion() {
@@ -329,7 +327,7 @@ class RecipientFieldView @JvmOverloads constructor(
     }
 
     private fun showContactContextMenu(recipient: Recipient, anchor: BackspaceAwareChip, isForSingleChip: Boolean = false) {
-        contextMenuBinding.contactDetails.setRecipient(recipient, contactMap)
+        contextMenuBinding.contactDetails.setRecipient(recipient)
 
         popupRecipient = recipient
         popupDeletesTheCollapsedChip = isForSingleChip

--- a/app/src/main/java/com/infomaniak/mail/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Extensions.kt
@@ -113,6 +113,7 @@ import java.util.Date
 import java.util.Scanner
 
 //region Type alias
+// Explanation of this Map: Map<Email, Map<Name, MergedContact>>
 typealias MergedContactDictionary = Map<String, Map<String, MergedContact>>
 //endregion
 

--- a/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2023 Infomaniak Network SA
+ * Copyright (C) 2022-2024 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -54,9 +54,7 @@ class AvatarView @JvmOverloads constructor(
     private var savedCorrespondent: Correspondent? = null
 
     private val mergedContactObserver = Observer<MergedContactDictionary> { contacts ->
-        savedCorrespondent?.let { correspondent ->
-            loadAvatar(correspondent, contacts)
-        }
+        savedCorrespondent?.let { correspondent -> loadAvatarUsingDictionary(correspondent, contacts) }
     }
 
     @Inject
@@ -110,10 +108,7 @@ class AvatarView @JvmOverloads constructor(
         } else {
             // Avoid lateinit property has not been initialized in preview
             val contactsFromViewModel = if (isInEditMode) emptyMap() else avatarMergedContactData.mergedContactLiveData.value
-
-            val contacts = contactsFromViewModel ?: emptyMap()
-            loadAvatar(correspondent, contacts)
-
+            loadAvatarUsingDictionary(correspondent, contacts = contactsFromViewModel ?: emptyMap())
             savedCorrespondent = correspondent
         }
     }
@@ -133,9 +128,9 @@ class AvatarView @JvmOverloads constructor(
         return recipientsForEmail?.getOrElse(correspondent.name) { recipientsForEmail.entries.elementAt(0).value }
     }
 
-    private fun loadAvatar(correspondent: Correspondent, contacts: MergedContactDictionary) {
+    private fun loadAvatarUsingDictionary(correspondent: Correspondent, contacts: MergedContactDictionary) {
         val mergedContact = searchInMergedContact(correspondent, contacts)
-        binding.avatarImage.baseLoadAvatar(mergedContact ?: correspondent)
+        binding.avatarImage.baseLoadAvatar(correspondent = mergedContact ?: correspondent)
     }
 
     private fun ImageView.baseLoadAvatar(correspondent: Correspondent): Disposable {

--- a/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
@@ -113,10 +113,6 @@ class AvatarView @JvmOverloads constructor(
         }
     }
 
-    fun loadAvatar(correspondent: Correspondent?, contacts: MergedContactDictionary) {
-        // Temp
-    }
-
     fun loadAvatar(mergedContact: MergedContact) {
         binding.avatarImage.baseLoadAvatar(mergedContact)
     }

--- a/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
@@ -80,11 +80,13 @@ class AvatarView @JvmOverloads constructor(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        if (isInEditMode) return // Avoid lateinit property has not been initialized in preview
         avatarMergedContactData.mergedContactLiveData.observeForever(mergedContactObserver)
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
+        if (isInEditMode) return // Avoid lateinit property has not been initialized in preview
         avatarMergedContactData.mergedContactLiveData.removeObserver(mergedContactObserver)
     }
 
@@ -106,7 +108,10 @@ class AvatarView @JvmOverloads constructor(
         if (correspondent == null) {
             loadUnknownUserAvatar()
         } else {
-            val contacts = avatarMergedContactData.mergedContactLiveData.value ?: emptyMap()
+            // Avoid lateinit property has not been initialized in preview
+            val contactsFromViewModel = if (isInEditMode) emptyMap() else avatarMergedContactData.mergedContactLiveData.value
+
+            val contacts = contactsFromViewModel ?: emptyMap()
             loadAvatar(correspondent, contacts)
 
             savedCorrespondent = correspondent

--- a/app/src/main/java/com/infomaniak/mail/views/itemViews/AvatarMergedContactData.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/itemViews/AvatarMergedContactData.kt
@@ -1,0 +1,28 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2023 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.views.itemViews
+
+import androidx.lifecycle.MutableLiveData
+import com.infomaniak.mail.utils.MergedContactDictionary
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AvatarMergedContactData @Inject constructor() {
+    val mergedContactLiveData = MutableLiveData<MergedContactDictionary>()
+}

--- a/app/src/main/java/com/infomaniak/mail/views/itemViews/AvatarMergedContactData.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/itemViews/AvatarMergedContactData.kt
@@ -21,8 +21,10 @@ import androidx.lifecycle.asLiveData
 import com.infomaniak.mail.data.cache.userInfo.MergedContactController
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.utils.ContactUtils
+import com.infomaniak.mail.utils.coroutineContext
 import io.realm.kotlin.ext.copyFromRealm
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.mapLatest
 import javax.inject.Inject
@@ -32,10 +34,13 @@ import javax.inject.Singleton
 @Singleton
 class AvatarMergedContactData @Inject constructor(
     mergedContactController: MergedContactController,
+    globalCoroutineScope: CoroutineScope,
     @IoDispatcher ioDispatcher: CoroutineDispatcher,
 ) {
+    private val ioCoroutineContext = globalCoroutineScope.coroutineContext(ioDispatcher)
+
     val mergedContactLiveData = mergedContactController
         .getMergedContactsAsync()
         .mapLatest { ContactUtils.arrangeMergedContacts(it.list.copyFromRealm()) }
-        .asLiveData(ioDispatcher) // TODO : was ioCoroutineContext
+        .asLiveData(ioCoroutineContext)
 }

--- a/app/src/main/java/com/infomaniak/mail/views/itemViews/AvatarMergedContactData.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/itemViews/AvatarMergedContactData.kt
@@ -17,12 +17,25 @@
  */
 package com.infomaniak.mail.views.itemViews
 
-import androidx.lifecycle.MutableLiveData
-import com.infomaniak.mail.utils.MergedContactDictionary
+import androidx.lifecycle.asLiveData
+import com.infomaniak.mail.data.cache.userInfo.MergedContactController
+import com.infomaniak.mail.di.IoDispatcher
+import com.infomaniak.mail.utils.ContactUtils
+import io.realm.kotlin.ext.copyFromRealm
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.mapLatest
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
-class AvatarMergedContactData @Inject constructor() {
-    val mergedContactLiveData = MutableLiveData<MergedContactDictionary>()
+class AvatarMergedContactData @Inject constructor(
+    mergedContactController: MergedContactController,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher,
+) {
+    val mergedContactLiveData = mergedContactController
+        .getMergedContactsAsync()
+        .mapLatest { ContactUtils.arrangeMergedContacts(it.list.copyFromRealm()) }
+        .asLiveData(ioDispatcher) // TODO : was ioCoroutineContext
 }


### PR DESCRIPTION
AvatarView automatically updates its avatars rather than relying on parent fragments to relay the information up to each AvatarView when a new mergedContactDictionary is obtained