### PR TITLE
Only save Draft when adding Attachment

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListMultiSelection.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListMultiSelection.kt
@@ -44,7 +44,7 @@ import com.infomaniak.mail.utils.extensions.updateNavigationBarColor
 class ThreadListMultiSelection {
 
     lateinit var mainViewModel: MainViewModel
-    lateinit var threadListFragment: ThreadListFragment
+    private lateinit var threadListFragment: ThreadListFragment
     lateinit var unlockSwipeActionsIfSet: () -> Unit
     lateinit var localSettings: LocalSettings
 

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -475,7 +475,8 @@ class NewMessageFragment : Fragment() {
             if (isFirstTime) {
                 isFirstTime = false
                 observeImportAttachments()
-            } else {
+            } else if (attachments.count() > attachmentAdapter.itemCount) {
+                // If we are adding Attachments, directly save the Draft, so the Attachments' upload starts now.
                 saveDraft()
             }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -477,6 +477,7 @@ class NewMessageFragment : Fragment() {
                 observeImportAttachments()
             } else if (attachments.count() > attachmentAdapter.itemCount) {
                 // If we are adding Attachments, directly save the Draft, so the Attachments' upload starts now.
+                // TODO: Only save Attachments, and not the whole Draft.
                 saveDraft()
             }
 


### PR DESCRIPTION
We were saving Draft everytime we add or remove an Attachment, it's too much.
Now, we only save Draft when adding an Attachment.

Also, if we add a lot of Attachments at the same time _(via the FilePicker)_, and we delete them all while it's still saving, the DraftsActionsWorker will fail because it's won't find the files on the phone disk.
Now, it will just ignore these failures so the Draft can be saved.