### PR TITLE
Add possibility to reply to calendar events

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,9 +110,8 @@ dependencies {
     implementation libs.sentry.android.fragment
 
     // Test
-    androidTestImplementation libs.test.runner
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testRuntimeOnly libs.junit.jupiter.engine
+    testImplementation libs.junit
+    androidTestImplementation libs.ext.junit
 
     // Debug
     if (enableLeakCanary) debugImplementation libs.leakcanary.android

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -38,6 +38,7 @@ import com.infomaniak.mail.data.models.ai.AiResult
 import com.infomaniak.mail.data.models.ai.ContextMessage
 import com.infomaniak.mail.data.models.ai.UserMessage
 import com.infomaniak.mail.data.models.calendar.Attendee
+import com.infomaniak.mail.data.models.calendar.CalendarEvent
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
 import com.infomaniak.mail.data.models.correspondent.Contact
 import com.infomaniak.mail.data.models.correspondent.Recipient
@@ -392,16 +393,16 @@ object ApiRepository : ApiRepositoryCore() {
         useInfomaniakCalendarRoute: Boolean,
         calendarEventId: Int,
         attachmentResource: String,
-    ): ApiResponse<Boolean> {
+    ): ApiResponse<*> {
         val body = mapOf("reply" to attendanceState.apiValue)
 
-        val route = if (useInfomaniakCalendarRoute) {
-            ApiRoutes.infomaniakCalendarEventReply(calendarEventId)
+        val response: ApiResponse<*> = if (useInfomaniakCalendarRoute) {
+            callApi<ApiResponse<Boolean>>(ApiRoutes.infomaniakCalendarEventReply(calendarEventId), POST, body)
         } else {
-            ApiRoutes.icsCalendarEventReply(attachmentResource)
+            callApi<ApiResponse<Map<String, CalendarEvent>>>(ApiRoutes.icsCalendarEventReply(attachmentResource), POST, body)
         }
 
-        return callApi(route, POST, body)
+        return response
     }
 
     /**

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -17,7 +17,6 @@
  */
 package com.infomaniak.mail.data.api
 
-import android.util.Log
 import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.R
 import com.infomaniak.lib.core.api.ApiController
@@ -394,7 +393,6 @@ object ApiRepository : ApiRepositoryCore() {
         calendarEventId: Int,
         attachmentResource: String,
     ): ApiResponse<Boolean> {
-        Log.v("gibran", "replyToCalendarEvent: call to reply to API with attendanceState: $attendanceState");
         val body = mapOf("reply" to attendanceState.apiValue)
 
         val route = if (useInfomaniakCalendarRoute) {

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.mail.data.api
 
+import android.util.Log
 import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.R
 import com.infomaniak.lib.core.api.ApiController
@@ -392,14 +393,17 @@ object ApiRepository : ApiRepositoryCore() {
         useInfomaniakCalendarRoute: Boolean,
         calendarEventId: Int,
         attachmentResource: String,
-    ): ApiResponse<CalendarEventResponse> {
+    ): ApiResponse<Boolean> {
+        Log.v("gibran", "replyToCalendarEvent: call to reply to API with attendanceState: $attendanceState");
         val body = mapOf("reply" to attendanceState.apiValue)
 
-        return if (useInfomaniakCalendarRoute) {
-            callApi(ApiRoutes.infomaniakCalendarEventReply(calendarEventId), GET, body)
+        val route = if (useInfomaniakCalendarRoute) {
+            ApiRoutes.infomaniakCalendarEventReply(calendarEventId)
         } else {
-            callApi(ApiRoutes.icsCalendarEventReply(attachmentResource), GET, body)
+            ApiRoutes.icsCalendarEventReply(attachmentResource)
         }
+
+        return callApi(route, POST, body)
     }
 
     /**

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -37,7 +37,7 @@ import com.infomaniak.mail.data.models.ai.AiMessage
 import com.infomaniak.mail.data.models.ai.AiResult
 import com.infomaniak.mail.data.models.ai.ContextMessage
 import com.infomaniak.mail.data.models.ai.UserMessage
-import com.infomaniak.mail.data.models.calendar.Attendee
+import com.infomaniak.mail.data.models.calendar.Attendee.AttendanceState
 import com.infomaniak.mail.data.models.calendar.CalendarEvent
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
 import com.infomaniak.mail.data.models.correspondent.Contact
@@ -382,27 +382,22 @@ object ApiRepository : ApiRepositoryCore() {
     }
 
     fun getAttachmentCalendarEvent(resource: String): ApiResponse<CalendarEventResponse> {
-        return callApi(
-            url = ApiRoutes.calendarEvent(resource),
-            method = GET,
-        )
+        return callApi(url = ApiRoutes.calendarEvent(resource), method = GET)
     }
 
     fun replyToCalendarEvent(
-        attendanceState: Attendee.AttendanceState,
+        attendanceState: AttendanceState,
         useInfomaniakCalendarRoute: Boolean,
         calendarEventId: Int,
         attachmentResource: String,
     ): ApiResponse<*> {
         val body = mapOf("reply" to attendanceState.apiValue)
 
-        val response: ApiResponse<*> = if (useInfomaniakCalendarRoute) {
+        return if (useInfomaniakCalendarRoute) {
             callApi<ApiResponse<Boolean>>(ApiRoutes.infomaniakCalendarEventReply(calendarEventId), POST, body)
         } else {
             callApi<ApiResponse<Map<String, CalendarEvent>>>(ApiRoutes.icsCalendarEventReply(attachmentResource), POST, body)
         }
-
-        return response
     }
 
     /**

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -37,6 +37,7 @@ import com.infomaniak.mail.data.models.ai.AiMessage
 import com.infomaniak.mail.data.models.ai.AiResult
 import com.infomaniak.mail.data.models.ai.ContextMessage
 import com.infomaniak.mail.data.models.ai.UserMessage
+import com.infomaniak.mail.data.models.calendar.Attendee
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
 import com.infomaniak.mail.data.models.correspondent.Contact
 import com.infomaniak.mail.data.models.correspondent.Recipient
@@ -383,8 +384,22 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(
             url = ApiRoutes.calendarEvent(resource),
             method = GET,
-            okHttpClient = HttpClient.okHttpClientLongTimeout,
         )
+    }
+
+    fun replyToCalendarEvent(
+        attendanceState: Attendee.AttendanceState,
+        useInfomaniakCalendarRoute: Boolean,
+        calendarEventId: Int,
+        attachmentResource: String,
+    ): ApiResponse<CalendarEventResponse> {
+        val body = mapOf("reply" to attendanceState.apiValue)
+
+        return if (useInfomaniakCalendarRoute) {
+            callApi(ApiRoutes.infomaniakCalendarEventReply(calendarEventId), GET, body)
+        } else {
+            callApi(ApiRoutes.icsCalendarEventReply(attachmentResource), GET, body)
+        }
     }
 
     /**

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
@@ -255,6 +255,6 @@ object ApiRoutes {
     }
 
     fun resource(resource: String): String {
-        return "${MAIL_API}${resource}"
+        return "$MAIL_API$resource"
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
@@ -50,16 +50,6 @@ object ApiRoutes {
     }
     //endregion
 
-    //region Resource
-    fun resource(resource: String): String {
-        return "${MAIL_API}${resource}"
-    }
-
-    fun calendarEvent(resource: String): String {
-        return "${resource(resource)}?format=render"
-    }
-    //endregion
-
     //region Personal Information Manager
     private fun pim(): String {
         return "$MAIL_API/api/pim"
@@ -75,6 +65,20 @@ object ApiRoutes {
 
     fun contacts(): String {
         return "${contact()}/all?with=emails,details,others,contacted_times&filters=has_email"
+    }
+    //endregion
+
+    //region Calendar
+    fun calendarEvent(resource: String): String {
+        return "${resource(resource)}?format=render"
+    }
+
+    fun infomaniakCalendarEventReply(calendarEventId: Int): String {
+        return "${pim()}/event/$calendarEventId/reply"
+    }
+
+    fun icsCalendarEventReply(resource: String): String {
+        return "${resource(resource)}/reply"
     }
     //endregion
 
@@ -248,5 +252,9 @@ object ApiRoutes {
 
     fun ping(): String {
         return "$MAIL_API/api/ping-with-auth"
+    }
+
+    fun resource(resource: String): String {
+        return "${MAIL_API}${resource}"
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023 Infomaniak Network SA
+ * Copyright (C) 2023-2024 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -708,6 +708,7 @@ class RefreshController @Inject constructor(
             isTrashed = folder.role == FolderRole.TRASH,
             isFromSearch = false,
             draftLocalUuid = null,
+            latestCalendarEventResponse = null,
         )
 
         if (existingMessage == null) folder.messages.add(remoteMessage)

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2023 Infomaniak Network SA
+ * Copyright (C) 2022-2024 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -97,6 +97,7 @@ class ThreadController @Inject constructor(
                     isFullyDownloaded = localMessage?.isFullyDownloaded() ?: false,
                     isTrashed = folderRole == FolderRole.TRASH,
                     isFromSearch = localMessage == null,
+                    latestCalendarEventResponse = localMessage?.latestCalendarEventResponse,
                     draftLocalUuid = localMessage?.draftLocalUuid,
                 )
 
@@ -257,6 +258,7 @@ class ThreadController @Inject constructor(
                                     isTrashed = localMessage.isTrashed,
                                     isFromSearch = localMessage.isFromSearch,
                                     draftLocalUuid = remoteMessage.getDraftLocalUuid(realm),
+                                    latestCalendarEventResponse = localMessage.latestCalendarEventResponse,
                                     messageIds = localMessage.messageIds,
                                 )
                                 MessageController.upsertMessage(remoteMessage, realm = this)

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/Attendee.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/Attendee.kt
@@ -55,7 +55,7 @@ class Attendee() : EmbeddedRealmObject, Correspondent {
         _state = state
     }
 
-    fun manuallyUpdateAttendeeAfterReplying(newAttendanceState: AttendanceState) {
+    fun manuallyOverrideAttendanceState(newAttendanceState: AttendanceState) {
         _state = newAttendanceState.apiValue
     }
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/Attendee.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/Attendee.kt
@@ -55,6 +55,10 @@ class Attendee() : EmbeddedRealmObject, Correspondent {
         _state = state
     }
 
+    fun manuallyUpdateAttendeeAfterReplying(newAttendanceState: AttendanceState) {
+        _state = newAttendanceState.apiValue
+    }
+
     enum class AttendanceState(val apiValue: String, @DrawableRes val icon: Int?, @ColorRes val iconColor: Int?) {
         ACCEPTED("ACCEPTED", R.drawable.ic_check_rounded, R.color.greenSuccess),
         NEEDS_ACTION("NEEDS-ACTION", null, null),

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
@@ -50,8 +50,6 @@ class CalendarEvent : EmbeddedRealmObject {
 
     /** Don't forget to update equals() and hashCode() if a field is added */
 
-    val iAmInvited get() = attendees.any(Attendee::isMe)
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
@@ -76,6 +76,7 @@ class CalendarEvent() : EmbeddedRealmObject {
         if (location != other.location) return false
         if (isFullDay != other.isFullDay) return false
         if (start != other.start) return false
+
         return end == other.end
     }
 
@@ -83,9 +84,7 @@ class CalendarEvent() : EmbeddedRealmObject {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as CalendarEvent
-
-        if (!everythingButAttendeesIsTheSame(other)) return false
+        if (!everythingButAttendeesIsTheSame(other as CalendarEvent)) return false
 
         return attendees == other.attendees
     }

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
@@ -50,6 +50,8 @@ class CalendarEvent : EmbeddedRealmObject {
 
     /** Don't forget to update equals() and hashCode() if a field is added */
 
+    val iAmInvited get() = attendees.any(Attendee::isMe)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.UseSerializers
 import java.util.Date
 
 @Serializable
-class CalendarEvent : EmbeddedRealmObject {
+class CalendarEvent() : EmbeddedRealmObject {
 
     /** Don't forget to update equals() and hashCode() if a field is added */
 
@@ -48,7 +48,36 @@ class CalendarEvent : EmbeddedRealmObject {
     var attendees: RealmList<Attendee> = realmListOf()
     //endregion
 
+    constructor(
+        id: Int,
+        type: String,
+        title: String,
+        location: String?,
+        isFullDay: Boolean,
+        start: RealmInstant,
+        end: RealmInstant,
+        attendees: RealmList<Attendee>,
+    ) : this() {
+        this.id = id
+        this.type = type
+        this.title = title
+        this.location = location
+        this.isFullDay = isFullDay
+        this.start = start
+        this.end = end
+        this.attendees = attendees
+    }
+
     /** Don't forget to update equals() and hashCode() if a field is added */
+
+    fun everythingButAttendeesIsTheSame(other: CalendarEvent): Boolean {
+        if (type != other.type) return false
+        if (title != other.title) return false
+        if (location != other.location) return false
+        if (isFullDay != other.isFullDay) return false
+        if (start != other.start) return false
+        return end == other.end
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -56,12 +85,7 @@ class CalendarEvent : EmbeddedRealmObject {
 
         other as CalendarEvent
 
-        if (type != other.type) return false
-        if (title != other.title) return false
-        if (location != other.location) return false
-        if (isFullDay != other.isFullDay) return false
-        if (start != other.start) return false
-        if (end != other.end) return false
+        if (!everythingButAttendeesIsTheSame(other)) return false
 
         return attendees == other.attendees
     }

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
@@ -37,6 +37,7 @@ class CalendarEvent : EmbeddedRealmObject {
     /** Don't forget to update equals() and hashCode() if a field is added */
 
     //region Remote data
+    var id: Int = 0
     var type: String = ""
     var title: String = ""
     var location: String? = null

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
@@ -29,14 +29,25 @@ class CalendarEventResponse : EmbeddedRealmObject {
     @SerialName("user_stored_event")
     private var userStoredEvent: CalendarEvent? = null
     @SerialName("user_stored_event_deleted")
-    var isUserStoredEventDeleted: Boolean = false
+    private var isUserStoredEventDeleted: Boolean = false
     @SerialName("attachment_event")
     private var attachmentEvent: CalendarEvent? = null
     @SerialName("attachment_event_method")
     private var _attachmentEventMethod: String? = null
     //endregion
 
+    private val attachmentEventMethod: AttachmentEventMethod?
+        get() = Utils.enumValueOfOrNull<AttachmentEventMethod>(_attachmentEventMethod)
+
     val calendarEvent get() = userStoredEvent ?: attachmentEvent
+
+    val isCanceled get() = isUserStoredEventDeleted || attachmentEventMethod == AttachmentEventMethod.CANCEL
+
+    fun isReplyAuthorized(): Boolean {
+        return (attachmentEventMethod == null || attachmentEventMethod == AttachmentEventMethod.REQUEST)
+                && !isCanceled
+                && calendarEvent?.iAmInvited == true
+    }
 
     fun hasUserStoredEvent() = userStoredEvent != null
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
@@ -50,7 +50,7 @@ class CalendarEventResponse : EmbeddedRealmObject {
                 && calendarEvent?.attendees?.isUserIn() == true
     }
 
-    fun hasInfomaniakCalendarEventAssociated(): Boolean = userStoredEvent != null
+    fun hasAssociatedInfomaniakCalendarEvent(): Boolean = userStoredEvent != null
 
     fun hasUserStoredEvent() = userStoredEvent != null
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.data.models.calendar
 
 import com.infomaniak.lib.core.utils.Utils
+import com.infomaniak.mail.utils.isUserIn
 import io.realm.kotlin.types.EmbeddedRealmObject
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -46,7 +47,7 @@ class CalendarEventResponse : EmbeddedRealmObject {
     fun isReplyAuthorized(): Boolean {
         return (attachmentEventMethod == null || attachmentEventMethod == AttachmentEventMethod.REQUEST)
                 && !isCanceled
-                && calendarEvent?.iAmInvited == true
+                && calendarEvent?.attendees?.isUserIn() == true
     }
 
     fun hasInfomaniakCalendarEventAssociated(): Boolean = userStoredEvent != null

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
@@ -24,7 +24,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-class CalendarEventResponse : EmbeddedRealmObject {
+class CalendarEventResponse() : EmbeddedRealmObject {
 
     //region Remote data
     @SerialName("user_stored_event")
@@ -36,6 +36,18 @@ class CalendarEventResponse : EmbeddedRealmObject {
     @SerialName("attachment_event_method")
     private var _attachmentEventMethod: String? = null
     //endregion
+
+    constructor(
+        userStoredEvent: CalendarEvent?,
+        isUserStoredEventDeleted: Boolean,
+        attachmentEvent: CalendarEvent?,
+        attachmentEventMethod: String?
+    ) : this() {
+        this.userStoredEvent = userStoredEvent
+        this.isUserStoredEventDeleted = isUserStoredEventDeleted
+        this.attachmentEvent = attachmentEvent
+        this._attachmentEventMethod = attachmentEventMethod
+    }
 
     private val attachmentEventMethod: AttachmentEventMethod?
         get() = Utils.enumValueOfOrNull<AttachmentEventMethod>(_attachmentEventMethod)
@@ -55,6 +67,22 @@ class CalendarEventResponse : EmbeddedRealmObject {
     fun hasUserStoredEvent() = userStoredEvent != null
 
     fun hasAttachmentEvent() = attachmentEvent != null
+
+    fun everythingButAttendeesIsTheSame(other: CalendarEventResponse?): Boolean {
+        if (other == null) return false
+
+        if (isUserStoredEventDeleted != other.isUserStoredEventDeleted) return false
+        if (_attachmentEventMethod != other._attachmentEventMethod) return false
+
+        val c1 = calendarEvent
+        val c2 = other.calendarEvent
+
+        if (c1 == null && c2 == null) return true
+        if (c1 == null) return false
+        if (c2 == null) return false
+
+        return c1.everythingButAttendeesIsTheSame(c2)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
@@ -49,6 +49,8 @@ class CalendarEventResponse : EmbeddedRealmObject {
                 && calendarEvent?.iAmInvited == true
     }
 
+    fun hasInfomaniakCalendarEventAssociated(): Boolean = userStoredEvent != null
+
     fun hasUserStoredEvent() = userStoredEvent != null
 
     fun hasAttachmentEvent() = attachmentEvent != null

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
@@ -41,7 +41,7 @@ class CalendarEventResponse() : EmbeddedRealmObject {
         userStoredEvent: CalendarEvent?,
         isUserStoredEventDeleted: Boolean,
         attachmentEvent: CalendarEvent?,
-        attachmentEventMethod: String?
+        attachmentEventMethod: String?,
     ) : this() {
         this.userStoredEvent = userStoredEvent
         this.isUserStoredEventDeleted = isUserStoredEventDeleted
@@ -64,8 +64,6 @@ class CalendarEventResponse() : EmbeddedRealmObject {
 
     fun hasAssociatedInfomaniakCalendarEvent(): Boolean = userStoredEvent != null
 
-    fun hasUserStoredEvent() = userStoredEvent != null
-
     fun hasAttachmentEvent() = attachmentEvent != null
 
     fun everythingButAttendeesIsTheSame(other: CalendarEventResponse?): Boolean {
@@ -78,8 +76,7 @@ class CalendarEventResponse() : EmbeddedRealmObject {
         val c2 = other.calendarEvent
 
         if (c1 == null && c2 == null) return true
-        if (c1 == null) return false
-        if (c2 == null) return false
+        if (c1 == null || c2 == null) return false
 
         return c1.everythingButAttendeesIsTheSame(c2)
     }

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -167,7 +167,7 @@ class Message : RealmObject {
             if (it == null) SentryLog.e("ThreadAdapter", "Message $uid has empty from")
         }
 
-    val calendarAttachment: Attachment? get() = attachments.firstOrNull(Attachment::isCalendarEvent)
+    val calendarAttachment: Attachment? get() = if (isDraft) null else attachments.firstOrNull(Attachment::isCalendarEvent)
 
     val dkimStatus: MessageDKIM get() = enumValueOfOrNull<MessageDKIM>(_dkimStatus) ?: MessageDKIM.VALID
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -195,6 +195,7 @@ class Message : RealmObject {
         isTrashed: Boolean,
         isFromSearch: Boolean,
         draftLocalUuid: String?,
+        latestCalendarEventResponse: CalendarEventResponse?,
         messageIds: RealmSet<String>? = null,
     ) {
         this.date = date
@@ -204,6 +205,7 @@ class Message : RealmObject {
         this.isFromSearch = isFromSearch
         this.messageIds = messageIds ?: computeMessageIds()
         shortUid = uid.toShortUid()
+        this.latestCalendarEventResponse = latestCalendarEventResponse
     }
 
     fun keepHeavyData(message: Message) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -79,7 +79,7 @@ class ThreadAdapter(
     navigateToNewMessageActivity: (Uri) -> Unit,
     navigateToAttendeeBottomSheet: (List<Attendee>) -> Unit,
     navigateToDownloadProgressDialog: (Int, Bundle) -> Unit,
-    replyToCalendarEvent: (AttendanceState, message: Message) -> Unit,
+    replyToCalendarEvent: (AttendanceState, Message) -> Unit,
     promptLink: (String, ContextMenuType) -> Unit,
 ) : ListAdapter<Message, ThreadViewHolder>(MessageDiffCallback()) {
 
@@ -200,7 +200,7 @@ class ThreadAdapter(
                     isCanceled = calendarEventResponse.isCanceled,
                     shouldDisplayReplyOptions = calendarEventResponse.isReplyAuthorized(),
                     attachment = attachment,
-                    hasInfomaniakCalendarEventAssociated = calendarEventResponse.hasInfomaniakCalendarEventAssociated(),
+                    hasAssociatedInfomaniakCalendarEvent = calendarEventResponse.hasAssociatedInfomaniakCalendarEvent(),
                     shouldStartExpanded = isCalendarEventExpandedMap[message.uid] ?: false,
                 )
             }
@@ -712,7 +712,7 @@ class ThreadAdapter(
         var navigateToNewMessageActivity: (Uri) -> Unit,
         var navigateToAttendeeBottomSheet: (List<Attendee>) -> Unit,
         var navigateToDownloadProgressDialog: (Int, Bundle) -> Unit,
-        var replyToCalendarEvent: (AttendanceState, message: Message) -> Unit,
+        var replyToCalendarEvent: (AttendanceState, Message) -> Unit,
         var promptLink: (String, ContextMenuType) -> Unit,
     )
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -41,6 +41,7 @@ import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Attachment
 import com.infomaniak.mail.data.models.Attachment.*
 import com.infomaniak.mail.data.models.calendar.Attendee
+import com.infomaniak.mail.data.models.calendar.Attendee.AttendanceState
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.message.Message.*
@@ -77,7 +78,7 @@ class ThreadAdapter(
     navigateToNewMessageActivity: (Uri) -> Unit,
     navigateToAttendeeBottomSheet: (List<Attendee>) -> Unit,
     navigateToDownloadProgressDialog: (Int, Bundle) -> Unit,
-    replyToCalendarEvent: (Attendee.AttendanceState, message: Message) -> Unit,
+    replyToCalendarEvent: (AttendanceState, message: Message) -> Unit,
     promptLink: (String, ContextMenuType) -> Unit,
 ) : ListAdapter<Message, ThreadViewHolder>(MessageDiffCallback()) {
 
@@ -709,7 +710,7 @@ class ThreadAdapter(
         var navigateToNewMessageActivity: (Uri) -> Unit,
         var navigateToAttendeeBottomSheet: (List<Attendee>) -> Unit,
         var navigateToDownloadProgressDialog: (Int, Bundle) -> Unit,
-        var replyToCalendarEvent: (Attendee.AttendanceState, message: Message) -> Unit,
+        var replyToCalendarEvent: (AttendanceState, message: Message) -> Unit,
         var promptLink: (String, ContextMenuType) -> Unit,
     )
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -76,6 +76,7 @@ class ThreadAdapter(
     navigateToNewMessageActivity: (Uri) -> Unit,
     navigateToAttendeeBottomSheet: (List<Attendee>) -> Unit,
     navigateToDownloadProgressDialog: (Int, Bundle) -> Unit,
+    replyToCalendarEvent: (Attendee.AttendanceState, message: Message) -> Unit,
     promptLink: (String, ContextMenuType) -> Unit,
 ) : ListAdapter<Message, ThreadViewHolder>(MessageDiffCallback()) {
 
@@ -119,6 +120,7 @@ class ThreadAdapter(
             navigateToNewMessageActivity,
             navigateToAttendeeBottomSheet,
             navigateToDownloadProgressDialog,
+            replyToCalendarEvent,
             promptLink,
         )
     }
@@ -186,9 +188,11 @@ class ThreadAdapter(
             isVisible = calendarEvent != null
 
             calendarEvent?.let {
-                val isCanceled = message.latestCalendarEventResponse!!.isCanceled
-                val shouldDisplayReplyOptions = message.latestCalendarEventResponse!!.isReplyAuthorized()
-                loadCalendarEvent(it, isCanceled, shouldDisplayReplyOptions, attachment)
+                val calendarEventResponse = message.latestCalendarEventResponse!!
+                val isCanceled = calendarEventResponse.isCanceled
+                val shouldDisplayReplyOptions = calendarEventResponse.isReplyAuthorized()
+                val hasInfomaniakCalendarEventAssociated = calendarEventResponse.hasInfomaniakCalendarEventAssociated()
+                loadCalendarEvent(it, isCanceled, shouldDisplayReplyOptions, attachment, hasInfomaniakCalendarEventAssociated)
             }
 
             initCallback(
@@ -201,6 +205,9 @@ class ThreadAdapter(
                         attachment.createDownloadDialogNavArgs(AttachmentIntentType.OPEN_WITH),
                     )
                 },
+                replyToCalendarEvent = { attendanceState ->
+                    threadAdapterCallbacks?.replyToCalendarEvent?.invoke(attendanceState, message)
+                }
             )
         }
     }
@@ -686,6 +693,7 @@ class ThreadAdapter(
         var navigateToNewMessageActivity: (Uri) -> Unit,
         var navigateToAttendeeBottomSheet: (List<Attendee>) -> Unit,
         var navigateToDownloadProgressDialog: (Int, Bundle) -> Unit,
+        var replyToCalendarEvent: (Attendee.AttendanceState, message: Message) -> Unit,
         var promptLink: (String, ContextMenuType) -> Unit,
     )
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -186,8 +186,9 @@ class ThreadAdapter(
             isVisible = calendarEvent != null
 
             calendarEvent?.let {
-                val hasBeenDeleted = message.latestCalendarEventResponse!!.isUserStoredEventDeleted
-                loadCalendarEvent(it, hasBeenDeleted, attachment)
+                val isCanceled = message.latestCalendarEventResponse!!.isCanceled
+                val shouldDisplayReplyOptions = message.latestCalendarEventResponse!!.isReplyAuthorized()
+                loadCalendarEvent(it, isCanceled, shouldDisplayReplyOptions, attachment)
             }
 
             initCallback(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -65,6 +65,7 @@ import com.google.android.material.R as RMaterial
 
 class ThreadAdapter(
     private val shouldLoadDistantResources: Boolean,
+    private val isCalendarEventExpandedMap: MutableMap<String, Boolean>,
     onContactClicked: (contact: Recipient) -> Unit,
     onDeleteDraftClicked: (message: Message) -> Unit,
     onDraftClicked: (message: Message) -> Unit,
@@ -190,10 +191,15 @@ class ThreadAdapter(
 
             calendarEvent?.let {
                 val calendarEventResponse = message.latestCalendarEventResponse!!
-                val isCanceled = calendarEventResponse.isCanceled
-                val shouldDisplayReplyOptions = calendarEventResponse.isReplyAuthorized()
-                val hasInfomaniakCalendarEventAssociated = calendarEventResponse.hasInfomaniakCalendarEventAssociated()
-                loadCalendarEvent(it, isCanceled, shouldDisplayReplyOptions, attachment, hasInfomaniakCalendarEventAssociated)
+
+                loadCalendarEvent(
+                    calendarEvent = it,
+                    isCanceled = calendarEventResponse.isCanceled,
+                    shouldDisplayReplyOptions = calendarEventResponse.isReplyAuthorized(),
+                    attachment = attachment,
+                    hasInfomaniakCalendarEventAssociated = calendarEventResponse.hasInfomaniakCalendarEventAssociated(),
+                    shouldStartExpanded = isCalendarEventExpandedMap[message.uid] ?: false,
+                )
             }
 
             initCallback(
@@ -208,7 +214,10 @@ class ThreadAdapter(
                 },
                 replyToCalendarEvent = { attendanceState ->
                     threadAdapterCallbacks?.replyToCalendarEvent?.invoke(attendanceState, message)
-                }
+                },
+                onAttendeesButtonClicked = { isExpanded ->
+                    isCalendarEventExpandedMap[message.uid] = isExpanded
+                },
             )
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -162,6 +162,7 @@ class ThreadAdapter(
                     failedLoadingErrorMessage.isVisible = true
                     if (isExpandedMap[message.uid] == true) onExpandedMessageLoaded(message.uid)
                 }
+                NotifyType.FAILED_CALENDAR_REPLY -> holder.bindCalendarEvent(message)
             }
         }
     }.getOrDefault(Unit)
@@ -590,10 +591,16 @@ class ThreadAdapter(
         threadAdapterCallbacks = null
     }
 
+    fun undoUserAttendanceClick(message: Message) {
+        val indexOfMessage = messages.indexOfFirst { it.uid == message.uid }.takeIf { it >= 0 }
+        indexOfMessage?.let { notifyItemChanged(it, NotifyType.FAILED_CALENDAR_REPLY) }
+    }
+
     private enum class NotifyType {
         TOGGLE_LIGHT_MODE,
         RE_RENDER,
         FAILED_MESSAGE,
+        FAILED_CALENDAR_REPLY,
     }
 
     enum class ContextMenuType {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -165,8 +165,8 @@ class ThreadAdapter(
                     if (isExpandedMap[message.uid] == true) onExpandedMessageLoaded(message.uid)
                 }
                 NotifyType.ONLY_REBIND_CALENDAR_ATTENDANCE -> {
-                    val attendees = message.latestCalendarEventResponse?.calendarEvent?.attendees
-                    holder.binding.calendarEvent.onlyUpdateAttendance(attendees ?: emptyList())
+                    val attendees = message.latestCalendarEventResponse?.calendarEvent?.attendees ?: emptyList()
+                    holder.binding.calendarEvent.onlyUpdateAttendance(attendees)
                 }
             }
         }
@@ -219,9 +219,7 @@ class ThreadAdapter(
                 replyToCalendarEvent = { attendanceState ->
                     threadAdapterCallbacks?.replyToCalendarEvent?.invoke(attendanceState, message)
                 },
-                onAttendeesButtonClicked = { isExpanded ->
-                    isCalendarEventExpandedMap[message.uid] = isExpanded
-                },
+                onAttendeesButtonClicked = { isExpanded -> isCalendarEventExpandedMap[message.uid] = isExpanded },
             )
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -67,6 +67,7 @@ import com.google.android.material.R as RMaterial
 class ThreadAdapter(
     private val shouldLoadDistantResources: Boolean,
     private val isCalendarEventExpandedMap: MutableMap<String, Boolean>,
+    private val userAttendanceStateOverrideMap: MutableMap<String, AttendanceState>,
     onContactClicked: (contact: Recipient) -> Unit,
     onDeleteDraftClicked: (message: Message) -> Unit,
     onDraftClicked: (message: Message) -> Unit,
@@ -195,6 +196,7 @@ class ThreadAdapter(
 
                 loadCalendarEvent(
                     calendarEvent = it,
+                    userAttendanceState = userAttendanceStateOverrideMap[message.uid],
                     isCanceled = calendarEventResponse.isCanceled,
                     shouldDisplayReplyOptions = calendarEventResponse.isReplyAuthorized(),
                     attachment = attachment,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -22,6 +22,7 @@ import android.content.res.Configuration
 import android.graphics.drawable.InsetDrawable
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -325,6 +326,7 @@ class ThreadFragment : Fragment() {
 
     private fun observeMessagesLive() = with(threadViewModel) {
         messagesLive.observe(viewLifecycleOwner) { messages ->
+            Log.e("gibran", "observeMessagesLive: observed messages change and submitting list", );
             SentryLog.i("UI", "Received ${messages.count()} messages")
 
             if (messages.isEmpty()) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -252,9 +252,10 @@ class ThreadFragment : Fragment() {
                     message,
                 ).observe(viewLifecycleOwner) { successfullyUpdated ->
                     if (successfullyUpdated) {
+                        snackbarManager.setValue(getString(R.string.snackbarCalendarChoiceSent))
                         // updateRealmLocally() // TODO
                     } else {
-                        snackbarManager.setValue("Could not reply to the event") // TODO
+                        snackbarManager.setValue(getString(R.string.errorCalendarChoiceCouldNotBeSent))
                         threadAdapter.undoUserAttendanceClick(message)
                     }
                 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -244,6 +244,7 @@ class ThreadFragment : Fragment() {
             },
             navigateToNewMessageActivity = { twoPaneViewModel.navigateToNewMessage(mailToUri = it) },
             navigateToDownloadProgressDialog = ::safeNavigate,
+            replyToCalendarEvent = threadViewModel::replyToCalendarEvent,
             promptLink = { data, type ->
                 // When adding a phone number to contacts, Google decodes this value in case it's url-encoded. But I could not
                 // reproduce this issue when manually creating a url-encoded href. If this is triggered, fix it by also

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -199,6 +199,7 @@ class ThreadFragment : Fragment() {
         adapter = ThreadAdapter(
             shouldLoadDistantResources = shouldLoadDistantResources(),
             isCalendarEventExpandedMap = threadViewModel.isCalendarEventExpandedMap,
+            userAttendanceStateOverrideMap = threadViewModel.userAttendanceStateOverrideMap,
             onContactClicked = {
                 safeNavigate(
                     resId = R.id.detailedContactBottomSheetDialog,
@@ -253,7 +254,7 @@ class ThreadFragment : Fragment() {
                 ).observe(viewLifecycleOwner) { successfullyUpdated ->
                     if (successfullyUpdated) {
                         snackbarManager.setValue(getString(R.string.snackbarCalendarChoiceSent))
-                        // updateRealmLocally() // TODO
+                        threadViewModel.userAttendanceStateOverrideMap[message.uid] = attendanceState
                     } else {
                         snackbarManager.setValue(getString(R.string.errorCalendarChoiceCouldNotBeSent))
                         threadAdapter.undoUserAttendanceClick(message)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -198,6 +198,7 @@ class ThreadFragment : Fragment() {
     private fun setupAdapter() = with(binding.messagesList) {
         adapter = ThreadAdapter(
             shouldLoadDistantResources = shouldLoadDistantResources(),
+            isCalendarEventExpandedMap = threadViewModel.isCalendarEventExpandedMap,
             onContactClicked = {
                 safeNavigate(
                     resId = R.id.detailedContactBottomSheetDialog,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -22,7 +22,6 @@ import android.content.res.Configuration
 import android.graphics.drawable.InsetDrawable
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -341,7 +340,6 @@ class ThreadFragment : Fragment() {
 
     private fun observeMessagesLive() = with(threadViewModel) {
         messagesLive.observe(viewLifecycleOwner) { messages ->
-            Log.e("gibran", "observeMessagesLive: observed messages change and submitting list");
             SentryLog.i("UI", "Received ${messages.count()} messages")
 
             if (messages.isEmpty()) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -198,7 +198,6 @@ class ThreadFragment : Fragment() {
         adapter = ThreadAdapter(
             shouldLoadDistantResources = shouldLoadDistantResources(),
             isCalendarEventExpandedMap = threadViewModel.isCalendarEventExpandedMap,
-            userAttendanceStateOverrideMap = threadViewModel.userAttendanceStateOverrideMap,
             onContactClicked = {
                 safeNavigate(
                     resId = R.id.detailedContactBottomSheetDialog,
@@ -253,7 +252,7 @@ class ThreadFragment : Fragment() {
                 ).observe(viewLifecycleOwner) { successfullyUpdated ->
                     if (successfullyUpdated) {
                         snackbarManager.setValue(getString(R.string.snackbarCalendarChoiceSent))
-                        threadViewModel.userAttendanceStateOverrideMap[message.uid] = attendanceState
+                        threadViewModel.fetchCalendarEvents(listOf(message), forceFetch = true)
                     } else {
                         snackbarManager.setValue(getString(R.string.errorCalendarChoiceCouldNotBeSent))
                         threadAdapter.undoUserAttendanceClick(message)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -258,7 +258,8 @@ class ThreadViewModel @Inject constructor(
                 Sentry.withScope { scope ->
                     scope.level = SentryLevel.ERROR
                     scope.setExtra("message.uid", message.uid)
-                    scope.setExtra("event has userStoredEvent", calendarEventResponse.hasUserStoredEvent().toString())
+                    val hasUserStoredEvent = calendarEventResponse.hasAssociatedInfomaniakCalendarEvent()
+                    scope.setExtra("event has userStoredEvent", hasUserStoredEvent.toString())
                     scope.setExtra("event's isCanceled", calendarEventResponse.isCanceled.toString())
                     scope.setExtra("event has attachmentEvent", calendarEventResponse.hasAttachmentEvent().toString())
                     Sentry.captureMessage("Cannot find message by uid for fetched calendar event inside Realm")
@@ -269,10 +270,7 @@ class ThreadViewModel @Inject constructor(
 
     fun getCalendarEventTreatedMessageCount(): Int = treatedMessagesForCalendarEvent.count()
 
-    fun replyToCalendarEvent(
-        attendanceState: AttendanceState,
-        message: Message,
-    ) = liveData<Boolean>(ioCoroutineContext) {
+    fun replyToCalendarEvent(attendanceState: AttendanceState, message: Message) = liveData(ioCoroutineContext) {
         val calendarEventResponse = message.latestCalendarEventResponse!!
 
         val response = ApiRepository.replyToCalendarEvent(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -272,7 +272,7 @@ class ThreadViewModel @Inject constructor(
     fun replyToCalendarEvent(
         attendanceState: Attendee.AttendanceState,
         message: Message,
-    ) = viewModelScope.launch(ioCoroutineContext) {
+    ) = liveData<Boolean>(ioCoroutineContext) {
         val calendarEventResponse = message.latestCalendarEventResponse!!
 
         val response = ApiRepository.replyToCalendarEvent(
@@ -282,12 +282,7 @@ class ThreadViewModel @Inject constructor(
             attachmentResource = message.calendarAttachment!!.resource ?: "",
         )
 
-        if (response.isSuccess()) {
-            fetchCalendarEvents(listOf(message), forceFetch = true)
-        } else {
-
-            // TODO : Revert clicked button
-        }
+        emit(response.isSuccess() && response.data == true)
     }
 
     data class SubjectDataResult(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -30,6 +30,7 @@ import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshMo
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
 import com.infomaniak.mail.data.models.calendar.Attendee
+import com.infomaniak.mail.data.models.calendar.Attendee.AttendanceState
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message
@@ -269,7 +270,7 @@ class ThreadViewModel @Inject constructor(
     fun getCalendarEventTreatedMessageCount(): Int = treatedMessagesForCalendarEvent.count()
 
     fun replyToCalendarEvent(
-        attendanceState: Attendee.AttendanceState,
+        attendanceState: AttendanceState,
         message: Message,
     ) = liveData<Boolean>(ioCoroutineContext) {
         val calendarEventResponse = message.latestCalendarEventResponse!!

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -281,7 +281,7 @@ class ThreadViewModel @Inject constructor(
             attachmentResource = message.calendarAttachment!!.resource ?: "",
         )
 
-        emit(response.isSuccess() && response.data == true) // TODO : Handle api response when event is not inside infomaniak calendar
+        emit(response.isSuccess())
     }
 
     data class SubjectDataResult(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -68,6 +68,7 @@ class ThreadViewModel @Inject constructor(
     val quickActionBarClicks = SingleLiveEvent<QuickActionBarResult>()
 
     private val treatedMessagesForCalendarEvent = mutableSetOf<String>()
+    val isCalendarEventExpandedMap = mutableMapOf<String, Boolean>()
 
     var deletedMessagesUids = mutableSetOf<String>()
     val failedMessagesUids = SingleLiveEvent<List<String>>()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -70,6 +70,7 @@ class ThreadViewModel @Inject constructor(
 
     private val treatedMessagesForCalendarEvent = mutableSetOf<String>()
     val isCalendarEventExpandedMap = mutableMapOf<String, Boolean>()
+    val userAttendanceStateOverrideMap = mutableMapOf<String, AttendanceState>()
 
     var deletedMessagesUids = mutableSetOf<String>()
     val failedMessagesUids = SingleLiveEvent<List<String>>()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -18,7 +18,6 @@
 package com.infomaniak.mail.ui.main.thread
 
 import android.app.Application
-import android.util.Log
 import androidx.lifecycle.*
 import com.infomaniak.lib.core.utils.SingleLiveEvent
 import com.infomaniak.mail.MatomoMail.trackUserInfo
@@ -29,7 +28,6 @@ import com.infomaniak.mail.data.cache.mailboxContent.RefreshController
 import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshMode
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
-import com.infomaniak.mail.data.models.calendar.Attendee
 import com.infomaniak.mail.data.models.calendar.Attendee.AttendanceState
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
 import com.infomaniak.mail.data.models.mailbox.Mailbox
@@ -221,10 +219,8 @@ class ThreadViewModel @Inject constructor(
     fun fetchCalendarEvents(messages: List<Message>) {
         fetchCalendarEventJob?.cancel()
         fetchCalendarEventJob = viewModelScope.launch(ioCoroutineContext) {
-            Log.i("gibran", "fetchCalendarEvents - gotta fetch calendar events for messages.map { it.subject }: ${messages.map { it.subject }}")
             mailboxContentRealm().writeBlocking {
                 messages.forEach { message ->
-                    // Log.i("gibran", "fetchCalendarEvents - message.subject: ${message.subject}")
                     if (!message.isFullyDownloaded()) return@forEach // Only treat message that have their attachments downloaded
 
                     val alreadyTreated = !treatedMessagesForCalendarEvent.add(message.uid)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -232,7 +232,7 @@ class ThreadViewModel @Inject constructor(
                     scope.level = SentryLevel.ERROR
                     scope.setExtra("message.uid", message.uid)
                     scope.setExtra("event has userStoredEvent", calendarEventResponse.hasUserStoredEvent().toString())
-                    scope.setExtra("event's userStoredEventDeleted", calendarEventResponse.isUserStoredEventDeleted.toString())
+                    scope.setExtra("event's isCanceled", calendarEventResponse.isCanceled.toString())
                     scope.setExtra("event has attachmentEvent", calendarEventResponse.hasAttachmentEvent().toString())
                     Sentry.captureMessage("Cannot find message by uid for fetched calendar event inside Realm")
                 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -215,7 +215,7 @@ class ThreadViewModel @Inject constructor(
         quickActionBarClicks.postValue(QuickActionBarResult(thread.uid, message, menuId))
     }
 
-    fun fetchCalendarEvents(messages: List<Message>, forceFetch: Boolean = false) {
+    fun fetchCalendarEvents(messages: List<Message>) {
         fetchCalendarEventJob?.cancel()
         fetchCalendarEventJob = viewModelScope.launch(ioCoroutineContext) {
             Log.i("gibran", "fetchCalendarEvents - gotta fetch calendar events for messages.map { it.subject }: ${messages.map { it.subject }}")
@@ -224,10 +224,8 @@ class ThreadViewModel @Inject constructor(
                     // Log.i("gibran", "fetchCalendarEvents - message.subject: ${message.subject}")
                     if (!message.isFullyDownloaded()) return@forEach // Only treat message that have their attachments downloaded
 
-                    if (!forceFetch) {
-                        val alreadyTreated = !treatedMessagesForCalendarEvent.add(message.uid)
-                        if (alreadyTreated) return@forEach
-                    }
+                    val alreadyTreated = !treatedMessagesForCalendarEvent.add(message.uid)
+                    if (alreadyTreated) return@forEach
 
                     val icsAttachment = message.calendarAttachment ?: return@forEach
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -276,12 +276,12 @@ class ThreadViewModel @Inject constructor(
 
         val response = ApiRepository.replyToCalendarEvent(
             attendanceState,
-            useInfomaniakCalendarRoute = calendarEventResponse.hasInfomaniakCalendarEventAssociated(),
+            useInfomaniakCalendarRoute = calendarEventResponse.hasAssociatedInfomaniakCalendarEvent(),
             calendarEventId = calendarEventResponse.calendarEvent!!.id,
             attachmentResource = message.calendarAttachment!!.resource ?: "",
         )
 
-        emit(response.isSuccess() && response.data == true)
+        emit(response.isSuccess() && response.data == true) // TODO : Handle api response when event is not inside infomaniak calendar
     }
 
     data class SubjectDataResult(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
@@ -20,6 +20,7 @@ package com.infomaniak.mail.ui.main.thread.calendar
 import android.content.Context
 import android.os.Build
 import android.util.AttributeSet
+import android.util.Log
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.core.view.isGone
@@ -27,7 +28,6 @@ import androidx.core.view.isVisible
 import com.google.android.material.button.MaterialButton
 import com.infomaniak.lib.core.utils.*
 import com.infomaniak.mail.R
-import com.infomaniak.mail.data.api.ApiRepository
 import com.infomaniak.mail.data.models.Attachment
 import com.infomaniak.mail.data.models.calendar.Attendee
 import com.infomaniak.mail.data.models.calendar.CalendarEvent
@@ -162,12 +162,16 @@ class CalendarEventBannerView @JvmOverloads constructor(
 
     private fun MaterialButton.handleChoiceButtonBehavior(attendanceState: Attendee.AttendanceState) {
         setOnClickListener {
-            // TODO : Handle click color
-            // val changedSelectedButton = isChecked
-            // if (changedSelectedButton) resetChoiceButtons()
-            // isChecked = true
+            val previouslyUnchecked = isChecked
+            Log.e("gibran", "handleChoiceButtonBehavior - detected click on attendanceState: ${attendanceState}")
+            Log.e("gibran", "handleChoiceButtonBehavior - the button was in this state when click triggered: previouslyUnchecked: ${previouslyUnchecked}")
 
-            replyToCalendarEvent?.invoke(attendanceState)
+            if (previouslyUnchecked) {
+                resetChoiceButtons()
+                replyToCalendarEvent?.invoke(attendanceState)
+            }
+
+            isChecked = true
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
@@ -59,6 +59,7 @@ class CalendarEventBannerView @JvmOverloads constructor(
     private var navigateToAttendeesBottomSheet: ((List<Attendee>) -> Unit)? = null
     private var navigateToDownloadProgressDialog: (() -> Unit)? = null
     private var replyToCalendarEvent: ((Attendee.AttendanceState) -> Unit)? = null
+    private var onAttendeesButtonClicked: ((Boolean) -> Unit)? = null
 
     @Inject
     lateinit var snackbarManager: SnackbarManager
@@ -69,7 +70,10 @@ class CalendarEventBannerView @JvmOverloads constructor(
             maybeButton.handleChoiceButtonBehavior(Attendee.AttendanceState.TENTATIVE)
             noButton.handleChoiceButtonBehavior(Attendee.AttendanceState.DECLINED)
 
-            attendeesButton.addOnCheckedChangeListener { _, isChecked -> attendeesSubMenu.isVisible = isChecked }
+            attendeesButton.addOnCheckedChangeListener { _, isChecked ->
+                attendeesSubMenu.isVisible = isChecked
+                onAttendeesButtonClicked?.invoke(isChecked)
+            }
         }
     }
 
@@ -79,6 +83,7 @@ class CalendarEventBannerView @JvmOverloads constructor(
         shouldDisplayReplyOptions: Boolean,
         attachment: Attachment,
         hasInfomaniakCalendarEventAssociated: Boolean,
+        shouldStartExpanded: Boolean,
     ) = with(binding) {
         useInfomaniakCalendarRoute = hasInfomaniakCalendarEventAssociated
         savedAttendees = calendarEvent.attendees.copyFromRealm()
@@ -98,6 +103,9 @@ class CalendarEventBannerView @JvmOverloads constructor(
             isVisible = calendarEvent.location?.isNotBlank() == true
             text = calendarEvent.location
         }
+
+        attendeesButton.isChecked = shouldStartExpanded
+        attendeesSubMenu.isVisible = shouldStartExpanded
 
         val userAsAttendee = savedAttendees.findUser()
         setAttendanceUi(userAsAttendee != null, shouldDisplayReplyOptions, userAsAttendee?.state)
@@ -164,10 +172,12 @@ class CalendarEventBannerView @JvmOverloads constructor(
         navigateToAttendeesBottomSheet: (List<Attendee>) -> Unit,
         navigateToDownloadProgressDialog: () -> Unit,
         replyToCalendarEvent: (Attendee.AttendanceState) -> Unit,
+        onAttendeesButtonClicked: (Boolean) -> Unit,
     ) {
         this.navigateToAttendeesBottomSheet = navigateToAttendeesBottomSheet
         this.navigateToDownloadProgressDialog = navigateToDownloadProgressDialog
         this.replyToCalendarEvent = replyToCalendarEvent
+        this.onAttendeesButtonClicked = onAttendeesButtonClicked
     }
 
     private fun MaterialButton.handleChoiceButtonBehavior(attendanceState: Attendee.AttendanceState) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
@@ -80,14 +80,17 @@ class CalendarEventBannerView @JvmOverloads constructor(
 
     fun loadCalendarEvent(
         calendarEvent: CalendarEvent,
+        userAttendanceState: AttendanceState?,
         isCanceled: Boolean,
         shouldDisplayReplyOptions: Boolean,
         attachment: Attachment,
         hasInfomaniakCalendarEventAssociated: Boolean,
         shouldStartExpanded: Boolean,
     ) = with(binding) {
-        useInfomaniakCalendarRoute = hasInfomaniakCalendarEventAssociated
         savedAttendees = calendarEvent.attendees.copyFromRealm()
+        userAttendanceState?.let { savedAttendees.findUser()?.manuallyOverrideAttendanceState(it) }
+
+        useInfomaniakCalendarRoute = hasInfomaniakCalendarEventAssociated
         attachmentResource = attachment.resource ?: run {
             // TODO: Check this sentry
             Sentry.captureMessage("No attachment resource when trying to load calendar event")
@@ -196,7 +199,7 @@ class CalendarEventBannerView @JvmOverloads constructor(
     }
 
     private fun updateThisUsersAttendance(attendanceState: AttendanceState) {
-        savedAttendees.firstOrNull(Attendee::isMe)?.manuallyUpdateAttendeeAfterReplying(attendanceState)
+        savedAttendees.findUser()?.manuallyOverrideAttendanceState(attendanceState)
         binding.manyAvatarsView.setAttendees(savedAttendees)
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
@@ -29,6 +29,7 @@ import com.infomaniak.lib.core.utils.*
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Attachment
 import com.infomaniak.mail.data.models.calendar.Attendee
+import com.infomaniak.mail.data.models.calendar.Attendee.AttendanceState
 import com.infomaniak.mail.data.models.calendar.CalendarEvent
 import com.infomaniak.mail.databinding.ViewCalendarEventBannerBinding
 import com.infomaniak.mail.ui.main.SnackbarManager
@@ -58,7 +59,7 @@ class CalendarEventBannerView @JvmOverloads constructor(
 
     private var navigateToAttendeesBottomSheet: ((List<Attendee>) -> Unit)? = null
     private var navigateToDownloadProgressDialog: (() -> Unit)? = null
-    private var replyToCalendarEvent: ((Attendee.AttendanceState) -> Unit)? = null
+    private var replyToCalendarEvent: ((AttendanceState) -> Unit)? = null
     private var onAttendeesButtonClicked: ((Boolean) -> Unit)? = null
 
     @Inject
@@ -66,9 +67,9 @@ class CalendarEventBannerView @JvmOverloads constructor(
 
     init {
         with(binding) {
-            yesButton.handleChoiceButtonBehavior(Attendee.AttendanceState.ACCEPTED)
-            maybeButton.handleChoiceButtonBehavior(Attendee.AttendanceState.TENTATIVE)
-            noButton.handleChoiceButtonBehavior(Attendee.AttendanceState.DECLINED)
+            yesButton.handleChoiceButtonBehavior(AttendanceState.ACCEPTED)
+            maybeButton.handleChoiceButtonBehavior(AttendanceState.TENTATIVE)
+            noButton.handleChoiceButtonBehavior(AttendanceState.DECLINED)
 
             attendeesButton.addOnCheckedChangeListener { _, isChecked ->
                 attendeesSubMenu.isVisible = isChecked
@@ -153,15 +154,15 @@ class CalendarEventBannerView @JvmOverloads constructor(
     private fun setAttendanceUi(
         iAmInvited: Boolean,
         shouldDisplayReplyOptions: Boolean,
-        attendanceState: Attendee.AttendanceState?,
+        attendanceState: AttendanceState?,
     ) = with(binding) {
         notPartOfAttendeesWarning.isGone = iAmInvited
         participationButtons.isVisible = shouldDisplayReplyOptions
         attendeesLayout.isGone = savedAttendees.isEmpty()
 
-        yesButton.isChecked = attendanceState == Attendee.AttendanceState.ACCEPTED
-        maybeButton.isChecked = attendanceState == Attendee.AttendanceState.TENTATIVE
-        noButton.isChecked = attendanceState == Attendee.AttendanceState.DECLINED
+        yesButton.isChecked = attendanceState == AttendanceState.ACCEPTED
+        maybeButton.isChecked = attendanceState == AttendanceState.TENTATIVE
+        noButton.isChecked = attendanceState == AttendanceState.DECLINED
 
         displayOrganizer(savedAttendees)
         allAttendeesButton.setOnClickListener { navigateToAttendeesBottomSheet?.invoke(savedAttendees) }
@@ -171,7 +172,7 @@ class CalendarEventBannerView @JvmOverloads constructor(
     fun initCallback(
         navigateToAttendeesBottomSheet: (List<Attendee>) -> Unit,
         navigateToDownloadProgressDialog: () -> Unit,
-        replyToCalendarEvent: (Attendee.AttendanceState) -> Unit,
+        replyToCalendarEvent: (AttendanceState) -> Unit,
         onAttendeesButtonClicked: (Boolean) -> Unit,
     ) {
         this.navigateToAttendeesBottomSheet = navigateToAttendeesBottomSheet
@@ -180,7 +181,7 @@ class CalendarEventBannerView @JvmOverloads constructor(
         this.onAttendeesButtonClicked = onAttendeesButtonClicked
     }
 
-    private fun MaterialButton.handleChoiceButtonBehavior(attendanceState: Attendee.AttendanceState) {
+    private fun MaterialButton.handleChoiceButtonBehavior(attendanceState: AttendanceState) {
         setOnClickListener {
             val previouslyUnchecked = isChecked
 
@@ -194,7 +195,7 @@ class CalendarEventBannerView @JvmOverloads constructor(
         }
     }
 
-    private fun updateThisUsersAttendance(attendanceState: Attendee.AttendanceState) {
+    private fun updateThisUsersAttendance(attendanceState: AttendanceState) {
         savedAttendees.firstOrNull(Attendee::isMe)?.manuallyUpdateAttendeeAfterReplying(attendanceState)
         binding.manyAvatarsView.setAttendees(savedAttendees)
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
@@ -34,6 +34,7 @@ import com.infomaniak.mail.databinding.ViewCalendarEventBannerBinding
 import com.infomaniak.mail.ui.main.SnackbarManager
 import com.infomaniak.mail.utils.AttachmentIntentUtils.openAttachment
 import com.infomaniak.mail.utils.UiUtils.getPrettyNameAndEmail
+import com.infomaniak.mail.utils.findUser
 import com.infomaniak.mail.utils.toDate
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.kotlin.ext.copyFromRealm
@@ -98,7 +99,8 @@ class CalendarEventBannerView @JvmOverloads constructor(
             text = calendarEvent.location
         }
 
-        setAttendanceUi(calendarEvent.iAmInvited, shouldDisplayReplyOptions)
+        val userAsAttendee = savedAttendees.findUser()
+        setAttendanceUi(userAsAttendee != null, shouldDisplayReplyOptions, userAsAttendee?.state)
 
         addToCalendarButton.setOnClickListener {
             attachment.openAttachment(context, navigateToDownloadProgressDialog ?: return@setOnClickListener, snackbarManager)
@@ -140,10 +142,18 @@ class CalendarEventBannerView @JvmOverloads constructor(
         }
     }
 
-    private fun setAttendanceUi(iAmInvited: Boolean, shouldDisplayReplyOptions: Boolean) = with(binding) {
+    private fun setAttendanceUi(
+        iAmInvited: Boolean,
+        shouldDisplayReplyOptions: Boolean,
+        attendanceState: Attendee.AttendanceState?,
+    ) = with(binding) {
         notPartOfAttendeesWarning.isGone = iAmInvited
         participationButtons.isVisible = shouldDisplayReplyOptions
         attendeesLayout.isGone = savedAttendees.isEmpty()
+
+        yesButton.isChecked = attendanceState == Attendee.AttendanceState.ACCEPTED
+        maybeButton.isChecked = attendanceState == Attendee.AttendanceState.TENTATIVE
+        noButton.isChecked = attendanceState == Attendee.AttendanceState.DECLINED
 
         displayOrganizer(savedAttendees)
         allAttendeesButton.setOnClickListener { navigateToAttendeesBottomSheet?.invoke(savedAttendees) }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
@@ -54,7 +54,7 @@ class CalendarEventBannerView @JvmOverloads constructor(
     private val binding by lazy { ViewCalendarEventBannerBinding.inflate(LayoutInflater.from(context), this, true) }
 
     private var useInfomaniakCalendarRoute: Boolean = false
-    private lateinit var savedAttendees: List<Attendee>
+    private var savedAttendees: List<Attendee> = emptyList()
     private var attachmentResource: String = ""
 
     private var navigateToAttendeesBottomSheet: ((List<Attendee>) -> Unit)? = null
@@ -84,13 +84,13 @@ class CalendarEventBannerView @JvmOverloads constructor(
         isCanceled: Boolean,
         shouldDisplayReplyOptions: Boolean,
         attachment: Attachment,
-        hasInfomaniakCalendarEventAssociated: Boolean,
+        hasAssociatedInfomaniakCalendarEvent: Boolean,
         shouldStartExpanded: Boolean,
     ) = with(binding) {
         savedAttendees = calendarEvent.attendees.copyFromRealm()
         userAttendanceState?.let { savedAttendees.findUser()?.manuallyOverrideAttendanceState(it) }
 
-        useInfomaniakCalendarRoute = hasInfomaniakCalendarEventAssociated
+        useInfomaniakCalendarRoute = hasAssociatedInfomaniakCalendarEvent
         attachmentResource = attachment.resource ?: run {
             // TODO: Check this sentry
             Sentry.captureMessage("No attachment resource when trying to load calendar event")
@@ -190,7 +190,7 @@ class CalendarEventBannerView @JvmOverloads constructor(
 
             if (previouslyUnchecked) {
                 resetChoiceButtons()
-                updateThisUsersAttendance(attendanceState)
+                updateCurrentUsersAttendance(attendanceState)
                 replyToCalendarEvent?.invoke(attendanceState)
             }
 
@@ -198,7 +198,7 @@ class CalendarEventBannerView @JvmOverloads constructor(
         }
     }
 
-    private fun updateThisUsersAttendance(attendanceState: AttendanceState) {
+    private fun updateCurrentUsersAttendance(attendanceState: AttendanceState) {
         savedAttendees.findUser()?.manuallyOverrideAttendanceState(attendanceState)
         binding.manyAvatarsView.setAttendees(savedAttendees)
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/calendar/CalendarEventBannerView.kt
@@ -53,9 +53,9 @@ class CalendarEventBannerView @JvmOverloads constructor(
     private val binding by lazy { ViewCalendarEventBannerBinding.inflate(LayoutInflater.from(context), this, true) }
 
     private var useInfomaniakCalendarRoute: Boolean = false
-    // This value can be saved locally because it's used in only used in one situation. It's used when calling setAttendanceUi
-    // from onlyUpdateAttendance. The method onlyUpdateAttendance could only have been called if shouldDisplayReplyOptions hasn't
-    // changed since the last loadCalendarEvent call so it's safe to use it here.
+    // This value can be saved locally because it's only used in one situation : when calling setAttendanceUi() from
+    // onlyUpdateAttendance(). The method onlyUpdateAttendance() can only be called if shouldDisplayReplyOptions hasn't changed
+    // since the last loadCalendarEvent() call so it's safe to use it here.
     private var shouldDisplayReplyOptions: Boolean = false
     private var attachmentResource: String = ""
 
@@ -159,9 +159,8 @@ class CalendarEventBannerView @JvmOverloads constructor(
 
     private fun setAttendanceUi(attendees: List<Attendee>, shouldDisplayReplyOptions: Boolean) = with(binding) {
         val userAsAttendee = attendees.findUser()
-        val iAmInvited = userAsAttendee != null
 
-        notPartOfAttendeesWarning.isGone = iAmInvited
+        notPartOfAttendeesWarning.isVisible = userAsAttendee == null
         participationButtons.isVisible = shouldDisplayReplyOptions
         attendeesLayout.isGone = attendees.isEmpty()
 
@@ -189,9 +188,8 @@ class CalendarEventBannerView @JvmOverloads constructor(
 
     private fun MaterialButton.handleChoiceButtonBehavior(attendanceState: AttendanceState) {
         setOnClickListener {
-            val previouslyUnchecked = isChecked
-
-            if (previouslyUnchecked) {
+            // Do nothing if it was already selected
+            if (isChecked) {
                 resetChoiceButtons()
                 replyToCalendarEvent?.invoke(attendanceState)
             }

--- a/app/src/main/java/com/infomaniak/mail/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Extensions.kt
@@ -71,6 +71,7 @@ import com.infomaniak.mail.data.LocalSettings.ThreadDensity
 import com.infomaniak.mail.data.models.Attachment
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
+import com.infomaniak.mail.data.models.correspondent.Correspondent
 import com.infomaniak.mail.data.models.correspondent.MergedContact
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.data.models.draft.Draft.DraftMode
@@ -627,6 +628,10 @@ fun ShapeableImageView.setInnerStrokeWidth(strokeWidth: Float) {
     val halfStrokeWidth = (strokeWidth / 2.0f).roundToInt()
     setPaddingRelative(halfStrokeWidth, halfStrokeWidth, halfStrokeWidth, halfStrokeWidth)
 }
+
+fun <T : Correspondent> List<T>.findUser(): T? = firstOrNull(Correspondent::isMe)
+
+fun List<Correspondent>.isUserIn(): Boolean = findUser() != null
 
 fun ViewPager2.removeOverScrollForApiBelow31() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -249,6 +249,7 @@
     <string name="errorAlreadyLinkedMailbox">Diese E-Mail-Adresse ist bereits mit Ihrem Konto verknüpft</string>
     <string name="errorAtLeastOneRecipient">Es ist mindestens ein Empfänger erforderlich</string>
     <string name="errorAttachmentNotFound">Dateianhang unauffindbar</string>
+    <string name="errorCalendarChoiceCouldNotBeSent">Beim Senden Ihrer Auswahl ist ein Fehler aufgetreten</string>
     <string name="errorCorruptAttachment">Der Entwurf konnte nicht bearbeitet werden, ein Anhang ist beschädigt</string>
     <string name="errorDraftNotFound">Entwurf unauffindbar</string>
     <string name="errorEditScheduledMessage">Geplante oder versendete Nachrichten können nicht geändert werden</string>
@@ -454,6 +455,7 @@
     <string name="settingsTransferEmailsTitle">E-Mails übertragen</string>
     <string name="settingsTransferInBody">Im Nachrichtentext</string>
     <string name="snackbarBlockUserConfirmation">Absender ist jetzt blockiert</string>
+    <string name="snackbarCalendarChoiceSent">Auswahl erfolgreich gesendet</string>
     <string name="snackbarContactSaved">Neuer Kontakt erfolgreich registriert</string>
     <string name="snackbarDeletedConversation">Unterhaltung existiert nicht mehr</string>
     <string name="snackbarDisplayProblemReported">Anzeigeproblem gemeldet</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -249,7 +249,7 @@
     <string name="errorAlreadyLinkedMailbox">Diese E-Mail-Adresse ist bereits mit Ihrem Konto verknüpft</string>
     <string name="errorAtLeastOneRecipient">Es ist mindestens ein Empfänger erforderlich</string>
     <string name="errorAttachmentNotFound">Dateianhang unauffindbar</string>
-    <string name="errorCalendarChoiceCouldNotBeSent">Beim Senden Ihrer Auswahl ist ein Fehler aufgetreten</string>
+    <string name="errorCalendarChoiceCouldNotBeSent">Beim Senden Ihrer Antwort ist ein Fehler aufgetreten</string>
     <string name="errorCorruptAttachment">Der Entwurf konnte nicht bearbeitet werden, ein Anhang ist beschädigt</string>
     <string name="errorDraftNotFound">Entwurf unauffindbar</string>
     <string name="errorEditScheduledMessage">Geplante oder versendete Nachrichten können nicht geändert werden</string>
@@ -455,7 +455,7 @@
     <string name="settingsTransferEmailsTitle">E-Mails übertragen</string>
     <string name="settingsTransferInBody">Im Nachrichtentext</string>
     <string name="snackbarBlockUserConfirmation">Absender ist jetzt blockiert</string>
-    <string name="snackbarCalendarChoiceSent">Auswahl erfolgreich gesendet</string>
+    <string name="snackbarCalendarChoiceSent">Antwort berücksichtigt</string>
     <string name="snackbarContactSaved">Neuer Kontakt erfolgreich registriert</string>
     <string name="snackbarDeletedConversation">Unterhaltung existiert nicht mehr</string>
     <string name="snackbarDisplayProblemReported">Anzeigeproblem gemeldet</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -249,6 +249,7 @@
     <string name="errorAlreadyLinkedMailbox">Esta dirección de correo electrónico ya está vinculada a su cuenta</string>
     <string name="errorAtLeastOneRecipient">Se precisa al menos un destinatario</string>
     <string name="errorAttachmentNotFound">No se ha encontrado el adjunto</string>
+    <string name="errorCalendarChoiceCouldNotBeSent">Se ha producido un error al enviar su elección</string>
     <string name="errorCorruptAttachment">No se ha podido gestionar el borrador, un archivo adjunto está dañado</string>
     <string name="errorDraftNotFound">No se puede encontrar el borrador</string>
     <string name="errorEditScheduledMessage">Imposible modificar un mensaje programado o enviado</string>
@@ -454,6 +455,7 @@
     <string name="settingsTransferEmailsTitle">Transferir correos electrónicos</string>
     <string name="settingsTransferInBody">En el cuerpo del mensaje</string>
     <string name="snackbarBlockUserConfirmation">El remitente está bloqueado</string>
+    <string name="snackbarCalendarChoiceSent">Elección enviada correctamente</string>
     <string name="snackbarContactSaved">Nuevo contacto registrado correctamente</string>
     <string name="snackbarDeletedConversation">La conversación ya no existe</string>
     <string name="snackbarDisplayProblemReported">Problema de visualización notificado</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -249,7 +249,7 @@
     <string name="errorAlreadyLinkedMailbox">Esta dirección de correo electrónico ya está vinculada a su cuenta</string>
     <string name="errorAtLeastOneRecipient">Se precisa al menos un destinatario</string>
     <string name="errorAttachmentNotFound">No se ha encontrado el adjunto</string>
-    <string name="errorCalendarChoiceCouldNotBeSent">Se ha producido un error al enviar su elección</string>
+    <string name="errorCalendarChoiceCouldNotBeSent">Se ha producido un error al enviar su respuesta</string>
     <string name="errorCorruptAttachment">No se ha podido gestionar el borrador, un archivo adjunto está dañado</string>
     <string name="errorDraftNotFound">No se puede encontrar el borrador</string>
     <string name="errorEditScheduledMessage">Imposible modificar un mensaje programado o enviado</string>
@@ -455,7 +455,7 @@
     <string name="settingsTransferEmailsTitle">Transferir correos electrónicos</string>
     <string name="settingsTransferInBody">En el cuerpo del mensaje</string>
     <string name="snackbarBlockUserConfirmation">El remitente está bloqueado</string>
-    <string name="snackbarCalendarChoiceSent">Elección enviada correctamente</string>
+    <string name="snackbarCalendarChoiceSent">Respuesta tenida en cuenta</string>
     <string name="snackbarContactSaved">Nuevo contacto registrado correctamente</string>
     <string name="snackbarDeletedConversation">La conversación ya no existe</string>
     <string name="snackbarDisplayProblemReported">Problema de visualización notificado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -251,7 +251,7 @@
     <string name="errorAlreadyLinkedMailbox">Cette adresse mail est déjà liée à votre compte</string>
     <string name="errorAtLeastOneRecipient">Il faut au minimum un destinataire</string>
     <string name="errorAttachmentNotFound">Pièce jointe introuvable</string>
-    <string name="errorCalendarChoiceCouldNotBeSent">Une erreur s’est produite lors de l’envoi de votre choix</string>
+    <string name="errorCalendarChoiceCouldNotBeSent">Une erreur s’est produite lors de l’envoi de votre réponse</string>
     <string name="errorCorruptAttachment">Échec du traitement du brouillon, une pièce jointe est corrompue</string>
     <string name="errorDraftNotFound">Brouillon introuvable</string>
     <string name="errorEditScheduledMessage">Impossible de modifier un message planifié ou envoyé</string>
@@ -398,6 +398,14 @@
     <string name="settingsAccentColorDescription">Choisissez la couleur d’accentuation de l’application</string>
     <string name="settingsAiEngineDescription">Sélectionnez votre assistant à la rédaction</string>
     <string name="settingsAppLock">Verrouillage de l’application</string>
+    <string name="settingsAutoAdvanceDescription">Sélectionnez ce que vous souhaitez afficher lorsqu’un message est archivé ou supprimé\u0020</string>
+    <string name="settingsAutoAdvanceFollowingThreadDescription">Afficher la conversation suivante après archivage ou suppression</string>
+    <string name="settingsAutoAdvanceFollowingThreadTitle">Conversation suivante</string>
+    <string name="settingsAutoAdvanceListOfThreadsDescription">Afficher la liste des conversations après archivage ou suppression</string>
+    <string name="settingsAutoAdvanceListOfThreadsTitle">Liste des conversations</string>
+    <string name="settingsAutoAdvancePreviousThreadDescription">Afficher la conversation précédente après archivage ou suppression</string>
+    <string name="settingsAutoAdvancePreviousThreadTitle">Conversation précédente</string>
+    <string name="settingsAutoAdvanceTitle">Avance Automatique</string>
     <string name="settingsCancellationPeriodDescription">Vous avez la possibilité d’annuler l’envoi de votre e-mail jusqu’à 30 secondes</string>
     <string name="settingsCancellationPeriodTitle">Délai d’annulation d’envoi</string>
     <string name="settingsDefault">Par défaut</string>
@@ -463,7 +471,7 @@
     <string name="settingsTransferEmailsTitle">Transférer les e-mails</string>
     <string name="settingsTransferInBody">Dans le corps du message</string>
     <string name="snackbarBlockUserConfirmation">L’expéditeur est maintenant bloqué</string>
-    <string name="snackbarCalendarChoiceSent">Choix envoyé avec succès</string>
+    <string name="snackbarCalendarChoiceSent">Réponse prise en compte</string>
     <string name="snackbarContactSaved">Nouveau contact enregistré avec succès</string>
     <string name="snackbarDeletedConversation">La conversation n’existe plus</string>
     <string name="snackbarDisplayProblemReported">Problème d’affichage signalé</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -251,6 +251,7 @@
     <string name="errorAlreadyLinkedMailbox">Cette adresse mail est déjà liée à votre compte</string>
     <string name="errorAtLeastOneRecipient">Il faut au minimum un destinataire</string>
     <string name="errorAttachmentNotFound">Pièce jointe introuvable</string>
+    <string name="errorCalendarChoiceCouldNotBeSent">Une erreur s’est produite lors de l’envoi de votre choix</string>
     <string name="errorCorruptAttachment">Échec du traitement du brouillon, une pièce jointe est corrompue</string>
     <string name="errorDraftNotFound">Brouillon introuvable</string>
     <string name="errorEditScheduledMessage">Impossible de modifier un message planifié ou envoyé</string>
@@ -462,6 +463,7 @@
     <string name="settingsTransferEmailsTitle">Transférer les e-mails</string>
     <string name="settingsTransferInBody">Dans le corps du message</string>
     <string name="snackbarBlockUserConfirmation">L’expéditeur est maintenant bloqué</string>
+    <string name="snackbarCalendarChoiceSent">Choix envoyé avec succès</string>
     <string name="snackbarContactSaved">Nouveau contact enregistré avec succès</string>
     <string name="snackbarDeletedConversation">La conversation n’existe plus</string>
     <string name="snackbarDisplayProblemReported">Problème d’affichage signalé</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -249,6 +249,7 @@
     <string name="errorAlreadyLinkedMailbox">Questo indirizzo e-mail è già collegato al vostro account</string>
     <string name="errorAtLeastOneRecipient">È richiesto almeno un destinatario</string>
     <string name="errorAttachmentNotFound">Allegato non trovato</string>
+    <string name="errorCalendarChoiceCouldNotBeSent">Si è verificato un errore durante l’invio della scelta</string>
     <string name="errorCorruptAttachment">Impossibile gestire la bozza, un allegato è danneggiato</string>
     <string name="errorDraftNotFound">Bozza non trovata</string>
     <string name="errorEditScheduledMessage">Impossibile modificare un messaggio pianificato o inviato</string>
@@ -454,6 +455,7 @@
     <string name="settingsTransferEmailsTitle">Trasferimento di e-mail</string>
     <string name="settingsTransferInBody">Nel corpo del messaggio</string>
     <string name="snackbarBlockUserConfirmation">Il mittente è ora bloccato</string>
+    <string name="snackbarCalendarChoiceSent">Scelta inviata con successo</string>
     <string name="snackbarContactSaved">Nuovo contatto registrato con successo</string>
     <string name="snackbarDeletedConversation">La conversazione non esiste più</string>
     <string name="snackbarDisplayProblemReported">Problema di visualizzazione segnalato</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -249,7 +249,7 @@
     <string name="errorAlreadyLinkedMailbox">Questo indirizzo e-mail è già collegato al vostro account</string>
     <string name="errorAtLeastOneRecipient">È richiesto almeno un destinatario</string>
     <string name="errorAttachmentNotFound">Allegato non trovato</string>
-    <string name="errorCalendarChoiceCouldNotBeSent">Si è verificato un errore durante l’invio della scelta</string>
+    <string name="errorCalendarChoiceCouldNotBeSent">Si è verificato un errore nell’invio della risposta</string>
     <string name="errorCorruptAttachment">Impossibile gestire la bozza, un allegato è danneggiato</string>
     <string name="errorDraftNotFound">Bozza non trovata</string>
     <string name="errorEditScheduledMessage">Impossibile modificare un messaggio pianificato o inviato</string>
@@ -455,7 +455,7 @@
     <string name="settingsTransferEmailsTitle">Trasferimento di e-mail</string>
     <string name="settingsTransferInBody">Nel corpo del messaggio</string>
     <string name="snackbarBlockUserConfirmation">Il mittente è ora bloccato</string>
-    <string name="snackbarCalendarChoiceSent">Scelta inviata con successo</string>
+    <string name="snackbarCalendarChoiceSent">Risposta presa in considerazione</string>
     <string name="snackbarContactSaved">Nuovo contatto registrato con successo</string>
     <string name="snackbarDeletedConversation">La conversazione non esiste più</string>
     <string name="snackbarDisplayProblemReported">Problema di visualizzazione segnalato</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -255,7 +255,7 @@
     <string name="errorAlreadyLinkedMailbox">This email address is already linked to your account</string>
     <string name="errorAtLeastOneRecipient">At least one recipient is required</string>
     <string name="errorAttachmentNotFound">Attachment cannot be found</string>
-    <string name="errorCalendarChoiceCouldNotBeSent">An error occurred while sending your choice</string>
+    <string name="errorCalendarChoiceCouldNotBeSent">An error has occurred while sending your answer</string>
     <string name="errorCorruptAttachment">Failed to handle draft, an attachment is corrupted</string>
     <string name="errorDraftNotFound">Draft cannot be found</string>
     <string name="errorEditScheduledMessage">Scheduled or sent messages cannot be edited</string>
@@ -461,7 +461,7 @@
     <string name="settingsTransferEmailsTitle">Transfer emails</string>
     <string name="settingsTransferInBody">In the message body</string>
     <string name="snackbarBlockUserConfirmation">Sender is now blocked</string>
-    <string name="snackbarCalendarChoiceSent">Choice sent successfully</string>
+    <string name="snackbarCalendarChoiceSent">Response taken into account</string>
     <string name="snackbarContactSaved">New contact successfully registered</string>
     <string name="snackbarDeletedConversation">Conversation no longer exists</string>
     <string name="snackbarDisplayProblemReported">Display problem reported</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -255,6 +255,7 @@
     <string name="errorAlreadyLinkedMailbox">This email address is already linked to your account</string>
     <string name="errorAtLeastOneRecipient">At least one recipient is required</string>
     <string name="errorAttachmentNotFound">Attachment cannot be found</string>
+    <string name="errorCalendarChoiceCouldNotBeSent">An error occurred while sending your choice</string>
     <string name="errorCorruptAttachment">Failed to handle draft, an attachment is corrupted</string>
     <string name="errorDraftNotFound">Draft cannot be found</string>
     <string name="errorEditScheduledMessage">Scheduled or sent messages cannot be edited</string>
@@ -460,6 +461,7 @@
     <string name="settingsTransferEmailsTitle">Transfer emails</string>
     <string name="settingsTransferInBody">In the message body</string>
     <string name="snackbarBlockUserConfirmation">Sender is now blocked</string>
+    <string name="snackbarCalendarChoiceSent">Choice sent successfully</string>
     <string name="snackbarContactSaved">New contact successfully registered</string>
     <string name="snackbarDeletedConversation">Conversation no longer exists</string>
     <string name="snackbarDisplayProblemReported">Display problem reported</string>

--- a/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
+++ b/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
@@ -57,7 +57,7 @@ class CalendarEventResponseTest {
         }
         assertFalse(ThreadAdapter.MessageDiffCallback.everythingButAttendeesIsTheSame(message, otherThingsButAttendeesChanged))
 
-        // If only the attendance state of Attendees has changed in the Message, we need to not detect the change
+        // If only the attendance state of Attendees has changed in the Message, the change must NOT be detected
         val userStoredEvent2 = getBasicCalendarEvent(AttendanceState.ACCEPTED)
         val response2 = getBasicCalendarEventResponse(userStoredEvent2, false)
         val onlyAttendeesChanged = Message().apply {
@@ -67,7 +67,7 @@ class CalendarEventResponseTest {
         }
         assertTrue(ThreadAdapter.MessageDiffCallback.everythingButAttendeesIsTheSame(message, onlyAttendeesChanged))
 
-        // If both the attendance state and another field has changed, it needs to detect the change
+        // If both the attendance state and another field has changed, the change must be detected
         val otherThingsAndAttendeesChanged = Message().apply {
             body = filledBody
             splitBody = null
@@ -88,12 +88,12 @@ class CalendarEventResponseTest {
         val otherThingsButAttendeesChanged = getBasicCalendarEventResponse(userStoredEvent1, true)
         assertFalse(response.everythingButAttendeesIsTheSame(otherThingsButAttendeesChanged))
 
-        // If only the attendance state of Attendees has changed in the CalendarEventResponse, we need to not detect the change
+        // If only the attendance state of Attendees has changed in the CalendarEventResponse, the change must NOT be detected
         val userStoredEvent2 = getBasicCalendarEvent(AttendanceState.ACCEPTED)
         val onlyAttendeesChanged = getBasicCalendarEventResponse(userStoredEvent2, false)
         assertTrue(response.everythingButAttendeesIsTheSame(onlyAttendeesChanged))
 
-        // If both the attendance state and another field has changed, it needs to detect the change
+        // If both the attendance state and another field has changed, the change must be detected
         val otherThingsAndAttendeesChanged = getBasicCalendarEventResponse(userStoredEvent2, true)
         assertFalse(response.everythingButAttendeesIsTheSame(otherThingsAndAttendeesChanged))
     }
@@ -111,11 +111,11 @@ class CalendarEventResponseTest {
         }
         assertFalse(event.everythingButAttendeesIsTheSame(otherThingsButAttendeesHaveChanged))
 
-        // If only the attendance state of Attendees has changed in the CalendarEvent, we need to not detect the change
+        // If only the attendance state of Attendees has changed in the CalendarEvent, the change must NOT be detected
         val onlyAttendeesChanged = getBasicCalendarEvent(AttendanceState.ACCEPTED)
         assertTrue(event.everythingButAttendeesIsTheSame(onlyAttendeesChanged))
 
-        // If both the attendance state and another field has changed, it needs to detect the change
+        // If both the attendance state and another field has changed, the change must be detected
         val otherThingsAndAttendeesChanged = getBasicCalendarEvent(AttendanceState.ACCEPTED).apply {
             end = tomorrow
         }

--- a/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
+++ b/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail
+
+import com.infomaniak.mail.data.models.calendar.Attendee
+import com.infomaniak.mail.data.models.calendar.Attendee.AttendanceState
+import com.infomaniak.mail.data.models.calendar.CalendarEvent
+import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
+import com.infomaniak.mail.data.models.message.Body
+import com.infomaniak.mail.data.models.message.Message
+import com.infomaniak.mail.ui.main.thread.ThreadAdapter
+import io.realm.kotlin.ext.realmListOf
+import io.realm.kotlin.types.RealmInstant
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CalendarEventResponseTest {
+
+    @Test
+    fun messageChange_isDetected() {
+        val userStoredEvent1 = getBasicCalendarEvent(AttendanceState.TENTATIVE)
+        val response1 = getBasicCalendarEventResponse(userStoredEvent1, false)
+        val message = Message().apply {
+            body = null
+            splitBody = null
+            latestCalendarEventResponse = response1
+        }
+
+        // If nothing changed at all, no change should be detected
+        assertTrue(ThreadAdapter.MessageDiffCallback.everythingButAttendeesIsTheSame(message, message))
+
+        // If data inside the Message have changed, like its heavy data being downloaded, then we need to detect the change
+        val filledBody = Body().apply {
+            value = "<html><body>Hello</body></html>"
+            type = "text/html"
+        }
+        val otherThingsButAttendeesChanged = Message().apply {
+            body = filledBody
+            splitBody = null
+            latestCalendarEventResponse = response1
+        }
+        assertFalse(ThreadAdapter.MessageDiffCallback.everythingButAttendeesIsTheSame(message, otherThingsButAttendeesChanged))
+
+        // If only the attendance state of Attendees has changed in the Message, we need to not detect the change
+        val userStoredEvent2 = getBasicCalendarEvent(AttendanceState.ACCEPTED)
+        val response2 = getBasicCalendarEventResponse(userStoredEvent2, false)
+        val onlyAttendeesChanged = Message().apply {
+            body = null
+            splitBody = null
+            latestCalendarEventResponse = response2
+        }
+        assertTrue(ThreadAdapter.MessageDiffCallback.everythingButAttendeesIsTheSame(message, onlyAttendeesChanged))
+
+        // If both the attendance state and another field has changed, it needs to detect the change
+        val otherThingsAndAttendeesChanged = Message().apply {
+            body = filledBody
+            splitBody = null
+            latestCalendarEventResponse = response2
+        }
+        assertFalse(ThreadAdapter.MessageDiffCallback.everythingButAttendeesIsTheSame(message, otherThingsAndAttendeesChanged))
+    }
+
+    @Test
+    fun calendarEventResponseChange_isDetected() {
+        val userStoredEvent1 = getBasicCalendarEvent(AttendanceState.TENTATIVE)
+        val response = getBasicCalendarEventResponse(userStoredEvent1, false)
+
+        // If nothing changed at all, no change should be detected
+        assertTrue(response.everythingButAttendeesIsTheSame(response))
+
+        // If data inside the CalendarEventResponse have changed, like the event being deleted, then we need to detect the change
+        val otherThingsButAttendeesChanged = getBasicCalendarEventResponse(userStoredEvent1, true)
+        assertFalse(response.everythingButAttendeesIsTheSame(otherThingsButAttendeesChanged))
+
+        // If only the attendance state of Attendees has changed in the CalendarEventResponse, we need to not detect the change
+        val userStoredEvent2 = getBasicCalendarEvent(AttendanceState.ACCEPTED)
+        val onlyAttendeesChanged = getBasicCalendarEventResponse(userStoredEvent2, false)
+        assertTrue(response.everythingButAttendeesIsTheSame(onlyAttendeesChanged))
+
+        // If both the attendance state and another field has changed, it needs to detect the change
+        val otherThingsAndAttendeesChanged = getBasicCalendarEventResponse(userStoredEvent2, true)
+        assertFalse(response.everythingButAttendeesIsTheSame(otherThingsAndAttendeesChanged))
+    }
+
+    @Test
+    fun calendarEventChange_isDetected() {
+        val event = getBasicCalendarEvent(AttendanceState.TENTATIVE)
+
+        // If nothing changed at all, no change should be detected
+        assertTrue(event.everythingButAttendeesIsTheSame(event))
+
+        // If data inside the CalendarEvent have changed, like the date of the event, then we need to detect the change
+        val otherThingsButAttendeesHaveChanged = getBasicCalendarEvent(AttendanceState.TENTATIVE).apply {
+            end = tomorrow
+        }
+        assertFalse(event.everythingButAttendeesIsTheSame(otherThingsButAttendeesHaveChanged))
+
+        // If only the attendance state of Attendees has changed in the CalendarEvent, we need to not detect the change
+        val onlyAttendeesChanged = getBasicCalendarEvent(AttendanceState.ACCEPTED)
+        assertTrue(event.everythingButAttendeesIsTheSame(onlyAttendeesChanged))
+
+        // If both the attendance state and another field has changed, it needs to detect the change
+        val otherThingsAndAttendeesChanged = getBasicCalendarEvent(AttendanceState.ACCEPTED).apply {
+            end = tomorrow
+        }
+        assertFalse(event.everythingButAttendeesIsTheSame(otherThingsAndAttendeesChanged))
+    }
+
+    private fun getBasicCalendarEvent(thirdGuyAttendanceState: AttendanceState): CalendarEvent {
+        return CalendarEvent(
+            id = 123,
+            type = "VCALENDAR",
+            title = "Cool event",
+            location = null,
+            isFullDay = false,
+            start = today,
+            end = inOneHour,
+            attendees = realmListOf(
+                Attendee("alice@test.com", "Alice", true, AttendanceState.ACCEPTED.apiValue),
+                Attendee("bob@test.com", "Bob", true, AttendanceState.NEEDS_ACTION.apiValue),
+                Attendee("charlie@test.com", "Charlie", true, thirdGuyAttendanceState.apiValue),
+            ),
+        )
+    }
+
+    private fun getBasicCalendarEventResponse(
+        userStoredEvent: CalendarEvent,
+        isUserStoredEventDeleted: Boolean,
+    ): CalendarEventResponse {
+        val attachmentEvent = getBasicCalendarEvent(AttendanceState.NEEDS_ACTION)
+        return CalendarEventResponse(userStoredEvent, isUserStoredEventDeleted, attachmentEvent, "REQUEST")
+    }
+
+    companion object {
+        val today = RealmInstant.from(1706700836, 0)
+        val inOneHour = RealmInstant.from(1706704436, 0)
+        val tomorrow = RealmInstant.from(1706792315, 0)
+    }
+}

--- a/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
+++ b/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
@@ -45,7 +45,7 @@ class CalendarEventResponseTest {
         // If nothing changed at all, no change should be detected
         assertTrue(ThreadAdapter.MessageDiffCallback.everythingButAttendeesIsTheSame(message, message))
 
-        // If data inside the Message have changed, like its heavy data being downloaded, then we need to detect the change
+        // If data inside the Message have changed, like its heavy data being downloaded, the change must be detected
         val filledBody = Body().apply {
             value = "<html><body>Hello</body></html>"
             type = "text/html"
@@ -84,7 +84,7 @@ class CalendarEventResponseTest {
         // If nothing changed at all, no change should be detected
         assertTrue(response.everythingButAttendeesIsTheSame(response))
 
-        // If data inside the CalendarEventResponse have changed, like the event being deleted, then we need to detect the change
+        // If data inside the CalendarEventResponse have changed, like the event being deleted, the change must be detected
         val otherThingsButAttendeesChanged = getBasicCalendarEventResponse(userStoredEvent1, true)
         assertFalse(response.everythingButAttendeesIsTheSame(otherThingsButAttendeesChanged))
 
@@ -105,7 +105,7 @@ class CalendarEventResponseTest {
         // If nothing changed at all, no change should be detected
         assertTrue(event.everythingButAttendeesIsTheSame(event))
 
-        // If data inside the CalendarEvent have changed, like the date of the event, then we need to detect the change
+        // If data inside the CalendarEvent have changed, like the date of the event, the change must be detected
         val otherThingsButAttendeesHaveChanged = getBasicCalendarEvent(AttendanceState.TENTATIVE).apply {
             end = tomorrow
         }

--- a/app/src/test/java/com/infomaniak/mail/ExampleUnitTest.kt
+++ b/app/src/test/java/com/infomaniak/mail/ExampleUnitTest.kt
@@ -1,7 +1,24 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.infomaniak.mail
 
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,8 @@ googleServices = "4.4.0"
 hiltAndroid = "2.50"
 hiltAndroidx = "1.1.0"
 jsoup = "1.17.2"
-junitJupiterEngine = "5.10.1"
+junit = "4.13.2"
+junitVersion = "1.1.5"
 kapt = "1.8.22"
 kotlin = "1.9.22"
 ksp = "1.9.22-1.0.16"
@@ -19,7 +20,6 @@ navigation = "2.7.6"
 realmKotlin = "1.13.0"
 sentryAndroidFragment = "7.1.0"
 slidingPaneLayout = "1.2.0"
-testRunner = "1.5.2"
 webkit = "1.9.0"
 workConcurrentFutures = "1.1.0"
 workRuntimeKtx = "2.9.0"
@@ -46,8 +46,8 @@ webkit = { module = "androidx.webkit:webkit", version.ref = "webkit" }
 work-concurrent-futures = { module = "androidx.concurrent:concurrent-futures-ktx", version.ref = "workConcurrentFutures" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 # Unit tests
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiterEngine" }
-test-runner = { module = "androidx.test:runner", version.ref = "testRunner" }
+ext-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
+junit = { module = "junit:junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
The only way to have a not too ugly result was to handle the user's status change locally and not fetch the API to not trigger the adapter and bind the whole message again causing it to blink after each click.

This also means that right now, after the user has replied and left the thread, if he loses his internet connexion and comes back in the thread, the status of the user will be the one we had inside Realm when he last opened the thread and not the one he answered with. I think that this can be considered uncommon enough to let it slide

---

Nevermind, the adapter now detects if only the attendance state of attendee have changed and if so, only the precise UI elements associated to this get to bind instead of the whole message

Depends on #1670 