### PR TITLE
Stop detecting outlook blockquotes

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023 Infomaniak Network SA
+ * Copyright (C) 2023-2024 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,7 +39,9 @@ object MessageBodyUtils {
 
     private val quoteDescriptors = arrayOf(
         "blockquote[type=cite]", // macOS and iOS mail client
-        "#divRplyFwdMsg", // Microsoft Outlook
+        // The reply and forward #divRplyFwdMsg div only contains the header, the previous message body is written right next to
+        // this div and can't be detected
+        // "#divRplyFwdMsg", // Microsoft Outlook
         "#isForwardContent",
         "#isReplyContent",
         "#mailcontent:not(table)",


### PR DESCRIPTION
The id we used to detect outlook blockquotes is not enough. The div with this id only contains the header of the reply/forward but the content of the body of the previous email is right next to this div, at the same level as the div and was therefore not detected.

Instead of half detecting outlook blockquotes, don't detect anything for now until we truly detect them correctly