### PR TITLE
Remove SignatureAdapter memory leak

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -103,7 +103,7 @@ class NewMessageFragment : Fragment() {
     private var quoteWebView: WebView? = null
     private var signatureWebView: WebView? = null
 
-    private val signatureAdapter = SignatureAdapter(::onSignatureClicked)
+    private var signatureAdapter: SignatureAdapter? = SignatureAdapter(::onSignatureClicked)
     private val attachmentAdapter inline get() = binding.attachmentsRecyclerView.adapter as AttachmentAdapter
 
     private val newMessageActivity by lazy { requireActivity() as NewMessageActivity }
@@ -232,6 +232,7 @@ class NewMessageFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        signatureAdapter = null
         addressListPopupWindow = null
         quoteWebView?.destroyAndClearHistory()
         quoteWebView = null
@@ -375,7 +376,7 @@ class NewMessageFragment : Fragment() {
 
     private fun setupFromField(signatures: List<Signature>) = with(binding) {
 
-        signatureAdapter.setList(signatures)
+        signatureAdapter?.setList(signatures)
 
         fromMailAddress.post {
             runCatching {
@@ -429,7 +430,7 @@ class NewMessageFragment : Fragment() {
         fromLiveData.observe(viewLifecycleOwner) { (signature, shouldUpdateBodySignature) ->
             updateSelectedSignatureInFromField(signature)
             if (shouldUpdateBodySignature) updateBodySignature(signature)
-            signatureAdapter.updateSelectedSignature(signature.id)
+            signatureAdapter?.updateSelectedSignature(signature.id)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -103,7 +103,7 @@ class NewMessageFragment : Fragment() {
     private var quoteWebView: WebView? = null
     private var signatureWebView: WebView? = null
 
-    private var signatureAdapter: SignatureAdapter? = SignatureAdapter(::onSignatureClicked)
+    private var signatureAdapter: SignatureAdapter? = null
     private val attachmentAdapter inline get() = binding.attachmentsRecyclerView.adapter as AttachmentAdapter
 
     private val newMessageActivity by lazy { requireActivity() as NewMessageActivity }
@@ -376,7 +376,7 @@ class NewMessageFragment : Fragment() {
 
     private fun setupFromField(signatures: List<Signature>) = with(binding) {
 
-        signatureAdapter?.setList(signatures)
+        signatureAdapter = SignatureAdapter(::onSignatureClicked).also { it.setList(signatures) }
 
         fromMailAddress.post {
             runCatching {


### PR DESCRIPTION
Depends on #1834 

Remove strong reference about SignatureAdapter in NewMessageFragment.