### PR TITLE
Expose similar `safeNavigate` method in ThreadFragment as other fragments have

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneFragment.kt
@@ -129,35 +129,14 @@ abstract class TwoPaneFragment : Fragment() {
     }
 
     private fun observeThreadNavigation() = with(twoPaneViewModel) {
-
         getBackNavigationResult(AttachmentIntentUtils.DOWNLOAD_ATTACHMENT_RESULT, ::startActivity)
-
-        attachmentActionsArgs.observe(viewLifecycleOwner) {
-            safeNavigate(resId = R.id.attachmentActionsBottomSheetDialog, args = it.toBundle())
-        }
 
         newMessageArgs.observe(viewLifecycleOwner) {
             safeNavigateToNewMessageActivity(args = it.toBundle())
         }
 
-        replyBottomSheetArgs.observe(viewLifecycleOwner) {
-            safeNavigate(resId = R.id.replyBottomSheetDialog, args = it.toBundle())
-        }
-
-        threadActionsArgs.observe(viewLifecycleOwner) {
-            safeNavigate(resId = R.id.threadActionsBottomSheetDialog, args = it.toBundle())
-        }
-
-        messageActionsArgs.observe(viewLifecycleOwner) {
-            safeNavigate(resId = R.id.messageActionsBottomSheetDialog, args = it.toBundle())
-        }
-
-        detailedContactArgs.observe(viewLifecycleOwner) {
-            safeNavigate(resId = R.id.detailedContactBottomSheetDialog, args = it.toBundle())
-        }
-
-        attendeesArgs.observe(viewLifecycleOwner) {
-            safeNavigate(resId = R.id.attendeesBottomSheetDialog, args = it.toBundle())
+        navArgs.observe(viewLifecycleOwner) { (resId, args, className) ->
+            this@TwoPaneFragment.safeNavigate(resId = resId, args = args, currentClassName = className)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneFragment.kt
@@ -135,8 +135,8 @@ abstract class TwoPaneFragment : Fragment() {
             safeNavigateToNewMessageActivity(args = it.toBundle())
         }
 
-        navArgs.observe(viewLifecycleOwner) { (resId, args, className) ->
-            this@TwoPaneFragment.safeNavigate(resId = resId, args = args, currentClassName = className)
+        navArgs.observe(viewLifecycleOwner) { (resId, args) ->
+            safeNavigate(resId, args)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneViewModel.kt
@@ -89,13 +89,8 @@ class TwoPaneViewModel @Inject constructor(
         )
     }
 
-    fun safeNavigate(@IdRes resId: Int, args: Bundle?, className: String? = null) {
-        navArgs.value = NavData(resId = resId, args = args, className = className)
-    }
-
     data class NavData(
         @IdRes val resId: Int,
-        val args: Bundle? = null,
-        val className: String?,
+        val args: Bundle,
     )
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneViewModel.kt
@@ -18,21 +18,15 @@
 package com.infomaniak.mail.ui.main.folder
 
 import android.net.Uri
+import android.os.Bundle
+import androidx.annotation.IdRes
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.infomaniak.lib.core.utils.SingleLiveEvent
 import com.infomaniak.mail.data.cache.mailboxContent.DraftController
-import com.infomaniak.mail.data.models.calendar.Attendee
-import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.data.models.draft.Draft.DraftMode
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
-import com.infomaniak.mail.ui.main.thread.DetailedContactBottomSheetDialogArgs
-import com.infomaniak.mail.ui.main.thread.actions.AttachmentActionsBottomSheetDialogArgs
-import com.infomaniak.mail.ui.main.thread.actions.MessageActionsBottomSheetDialogArgs
-import com.infomaniak.mail.ui.main.thread.actions.ReplyBottomSheetDialogArgs
-import com.infomaniak.mail.ui.main.thread.actions.ThreadActionsBottomSheetDialogArgs
-import com.infomaniak.mail.ui.main.thread.calendar.AttendeesBottomSheetDialogArgs
 import com.infomaniak.mail.ui.newMessage.NewMessageActivityArgs
 import com.infomaniak.mail.utils.Utils.runCatchingRealm
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -49,13 +43,8 @@ class TwoPaneViewModel @Inject constructor(
     val rightPaneFolderName = MutableLiveData<String>()
     var previousFolderId: String? = null
 
-    val attachmentActionsArgs = SingleLiveEvent<AttachmentActionsBottomSheetDialogArgs>()
     val newMessageArgs = SingleLiveEvent<NewMessageActivityArgs>()
-    val replyBottomSheetArgs = SingleLiveEvent<ReplyBottomSheetDialogArgs>()
-    val threadActionsArgs = SingleLiveEvent<ThreadActionsBottomSheetDialogArgs>()
-    val messageActionsArgs = SingleLiveEvent<MessageActionsBottomSheetDialogArgs>()
-    val detailedContactArgs = SingleLiveEvent<DetailedContactBottomSheetDialogArgs>()
-    val attendeesArgs = SingleLiveEvent<AttendeesBottomSheetDialogArgs>()
+    val navArgs = SingleLiveEvent<NavData>()
 
     fun openThread(uid: String) {
         currentThreadUid.value = uid
@@ -67,10 +56,6 @@ class TwoPaneViewModel @Inject constructor(
 
     fun openDraft(thread: Thread) {
         navigateToSelectedDraft(thread.messages.single())
-    }
-
-    fun navigateToAttachmentActions(resource: String) {
-        attachmentActionsArgs.value = AttachmentActionsBottomSheetDialogArgs(resource)
     }
 
     private fun navigateToSelectedDraft(message: Message) = runCatchingRealm {
@@ -104,28 +89,13 @@ class TwoPaneViewModel @Inject constructor(
         )
     }
 
-    fun navigateToReply(messageUid: String, shouldLoadDistantResources: Boolean) {
-        replyBottomSheetArgs.value = ReplyBottomSheetDialogArgs(messageUid, shouldLoadDistantResources)
+    fun safeNavigate(@IdRes resId: Int, args: Bundle?, className: String? = null) {
+        navArgs.value = NavData(resId = resId, args = args, className = className)
     }
 
-    fun navigateToThreadActions(threadUid: String, shouldLoadDistantResources: Boolean, messageUidToReplyTo: String) {
-        threadActionsArgs.value = ThreadActionsBottomSheetDialogArgs(threadUid, shouldLoadDistantResources, messageUidToReplyTo)
-    }
-
-    fun navigateToMessageAction(messageUid: String, isThemeTheSame: Boolean, shouldLoadDistantResources: Boolean) {
-        messageActionsArgs.value = MessageActionsBottomSheetDialogArgs(
-            messageUid = messageUid,
-            threadUid = currentThreadUid.value ?: return,
-            isThemeTheSame = isThemeTheSame,
-            shouldLoadDistantResources = shouldLoadDistantResources,
-        )
-    }
-
-    fun navigateToDetailContact(recipient: Recipient) {
-        detailedContactArgs.value = DetailedContactBottomSheetDialogArgs(recipient)
-    }
-
-    fun navigateToAttendees(attendees: Array<Attendee>) {
-        attendeesArgs.value = AttendeesBottomSheetDialogArgs(attendees)
-    }
+    data class NavData(
+        @IdRes val resId: Int,
+        val args: Bundle? = null,
+        val className: String?,
+    )
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -62,6 +62,7 @@ import com.infomaniak.mail.ui.MainViewModel
 import com.infomaniak.mail.ui.alertDialogs.*
 import com.infomaniak.mail.ui.main.folder.TwoPaneFragment
 import com.infomaniak.mail.ui.main.folder.TwoPaneViewModel
+import com.infomaniak.mail.ui.main.folder.TwoPaneViewModel.NavData
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.ContextMenuType
 import com.infomaniak.mail.ui.main.thread.ThreadViewModel.OpenThreadResult
 import com.infomaniak.mail.ui.main.thread.actions.AttachmentActionsBottomSheetDialogArgs
@@ -495,7 +496,7 @@ class ThreadFragment : Fragment() {
     private fun Message.navigateToActionsBottomSheet() {
         safeNavigate(
             resId = R.id.messageActionsBottomSheetDialog,
-            MessageActionsBottomSheetDialogArgs(
+            args = MessageActionsBottomSheetDialogArgs(
                 messageUid = uid,
                 threadUid = twoPaneViewModel.currentThreadUid.value ?: return,
                 isThemeTheSame = threadAdapter.isThemeTheSameMap[uid] ?: return,
@@ -579,8 +580,8 @@ class ThreadFragment : Fragment() {
 
     fun getAnchor(): View? = _binding?.quickActionBar
 
-    private fun safeNavigate(@IdRes resId: Int, args: Bundle? = null) {
-        twoPaneViewModel.safeNavigate(resId, args)
+    private fun safeNavigate(@IdRes resId: Int, args: Bundle) {
+        twoPaneViewModel.navArgs.value = NavData(resId, args)
     }
 
     enum class HeaderState {


### PR DESCRIPTION
To simplify future addition of navigations from the ThreadFragment, all the variables and methods that had to be created are now simplified in a single `safeNavigate()` method that works just like the one in any other Fragment