### PR TITLE
Put back missing animations when removing Attachments

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -479,6 +479,8 @@ class NewMessageFragment : Fragment() {
                 saveDraft()
             }
 
+            // When removing an Attachment, both counts will be the same, because the Adapter is already notified.
+            // We don't want to notify it again, because it will cancel the nice animation.
             if (attachments.count() != attachmentAdapter.itemCount) attachmentAdapter.submitList(attachments)
 
             if (attachments.isEmpty()) TransitionManager.beginDelayedTransition(binding.root)

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -479,9 +479,9 @@ class NewMessageFragment : Fragment() {
                 saveDraft()
             }
 
-            val shouldTransition = attachmentAdapter.itemCount != 0 && attachments.isEmpty()
-            attachmentAdapter.submitList(attachments)
-            if (shouldTransition) TransitionManager.beginDelayedTransition(binding.root)
+            if (attachments.count() != attachmentAdapter.itemCount) attachmentAdapter.submitList(attachments)
+
+            if (attachments.isEmpty()) TransitionManager.beginDelayedTransition(binding.root)
             binding.attachmentsRecyclerView.isVisible = attachments.isNotEmpty()
 
             updateIsSendingAllowed(attachments)

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -636,7 +636,7 @@ class NewMessageViewModel @Inject constructor(
             val attachments = attachmentsLiveData.valueOrEmpty().toMutableList()
             val attachment = attachments[position]
             attachment.getUploadLocalFile()?.delete()
-            LocalStorageUtils.deleteAttachmentUploadDir(appContext, draftLocalUuid()!!, attachment.localUuid)
+            LocalStorageUtils.deleteAttachmentUploadDir(appContext, draftLocalUuid!!, attachment.localUuid)
             attachments.removeAt(position)
             attachmentsLiveData.value = attachments
         }.onFailure { exception ->


### PR DESCRIPTION
We were notifying twice the Adapter when removing an Attachment, so the animation was cancelled.