### PR TITLE
Save Draft in Activity `onStop` instead of Fragment one

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/BaseActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/BaseActivity.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.ui
 
 import android.os.Bundle
+import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import com.infomaniak.lib.applock.LockActivity
 import com.infomaniak.lib.applock.Utils.isKeyguardSecure
@@ -67,4 +68,9 @@ open class BaseActivity : AppCompatActivity() {
             resetLastAppClosing()
         }
     }
+
+    fun getCurrentFragment(@IdRes fragmentContainerViewId: Int) = supportFragmentManager
+        .findFragmentById(fragmentContainerViewId)
+        ?.childFragmentManager
+        ?.primaryNavigationFragment
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -123,11 +123,7 @@ class MainActivity : BaseActivity() {
         }
     }
 
-    private val currentFragment
-        get() = supportFragmentManager
-            .findFragmentById(R.id.mainHostFragment)
-            ?.childFragmentManager
-            ?.primaryNavigationFragment
+    private val currentFragment get() = getCurrentFragment(R.id.mainHostFragment)
 
     @Inject
     lateinit var draftsActionsWorkerScheduler: DraftsActionsWorker.Scheduler

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageActivity.kt
@@ -29,12 +29,14 @@ import com.infomaniak.mail.BuildConfig
 import com.infomaniak.mail.MatomoMail.trackDestination
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.AppSettings
+import com.infomaniak.mail.data.models.draft.Draft
 import com.infomaniak.mail.databinding.ActivityNewMessageBinding
 import com.infomaniak.mail.ui.BaseActivity
 import com.infomaniak.mail.ui.LaunchActivity
 import com.infomaniak.mail.ui.main.SnackbarManager
 import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.SentryDebug
+import com.infomaniak.mail.workers.DraftsActionsWorker
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -51,6 +53,9 @@ class NewMessageActivity : BaseActivity() {
 
     @Inject
     lateinit var snackbarManager: SnackbarManager
+
+    @Inject
+    lateinit var draftsActionsWorkerScheduler: DraftsActionsWorker.Scheduler
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -108,5 +113,35 @@ class NewMessageActivity : BaseActivity() {
     private fun onDestinationChanged(destination: NavDestination, arguments: Bundle?) {
         SentryDebug.addNavigationBreadcrumb(destination.displayName, arguments)
         trackDestination(destination)
+    }
+
+
+    override fun onStop() {
+        saveDraft()
+        super.onStop()
+    }
+
+    fun saveDraft() {
+
+        val fragment = getCurrentFragment(R.id.newMessageHostFragment)
+
+        val (subjectValue, uiBodyValue) = if (fragment is NewMessageFragment) {
+            with(fragment.binding) { subjectTextField.text.toString() to bodyTextField.text.toString() }
+        } else {
+            with(newMessageViewModel) { subjectTextField to bodyTextField }
+        }
+
+        newMessageViewModel.executeDraftActionWhenStopping(
+            action = if (newMessageViewModel.shouldSendInsteadOfSave) Draft.DraftAction.SEND else Draft.DraftAction.SAVE,
+            isFinishing = isFinishing,
+            isTaskRoot = isTaskRoot,
+            subjectValue = subjectValue,
+            uiBodyValue = uiBodyValue,
+            startWorkerCallback = ::startWorker,
+        )
+    }
+
+    private fun startWorker() {
+        draftsActionsWorkerScheduler.scheduleWork(newMessageViewModel.draftLocalUuid())
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -106,6 +106,9 @@ class NewMessageViewModel @Inject constructor(
     val uiQuoteLiveData = MutableLiveData<String?>()
     //endregion
 
+    var subjectTextField = ""
+    var bodyTextField = ""
+
     var isAutoCompletionOpened = false
     var isEditorExpanded = false
     var isExternalBannerManuallyClosed = false


### PR DESCRIPTION
Move the Draft saving from the Fragment's `onStop` to the Activity's `onStop` instead.
It will lessen the Toast spam of _"Saving draft"_.