### PR TITLE
Save Draft in Activity `onStop` instead of Fragment one

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -106,6 +106,9 @@ class NewMessageViewModel @Inject constructor(
     val uiQuoteLiveData = MutableLiveData<String?>()
     //endregion
 
+    var subjectTextField = ""
+    var bodyTextField = ""
+
     var isAutoCompletionOpened = false
     var isEditorExpanded = false
     var isExternalBannerManuallyClosed = false


### PR DESCRIPTION
Depends on #1832

Move the Draft saving from the Fragment's `onStop` to the Activity's `onStop` instead.
It will lessen the Toast spam of _"Saving draft"_.