### PR TITLE
fix: MessageWebviewClient throw an IllegalStateException [RLM_ERR_INVALIDATED_OBJECT]

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/MessageWebViewClient.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/MessageWebViewClient.kt
@@ -100,9 +100,10 @@ class MessageWebViewClient(
     }
 
     override fun onPageFinished(webView: WebView, url: String?) {
-        webView.loadUrl("javascript:removeAllProperties(); normalizeMessageWidth(${webView.width.toDp()}, '$messageUid')")
-        super.onPageFinished(webView, url)
-        onPageFinished?.invoke()
+        runCatchingRealm {
+            webView.loadUrl("javascript:removeAllProperties(); normalizeMessageWidth(${webView.width.toDp()}, '$messageUid')")
+            onPageFinished?.invoke()
+        }
     }
 
     fun unblockDistantResources() {


### PR DESCRIPTION

Fixes MAIL-ANDROID-3SZ
Fix #1752