### PR TITLE
Correctly trigger Chevron visibility updates

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -105,7 +105,7 @@ class NewMessageViewModel @Inject constructor(
 
     private var snapshot: DraftSnapshot? = null
 
-    var otherFieldsAreAllEmpty = SingleLiveEvent(true)
+    var otherFieldsAreAllEmpty = MutableLiveData(true)
     var initializeFieldsAsOpen = SingleLiveEvent<Boolean>()
     val importedAttachments = SingleLiveEvent<Pair<MutableList<Attachment>, ImportationResult>>()
     val isSendingAllowed = SingleLiveEvent(false)

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/RecipientFieldView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/RecipientFieldView.kt
@@ -166,8 +166,6 @@ class RecipientFieldView @JvmOverloads constructor(
 
     fun hideLoader() = with(binding) {
         textInput.isVisible = true
-        computeEndIconVisibility()
-
         loader.isGone = true
     }
 


### PR DESCRIPTION
The SingleLiveEvent is now a MutableLiveData because we want it to trigger when the Activity is recreated, so the chevron's visibility will be correctly computed.

Depends on #1766