### PR TITLE
Create a common bottom sheet scaffolding

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/views/BottomSheetScaffoldingView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/BottomSheetScaffoldingView.kt
@@ -55,17 +55,22 @@ class BottomSheetScaffoldingView @JvmOverloads constructor(
     private var centerHorizontally: Boolean = false
     private var childContainer: ViewGroup
 
+    var title: CharSequence?
+        get() = binding.titleTextView.text
+        set(value) {
+            binding.titleTextView.apply {
+                text = value
+                isVisible = value != null
+            }
+        }
+
     init {
         binding = ViewBottomSheetScaffoldingBinding.inflate(LayoutInflater.from(context), this, true)
         isBindingInflated = true
 
         with(binding) {
             attrs?.getAttributes(context, R.styleable.BottomSheetScaffoldingView) {
-                title.apply {
-                    val titleValue = getString(R.styleable.BottomSheetScaffoldingView_title)
-                    text = titleValue
-                    isVisible = titleValue != null
-                }
+                title = getString(R.styleable.BottomSheetScaffoldingView_title)
 
                 useDefaultLayout = getBoolean(R.styleable.BottomSheetScaffoldingView_useDefaultLayout, useDefaultLayout)
                 centerHorizontally = getBoolean(R.styleable.BottomSheetScaffoldingView_centerHorizontally, centerHorizontally)

--- a/app/src/main/java/com/infomaniak/mail/views/BottomSheetScaffoldingView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/BottomSheetScaffoldingView.kt
@@ -37,7 +37,7 @@ import com.infomaniak.lib.core.R as RCore
 class BottomSheetScaffoldingView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
+    defStyleAttr: Int = 0,
 ) : FrameLayout(context, attrs, defStyleAttr) {
 
     private val binding: ViewBottomSheetScaffoldingBinding
@@ -71,7 +71,6 @@ class BottomSheetScaffoldingView @JvmOverloads constructor(
         with(binding) {
             attrs?.getAttributes(context, R.styleable.BottomSheetScaffoldingView) {
                 title = getString(R.styleable.BottomSheetScaffoldingView_title)
-
                 useDefaultLayout = getBoolean(R.styleable.BottomSheetScaffoldingView_useDefaultLayout, useDefaultLayout)
                 centerHorizontally = getBoolean(R.styleable.BottomSheetScaffoldingView_centerHorizontally, centerHorizontally)
             }
@@ -83,17 +82,11 @@ class BottomSheetScaffoldingView @JvmOverloads constructor(
     private fun ViewBottomSheetScaffoldingBinding.initChildContainer(context: Context): ViewGroup {
         return if (useDefaultLayout) {
             val nestedScrollView = NestedScrollView(context).apply {
-                layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                )
+                layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
             }
 
             val linearLayout = LinearLayout(context).apply {
-                layoutParams = LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT,
-                )
+                layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
                 orientation = LinearLayout.VERTICAL
                 if (centerHorizontally) gravity = Gravity.CENTER_HORIZONTAL
                 setMarginsRelative(bottom = context.resources.getDimensionPixelSize(RCore.dimen.marginStandardMedium))
@@ -105,10 +98,7 @@ class BottomSheetScaffoldingView @JvmOverloads constructor(
             linearLayout
         } else {
             val frameLayout = FrameLayout(context).apply {
-                layoutParams = LayoutParams(
-                    LayoutParams.MATCH_PARENT,
-                    LayoutParams.WRAP_CONTENT,
-                )
+                layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
             }
 
             root.addView(frameLayout)

--- a/app/src/main/java/com/infomaniak/mail/views/BottomSheetScaffoldingView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/BottomSheetScaffoldingView.kt
@@ -1,0 +1,122 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import androidx.core.view.isVisible
+import androidx.core.widget.NestedScrollView
+import com.infomaniak.lib.core.utils.getAttributes
+import com.infomaniak.lib.core.utils.setMarginsRelative
+import com.infomaniak.mail.R
+import com.infomaniak.mail.databinding.ViewBottomSheetScaffoldingBinding
+import com.infomaniak.mail.ui.main.menu.SimpleSettingView
+import com.infomaniak.lib.core.R as RCore
+
+class BottomSheetScaffoldingView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val binding: ViewBottomSheetScaffoldingBinding
+
+    /**
+     * We can receive 2 types of children:
+     * - Children that come from the binding
+     * - Children of [SimpleSettingView] that are defined in the xml
+     *
+     * We need to only add the second type of children to the `binding.cardView` to be able to display them
+     */
+    private var isBindingInflated: Boolean = false
+
+    private var useDefaultLayout: Boolean = true
+    private var centerHorizontally: Boolean = false
+    private var childContainer: ViewGroup
+
+    init {
+        binding = ViewBottomSheetScaffoldingBinding.inflate(LayoutInflater.from(context), this, true)
+        isBindingInflated = true
+
+        with(binding) {
+            attrs?.getAttributes(context, R.styleable.BottomSheetScaffoldingView) {
+                title.apply {
+                    val titleValue = getString(R.styleable.BottomSheetScaffoldingView_title)
+                    text = titleValue
+                    isVisible = titleValue != null
+                }
+
+                useDefaultLayout = getBoolean(R.styleable.BottomSheetScaffoldingView_useDefaultLayout, useDefaultLayout)
+                centerHorizontally = getBoolean(R.styleable.BottomSheetScaffoldingView_centerHorizontally, centerHorizontally)
+            }
+
+            childContainer = initChildContainer(context)
+        }
+    }
+
+    private fun ViewBottomSheetScaffoldingBinding.initChildContainer(context: Context): ViewGroup {
+        return if (useDefaultLayout) {
+            val nestedScrollView = NestedScrollView(context).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                )
+            }
+
+            val linearLayout = LinearLayout(context).apply {
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                )
+                orientation = LinearLayout.VERTICAL
+                if (centerHorizontally) gravity = Gravity.CENTER_HORIZONTAL
+                setMarginsRelative(bottom = context.resources.getDimensionPixelSize(RCore.dimen.marginStandardMedium))
+            }
+
+            nestedScrollView.addView(linearLayout)
+            root.addView(nestedScrollView)
+
+            linearLayout
+        } else {
+            val frameLayout = FrameLayout(context).apply {
+                layoutParams = LayoutParams(
+                    LayoutParams.MATCH_PARENT,
+                    LayoutParams.WRAP_CONTENT,
+                )
+            }
+
+            root.addView(frameLayout)
+
+            frameLayout
+        }
+    }
+
+    override fun addView(child: View, index: Int, params: ViewGroup.LayoutParams?) {
+        if (isBindingInflated) {
+            childContainer.addView(child, index, params)
+        } else {
+            super.addView(child, index, params)
+        }
+    }
+}

--- a/app/src/main/res/layout/bottom_sheet_actions_menu.xml
+++ b/app/src/main/res/layout/bottom_sheet_actions_menu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2022-2023 Infomaniak Network SA
+  ~ Copyright (C) 2022-2024 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -15,119 +15,111 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.infomaniak.mail.views.BottomSheetScaffoldingView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    tools:context=".ui.main.thread.actions.MailActionsBottomSheetDialog">
+
+    <com.infomaniak.mail.ui.main.thread.actions.MainActionsView
+        android:id="@+id/mainActions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/marginStandardSmall"
+        app:menu="@menu/main_actions_thread_message_menu" />
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
+        android:divider="@drawable/divider"
+        android:dividerPadding="@dimen/marginStandardMedium"
         android:orientation="vertical"
-        android:paddingBottom="@dimen/marginStandardMedium">
+        android:showDividers="middle">
 
-        <include layout="@layout/view_bottom_sheet_separator" />
-
-        <com.infomaniak.mail.ui.main.thread.actions.MainActionsView
-            android:id="@+id/mainActions"
+        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+            android:id="@+id/lightTheme"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/marginStandardSmall"
-            app:menu="@menu/main_actions_thread_message_menu" />
+            android:visibility="gone"
+            app:icon="@drawable/ic_view_in_light"
+            app:text="@string/actionViewInLight"
+            app:visibleDivider="false"
+            tools:visibility="visible" />
 
-        <LinearLayout
+        <!-- TODO: Display this when Postpone/Snooze action will be done (v2) -->
+        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+            android:id="@+id/postpone"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:divider="@drawable/divider"
-            android:dividerPadding="@dimen/marginStandardMedium"
-            android:orientation="vertical"
-            android:showDividers="middle">
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:icon="@drawable/ic_alarm_clock"
+            app:text="@string/actionPostpone"
+            app:visibleDivider="false"
+            tools:visibility="visible" />
 
-            <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-                android:id="@+id/lightTheme"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:icon="@drawable/ic_view_in_light"
-                app:text="@string/actionViewInLight"
-                app:visibleDivider="false"
-                tools:visibility="visible" />
+        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+            android:id="@+id/move"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_email_action_move"
+            app:text="@string/actionMove"
+            app:visibleDivider="false" />
 
-            <!-- TODO: Display this when Postpone/Snooze action will be done (v2) -->
-            <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-                android:id="@+id/postpone"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:icon="@drawable/ic_alarm_clock"
-                app:text="@string/actionPostpone"
-                app:visibleDivider="false"
-                tools:visibility="visible" />
+        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+            android:id="@+id/reportJunk"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:icon="@drawable/ic_report_junk"
+            app:text="@string/actionReportJunk"
+            app:visibleDivider="false"
+            tools:visibility="visible" />
 
-            <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-                android:id="@+id/move"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:icon="@drawable/ic_email_action_move"
-                app:text="@string/actionMove"
-                app:visibleDivider="false" />
+        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+            android:id="@+id/markAsReadUnread"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_envelope"
+            app:text="@string/actionMarkAsUnread"
+            app:visibleDivider="false" />
 
-            <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-                android:id="@+id/reportJunk"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:icon="@drawable/ic_report_junk"
-                app:text="@string/actionReportJunk"
-                app:visibleDivider="false"
-                tools:visibility="visible" />
+        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+            android:id="@+id/archive"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_archive_folder"
+            app:text="@string/actionArchive"
+            app:visibleDivider="false" />
 
-            <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-                android:id="@+id/markAsReadUnread"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:icon="@drawable/ic_envelope"
-                app:text="@string/actionMarkAsUnread"
-                app:visibleDivider="false" />
+        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+            android:id="@+id/favorite"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_star"
+            app:text="@string/actionStar"
+            app:visibleDivider="false" />
 
-            <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-                android:id="@+id/archive"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:icon="@drawable/ic_archive_folder"
-                app:text="@string/actionArchive"
-                app:visibleDivider="false" />
+        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+            android:id="@+id/print"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:icon="@drawable/ic_email_action_print"
+            app:text="@string/actionPrint"
+            app:visibleDivider="false"
+            tools:visibility="visible" />
 
-            <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-                android:id="@+id/favorite"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:icon="@drawable/ic_star"
-                app:text="@string/actionStar"
-                app:visibleDivider="false" />
+        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+            android:id="@+id/reportDisplayProblem"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:icon="@drawable/ic_feedbacks"
+            app:staffOnly="true"
+            app:text="@string/actionReportDisplayProblem"
+            app:visibleDivider="false"
+            tools:visibility="visible" />
 
-            <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-                android:id="@+id/print"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:icon="@drawable/ic_email_action_print"
-                app:text="@string/actionPrint"
-                app:visibleDivider="false"
-                tools:visibility="visible" />
-
-            <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-                android:id="@+id/reportDisplayProblem"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:icon="@drawable/ic_feedbacks"
-                app:staffOnly="true"
-                app:text="@string/actionReportDisplayProblem"
-                app:visibleDivider="false"
-                tools:visibility="visible" />
-        </LinearLayout>
     </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+</com.infomaniak.mail.views.BottomSheetScaffoldingView>

--- a/app/src/main/res/layout/bottom_sheet_attachment_actions.xml
+++ b/app/src/main/res/layout/bottom_sheet_attachment_actions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2023 Infomaniak Network SA
+  ~ Copyright (C) 2023-2024 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -15,51 +15,43 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.infomaniak.mail.views.BottomSheetScaffoldingView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    tools:context=".ui.main.thread.actions.AttachmentActionsBottomSheetDialog">
 
-    <LinearLayout
+    <com.infomaniak.mail.views.AttachmentDetailsView
+        android:id="@+id/attachmentDetails"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/marginStandardMedium">
+        android:layout_marginEnd="@dimen/marginStandardMedium"
+        android:layout_marginBottom="@dimen/marginStandard"
+        app:displayStyle="bottomSheet" />
 
-        <include layout="@layout/view_bottom_sheet_separator" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/openWithItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_open_with"
+        app:text="@string/openWith"
+        app:visibleDivider="false" />
 
-        <com.infomaniak.mail.views.AttachmentDetailsView
-            android:id="@+id/attachmentDetails"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/marginStandardMedium"
-            android:layout_marginBottom="@dimen/marginStandard"
-            app:displayStyle="bottomSheet" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/kDriveItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_kdrive"
+        app:keepIconTint="true"
+        app:text="@string/saveToDriveItem" />
 
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/openWithItem"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_open_with"
-            app:text="@string/openWith"
-            app:visibleDivider="false" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/deviceItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_import"
+        app:iconTint="?attr/colorPrimary"
+        app:text="@string/saveToDriveDeviceItem" />
 
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/kDriveItem"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_kdrive"
-            app:keepIconTint="true"
-            app:text="@string/saveToDriveItem" />
-
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/deviceItem"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_import"
-            app:iconTint="?attr/colorPrimary"
-            app:text="@string/saveToDriveDeviceItem" />
-
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+</com.infomaniak.mail.views.BottomSheetScaffoldingView>

--- a/app/src/main/res/layout/bottom_sheet_detailed_contact.xml
+++ b/app/src/main/res/layout/bottom_sheet_detailed_contact.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2022-2023 Infomaniak Network SA
+  ~ Copyright (C) 2022-2024 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -15,53 +15,43 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.infomaniak.mail.views.BottomSheetScaffoldingView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     tools:context=".ui.main.thread.DetailedContactBottomSheetDialog">
 
-    <LinearLayout
+    <com.infomaniak.mail.ui.main.AvatarNameEmailView
+        android:id="@+id/contactDetails"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/marginStandardMedium">
+        app:processNameAndEmail="false"
+        tools:avatar="@tools:sample/avatars[10]"
+        tools:email="steph.guy@ik.me"
+        tools:name="@tools:sample/full_names" />
 
-        <include layout="@layout/view_bottom_sheet_separator" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/writeMail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/marginStandardMedium"
+        app:icon="@drawable/ic_contact_action_write"
+        app:text="@string/contactActionWriteEmail"
+        app:visibleDivider="false" />
 
-        <com.infomaniak.mail.ui.main.AvatarNameEmailView
-            android:id="@+id/contactDetails"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:processNameAndEmail="false"
-            tools:avatar="@tools:sample/avatars[10]"
-            tools:email="steph.guy@ik.me"
-            tools:name="@tools:sample/full_names" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/addToContacts"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_contact_action_add_user"
+        app:text="@string/contactActionAddToContacts" />
 
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/writeMail"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/marginStandardMedium"
-            app:icon="@drawable/ic_contact_action_write"
-            app:text="@string/contactActionWriteEmail"
-            app:visibleDivider="false" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/copyAddress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_contact_action_copy"
+        app:text="@string/contactActionCopyEmailAddress" />
 
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/addToContacts"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_contact_action_add_user"
-            app:text="@string/contactActionAddToContacts" />
-
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/copyAddress"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_contact_action_copy"
-            app:text="@string/contactActionCopyEmailAddress" />
-
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+</com.infomaniak.mail.views.BottomSheetScaffoldingView>

--- a/app/src/main/res/layout/bottom_sheet_information.xml
+++ b/app/src/main/res/layout/bottom_sheet_information.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2023 Infomaniak Network SA
+  ~ Copyright (C) 2023-2024 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -15,62 +15,55 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.infomaniak.mail.views.BottomSheetScaffoldingView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    app:centerHorizontally="true"
     tools:context=".ui.bottomSheetDialogs.UpdateAvailableBottomSheetDialog">
 
-    <LinearLayout
+    <ImageView
+        android:id="@+id/info_illustration"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/marginStandardMedium"
+        android:importantForAccessibility="no"
+        android:maxHeight="270dp"
+        tools:src="@drawable/ic_update_logo" />
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/H2"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/marginStandardMedium"
         android:gravity="center"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/marginStandardMedium">
+        tools:text="@string/updateAvailableTitle" />
 
-        <include layout="@layout/view_bottom_sheet_separator" />
+    <TextView
+        android:id="@+id/description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/marginStandardMedium"
+        android:gravity="center"
+        tools:text="@string/updateAvailableDescription" />
 
-        <ImageView
-            android:id="@+id/info_illustration"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/marginStandardMedium"
-            android:importantForAccessibility="no"
-            android:maxHeight="270dp"
-            tools:src="@drawable/ic_update_logo" />
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/actionButton"
+        style="@style/TextButtonPrimary"
+        android:layout_width="match_parent"
+        android:layout_marginHorizontal="@dimen/marginStandardMedium"
+        android:layout_marginTop="@dimen/marginStandardMedium"
+        android:layout_marginBottom="@dimen/marginStandardSmall"
+        tools:text="@string/buttonUpdate" />
 
-        <TextView
-            android:id="@+id/title"
-            style="@style/H2"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/marginStandardMedium"
-            android:gravity="center"
-            tools:text="@string/updateAvailableTitle" />
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/secondaryActionButton"
+        style="@style/TextButtonSecondary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/marginStandardMedium"
+        android:text="@string/buttonLater" />
 
-        <TextView
-            android:id="@+id/description"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/marginStandardMedium"
-            android:gravity="center"
-            tools:text="@string/updateAvailableDescription" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/actionButton"
-            style="@style/TextButtonPrimary"
-            android:layout_width="match_parent"
-            android:layout_marginHorizontal="@dimen/marginStandardMedium"
-            android:layout_marginTop="@dimen/marginStandardMedium"
-            android:layout_marginBottom="@dimen/marginStandardSmall"
-            tools:text="@string/buttonUpdate" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/secondaryActionButton"
-            style="@style/TextButtonSecondary"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/marginStandardMedium"
-            android:text="@string/buttonLater" />
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+</com.infomaniak.mail.views.BottomSheetScaffoldingView>

--- a/app/src/main/res/layout/bottom_sheet_junk.xml
+++ b/app/src/main/res/layout/bottom_sheet_junk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2023 Infomaniak Network SA
+  ~ Copyright (C) 2023-2024 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -15,43 +15,33 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.infomaniak.mail.views.BottomSheetScaffoldingView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     tools:context=".ui.main.thread.actions.JunkBottomSheetDialog">
 
-    <LinearLayout
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/spam"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/marginStandardMedium">
+        app:icon="@drawable/ic_spam"
+        app:text="@string/actionSpam"
+        app:visibleDivider="false" />
 
-        <include layout="@layout/view_bottom_sheet_separator" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/phishing"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_email_action_phishing"
+        app:text="@string/actionPhishing" />
 
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/spam"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_spam"
-            app:text="@string/actionSpam"
-            app:visibleDivider="false" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/blockSender"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_email_action_block_user"
+        app:text="@string/actionBlockSender" />
 
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/phishing"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_email_action_phishing"
-            app:text="@string/actionPhishing" />
-
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/blockSender"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_email_action_block_user"
-            app:text="@string/actionBlockSender" />
-
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+</com.infomaniak.mail.views.BottomSheetScaffoldingView>

--- a/app/src/main/res/layout/bottom_sheet_multi_select.xml
+++ b/app/src/main/res/layout/bottom_sheet_multi_select.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2022-2023 Infomaniak Network SA
+  ~ Copyright (C) 2022-2024 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -15,51 +15,41 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.infomaniak.mail.views.BottomSheetScaffoldingView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".ui.main.thread.actions.ReplyBottomSheetDialog">
+    tools:context=".ui.main.thread.actions.MultiSelectBottomSheetDialog">
 
-    <LinearLayout
+    <com.infomaniak.mail.ui.main.thread.actions.MainActionsView
+        android:id="@+id/mainActions"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/marginStandardMedium">
+        android:layout_marginBottom="@dimen/marginStandardMedium"
+        app:menu="@menu/main_actions_multi_select_menu" />
 
-        <include layout="@layout/view_bottom_sheet_separator" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/postpone"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:icon="@drawable/ic_alarm_clock"
+        app:text="@string/actionPostpone" />
 
-        <com.infomaniak.mail.ui.main.thread.actions.MainActionsView
-            android:id="@+id/mainActions"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/marginStandardMedium"
-            app:menu="@menu/main_actions_multi_select_menu" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/spam"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_spam"
+        app:text="@string/actionSpam"
+        app:visibleDivider="false" />
 
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/postpone"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:icon="@drawable/ic_alarm_clock"
-            app:text="@string/actionPostpone" />
+    <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
+        android:id="@+id/favorite"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_star"
+        app:text="@string/actionStar" />
 
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/spam"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_spam"
-            app:text="@string/actionSpam"
-            app:visibleDivider="false" />
-
-        <com.infomaniak.mail.ui.main.thread.actions.ActionItemView
-            android:id="@+id/favorite"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_star"
-            app:text="@string/actionStar" />
-
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+</com.infomaniak.mail.views.BottomSheetScaffoldingView>

--- a/app/src/main/res/layout/bottom_sheet_restore_emails.xml
+++ b/app/src/main/res/layout/bottom_sheet_restore_emails.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2023 Infomaniak Network SA
+  ~ Copyright (C) 2023-2024 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -15,60 +15,53 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.infomaniak.mail.views.BottomSheetScaffoldingView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    tools:context=".ui.main.menu.RestoreEmailsBottomSheetDialog">
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/title"
+        style="@style/H2"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/marginStandardMedium">
+        android:layout_marginHorizontal="@dimen/marginStandardMedium"
+        android:layout_marginBottom="@dimen/marginStandardMedium"
+        android:text="@string/restoreEmailsTitle" />
 
-        <include layout="@layout/view_bottom_sheet_separator" />
+    <TextView
+        android:id="@+id/description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/marginStandardMedium"
+        android:text="@string/restoreEmailsText" />
 
-        <TextView
-            android:id="@+id/title"
-            style="@style/H2"
+    <com.infomaniak.lib.core.views.EndIconTextInputLayout
+        android:id="@+id/datePicker"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/marginStandardMedium"
+        android:layout_marginBottom="@dimen/marginStandardMedium">
+
+        <AutoCompleteTextView
+            android:id="@+id/datePickerText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/marginStandardMedium"
-            android:layout_marginBottom="@dimen/marginStandardMedium"
-            android:text="@string/restoreEmailsTitle" />
+            android:hint="@string/restoreEmailsBackupDate"
+            android:inputType="none" />
 
-        <TextView
-            android:id="@+id/description"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/marginStandardMedium"
-            android:text="@string/restoreEmailsText" />
+    </com.infomaniak.lib.core.views.EndIconTextInputLayout>
 
-        <com.infomaniak.lib.core.views.EndIconTextInputLayout
-            android:id="@+id/datePicker"
-            style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/marginStandardMedium"
-            android:layout_marginBottom="@dimen/marginStandardMedium">
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/restoreMailsButton"
+        style="@style/TextButtonPrimary"
+        android:layout_width="match_parent"
+        android:layout_marginHorizontal="@dimen/marginStandardMedium"
+        android:layout_marginTop="@dimen/marginStandardMedium"
+        android:layout_marginBottom="@dimen/marginStandardSmall"
+        android:enabled="false"
+        android:text="@string/buttonConfirmRestoreEmails" />
 
-            <AutoCompleteTextView
-                android:id="@+id/datePickerText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/restoreEmailsBackupDate"
-                android:inputType="none" />
-
-        </com.infomaniak.lib.core.views.EndIconTextInputLayout>
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/restoreMailsButton"
-            style="@style/TextButtonPrimary"
-            android:layout_width="match_parent"
-            android:layout_marginHorizontal="@dimen/marginStandardMedium"
-            android:layout_marginTop="@dimen/marginStandardMedium"
-            android:layout_marginBottom="@dimen/marginStandardSmall"
-            android:enabled="false"
-            android:text="@string/buttonConfirmRestoreEmails" />
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+</com.infomaniak.mail.views.BottomSheetScaffoldingView>

--- a/app/src/main/res/layout/view_bottom_sheet_scaffolding.xml
+++ b/app/src/main/res/layout/view_bottom_sheet_scaffolding.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2022-2024 Infomaniak Network SA
+  ~ Copyright (C) 2024 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -15,18 +15,23 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<com.infomaniak.mail.views.BottomSheetScaffoldingView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.main.thread.actions.ReplyBottomSheetDialog">
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/marginStandardMedium">
 
-    <com.infomaniak.mail.ui.main.thread.actions.MainActionsView
-        android:id="@+id/mainActions"
-        android:layout_width="match_parent"
+    <include layout="@layout/view_bottom_sheet_separator" />
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/BodyMedium"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/marginStandardMedium"
-        app:menu="@menu/main_actions_reply_menu" />
+        android:layout_gravity="center_horizontal"
+        tools:text="This bottom sheet's title" />
 
-</com.infomaniak.mail.views.BottomSheetScaffoldingView>
+    <!--Here will be added the children of the bottom sheet scaffolding-->
+
+</LinearLayout>

--- a/app/src/main/res/layout/view_bottom_sheet_scaffolding.xml
+++ b/app/src/main/res/layout/view_bottom_sheet_scaffolding.xml
@@ -25,7 +25,7 @@
     <include layout="@layout/view_bottom_sheet_separator" />
 
     <TextView
-        android:id="@+id/title"
+        android:id="@+id/titleTextView"
         style="@style/BodyMedium"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/view_bottom_sheet_scaffolding.xml
+++ b/app/src/main/res/layout/view_bottom_sheet_scaffolding.xml
@@ -32,6 +32,6 @@
         android:layout_gravity="center_horizontal"
         tools:text="This bottom sheet's title" />
 
-    <!--Here will be added the children of the bottom sheet scaffolding-->
+    <!-- Here will be added the children of the bottom sheet scaffolding -->
 
 </LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -171,4 +171,10 @@
         </attr>
     </declare-styleable>
 
+    <declare-styleable name="BottomSheetScaffoldingView">
+        <attr name="title" />
+        <attr name="useDefaultLayout" format="boolean" />
+        <attr name="centerHorizontally" format="boolean" />
+    </declare-styleable>
+
 </resources>


### PR DESCRIPTION
Makes creating new bottom sheets faster, easier and less error prone.

It helps avoid forgetting some parameters when creating new bottom sheets. Also fixes the way we scroll elements inside the bottom sheet, the handle should always stay on top (this especially makes sens when you think about the handle becoming a button when in accessibility mode). Helps make the bottom sheet title coherent across bottom sheets by being defined in a single place. 

The title feature only starts being used in the next calendar PR but this already lays the ground for that next PR