### PR TITLE
Fix a crash when an Email's body in a Notification had too many characters

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
@@ -251,8 +251,8 @@ class FetchMessagesManager @Inject constructor(
         private val TAG: String = FetchMessagesManager::class.java.simpleName
 
         // Based on what seems to be the limit taken into account by NotificationCompat.Builder, we truncate some fields to avoid
-        // pendingIntent that will trigger TransactionTooLargeException further down the line like sentry id 41593. We don't need
-        // the extra data, it was bound to be truncated anyway
-        private const val MAX_CHAR_LIMIT = 5 * 1024
+        // pendingIntent that will trigger TransactionTooLargeException further down the line like Sentry ID 41593. We don't need
+        // the extra data, it was bound to be truncated anyway.
+        private const val MAX_CHAR_LIMIT = 5 * 1_024
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
@@ -203,9 +203,9 @@ class FetchMessagesManager @Inject constructor(
                 ?: formattedPreview
         }
 
-        val subject = appContext.formatSubject(message.subject)
+        val subject = appContext.formatSubject(message.subject).take(MAX_CHAR_LIMIT)
         val formattedBody = body.replace("\\n+\\s*".toRegex(), "\n") // Ignore multiple/start whitespaces
-        val description = "$subject$formattedBody"
+        val description = "$subject$formattedBody".take(MAX_CHAR_LIMIT)
 
         // Show Message notification
         notificationUtils.showMessageNotification(
@@ -249,5 +249,10 @@ class FetchMessagesManager @Inject constructor(
 
     companion object {
         private val TAG: String = FetchMessagesManager::class.java.simpleName
+
+        // Based on what seems to be the limit taken into account by NotificationCompat.Builder, we truncate some fields to avoid
+        // pendingIntent that will trigger TransactionTooLargeException further down the line like sentry id 41593. We don't need
+        // the extra data, it was bound to be truncated anyway
+        private const val MAX_CHAR_LIMIT = 5 * 1024
     }
 }


### PR DESCRIPTION
Issue can be seen in sentry issues like the id 41593