### PR TITLE
Use custom FormatterFileSize

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/Quotas.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Quotas.kt
@@ -18,8 +18,8 @@
 package com.infomaniak.mail.data.models
 
 import android.content.Context
+import com.infomaniak.lib.core.utils.humanReadableBinaryBytesCount
 import com.infomaniak.mail.R
-import com.infomaniak.mail.utils.extensions.humanReadableBinaryBytesCount
 import io.realm.kotlin.types.EmbeddedRealmObject
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/app/src/main/java/com/infomaniak/mail/data/models/Quotas.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Quotas.kt
@@ -18,8 +18,8 @@
 package com.infomaniak.mail.data.models
 
 import android.content.Context
-import android.text.format.Formatter
 import com.infomaniak.mail.R
+import com.infomaniak.mail.utils.extensions.humanReadableBinaryBytesCount
 import io.realm.kotlin.types.EmbeddedRealmObject
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -31,16 +31,12 @@ class Quotas : EmbeddedRealmObject {
     @SerialName("size")
     private var _size: Long = 0L
 
-    private val size: Long
-        get() {
-            val converted = _size * 1_000L / 1_024L // Convert from binary units to decimal units
-            return converted * 1_000L // Convert from KiloOctets to Octets
-        }
+    private val size: Long get() = _size * 1_000L // Convert from KiloOctets to Octets
 
     fun getText(context: Context): String {
 
-        val usedSize = Formatter.formatShortFileSize(context, size)
-        val maxSize = Formatter.formatShortFileSize(context, QUOTAS_MAX_SIZE)
+        val usedSize = context.humanReadableBinaryBytesCount(size)
+        val maxSize = context.humanReadableBinaryBytesCount(QUOTAS_MAX_SIZE)
 
         return context.getString(R.string.menuDrawerMailboxStorage, usedSize, maxSize)
     }
@@ -48,6 +44,7 @@ class Quotas : EmbeddedRealmObject {
     fun getProgress(): Int = ceil(100.0f * size.toFloat() / QUOTAS_MAX_SIZE.toFloat()).toInt()
 
     companion object {
-        private const val QUOTAS_MAX_SIZE = 20_000_000_000L // TODO: Get this value from API?
+        // TODO: Get this value from API ? If the free IK.ME storage size change, we won't know it.
+        private const val QUOTAS_MAX_SIZE = 20L * 1_024L * 1_024L * 1_024L // 20 GB
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/Quotas.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Quotas.kt
@@ -18,7 +18,7 @@
 package com.infomaniak.mail.data.models
 
 import android.content.Context
-import com.infomaniak.lib.core.utils.humanReadableBinaryBytesCount
+import com.infomaniak.lib.core.utils.FormatterFileSize.formatShortFileSize
 import com.infomaniak.mail.R
 import io.realm.kotlin.types.EmbeddedRealmObject
 import kotlinx.serialization.SerialName
@@ -35,8 +35,8 @@ class Quotas : EmbeddedRealmObject {
 
     fun getText(context: Context): String {
 
-        val usedSize = context.humanReadableBinaryBytesCount(size)
-        val maxSize = context.humanReadableBinaryBytesCount(QUOTAS_MAX_SIZE)
+        val usedSize = context.formatShortFileSize(size)
+        val maxSize = context.formatShortFileSize(QUOTAS_MAX_SIZE)
 
         return context.getString(R.string.menuDrawerMailboxStorage, usedSize, maxSize)
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -543,7 +543,7 @@ class ThreadListFragment : TwoPaneFragment(), SwipeRefreshLayout.OnRefreshListen
                 threadListViewModel.currentThreadsCount = threads.count()
                 SentryLog.i(
                     "UI",
-                    "Received threads: ${threadListViewModel.currentThreadsCount} | (${currentFolder.value?.displayForSentry()}})",
+                    "Received threads: ${threadListViewModel.currentThreadsCount} | (${currentFolder.value?.displayForSentry()})",
                 )
                 updateThreadsVisibility()
             }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -19,7 +19,6 @@ package com.infomaniak.mail.ui.main.thread
 
 import android.annotation.SuppressLint
 import android.net.Uri
-import android.text.format.Formatter
 import android.view.LayoutInflater
 import android.view.ScaleGestureDetector
 import android.view.View.OnClickListener
@@ -462,7 +461,7 @@ class ThreadAdapter(
             attachment.size
         }.reduce { accumulator: Long, size: Long -> accumulator + size }
 
-        return Formatter.formatShortFileSize(context, totalAttachmentsFileSizeInBytes)
+        return context.humanReadableBinaryBytesCount(totalAttachmentsFileSizeInBytes)
     }
 
     private fun MessageViewHolder.bindContent(message: Message) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -38,6 +38,7 @@ import androidx.viewbinding.ViewBinding
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
 import com.infomaniak.lib.core.utils.context
+import com.infomaniak.lib.core.utils.humanReadableBinaryBytesCount
 import com.infomaniak.lib.core.utils.isNightModeEnabled
 import com.infomaniak.mail.MatomoMail.trackMessageEvent
 import com.infomaniak.mail.R

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -37,8 +37,8 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.viewbinding.ViewBinding
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
+import com.infomaniak.lib.core.utils.FormatterFileSize.formatShortFileSize
 import com.infomaniak.lib.core.utils.context
-import com.infomaniak.lib.core.utils.humanReadableBinaryBytesCount
 import com.infomaniak.lib.core.utils.isNightModeEnabled
 import com.infomaniak.mail.MatomoMail.trackMessageEvent
 import com.infomaniak.mail.R
@@ -462,7 +462,7 @@ class ThreadAdapter(
             attachment.size
         }.reduce { accumulator: Long, size: Long -> accumulator + size }
 
-        return context.humanReadableBinaryBytesCount(totalAttachmentsFileSizeInBytes)
+        return context.formatShortFileSize(totalAttachmentsFileSizeInBytes)
     }
 
     private fun MessageViewHolder.bindContent(message: Message) {

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -107,11 +107,14 @@ import io.realm.kotlin.types.RealmObject
 import kotlinx.serialization.encodeToString
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import java.text.StringCharacterIterator
 import java.util.Calendar
 import java.util.Date
 import java.util.Scanner
 import kotlin.collections.set
+import kotlin.math.abs
 import kotlin.math.roundToInt
+import kotlin.math.sign
 
 //region Type alias
 // Explanation of this Map: Map<Email, Map<Name, MergedContact>>
@@ -243,6 +246,26 @@ fun WebView.initWebViewClientAndBridge(
     ).also {
         webViewClient = it
     }
+}
+
+fun Context.humanReadableBinaryBytesCount(bytes: Long): String {
+    val absBytes = if (bytes == Long.MIN_VALUE) Long.MAX_VALUE else abs(bytes)
+    if (absBytes < 1_024L) return "$bytes B"
+
+    var value = absBytes
+    val characters = StringCharacterIterator("KMGTPE")
+
+    var i = 40
+    while (i >= 0 && absBytes > 0xfffccccccccccccL shr i) {
+        value = value shr 10
+        characters.next()
+        i -= 10
+    }
+
+    value *= bytes.sign.toLong()
+
+    val locale = resources.configuration.getLocales().get(0)
+    return String.format(locale, "%.1f %cB", value / 1_024.0f, characters.current())
 }
 //endregion
 

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -249,8 +249,10 @@ fun WebView.initWebViewClientAndBridge(
 }
 
 fun Context.humanReadableBinaryBytesCount(bytes: Long): String {
+    val byteChar = "B"
+
     val absBytes = if (bytes == Long.MIN_VALUE) Long.MAX_VALUE else abs(bytes)
-    if (absBytes < 1_024L) return "$bytes B"
+    if (absBytes < 1_024L) return "$bytes $byteChar"
 
     var value = absBytes
     val characters = StringCharacterIterator("KMGTPE")
@@ -265,7 +267,7 @@ fun Context.humanReadableBinaryBytesCount(bytes: Long): String {
     value *= bytes.sign.toLong()
 
     val locale = resources.configuration.getLocales().get(0)
-    return String.format(locale, "%.1f %cB", value / 1_024.0f, characters.current())
+    return String.format(locale, "%.1f %c$byteChar", value / 1_024.0f, characters.current())
 }
 //endregion
 

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -107,14 +107,11 @@ import io.realm.kotlin.types.RealmObject
 import kotlinx.serialization.encodeToString
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import java.text.StringCharacterIterator
 import java.util.Calendar
 import java.util.Date
 import java.util.Scanner
 import kotlin.collections.set
-import kotlin.math.abs
 import kotlin.math.roundToInt
-import kotlin.math.sign
 
 //region Type alias
 // Explanation of this Map: Map<Email, Map<Name, MergedContact>>
@@ -246,28 +243,6 @@ fun WebView.initWebViewClientAndBridge(
     ).also {
         webViewClient = it
     }
-}
-
-fun Context.humanReadableBinaryBytesCount(bytes: Long): String {
-    val byteChar = "B"
-
-    val absBytes = if (bytes == Long.MIN_VALUE) Long.MAX_VALUE else abs(bytes)
-    if (absBytes < 1_024L) return "$bytes $byteChar"
-
-    var value = absBytes
-    val characters = StringCharacterIterator("KMGTPE")
-
-    var i = 40
-    while (i >= 0 && absBytes > 0xfffccccccccccccL shr i) {
-        value = value shr 10
-        characters.next()
-        i -= 10
-    }
-
-    value *= bytes.sign.toLong()
-
-    val locale = resources.configuration.getLocales().get(0)
-    return String.format(locale, "%.1f %c$byteChar", value / 1_024.0f, characters.current())
 }
 //endregion
 

--- a/app/src/main/java/com/infomaniak/mail/views/AttachmentDetailsView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/AttachmentDetailsView.kt
@@ -18,7 +18,6 @@
 package com.infomaniak.mail.views
 
 import android.content.Context
-import android.text.format.Formatter
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
@@ -30,6 +29,7 @@ import com.infomaniak.lib.core.utils.setMarginsRelative
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Attachment
 import com.infomaniak.mail.databinding.ViewAttachmentDetailsBinding
+import com.infomaniak.mail.utils.extensions.humanReadableBinaryBytesCount
 import com.infomaniak.lib.core.R as RCore
 
 class AttachmentDetailsView @JvmOverloads constructor(
@@ -65,7 +65,7 @@ class AttachmentDetailsView @JvmOverloads constructor(
 
     fun setDetails(attachment: Attachment) = with(binding) {
         fileName.text = attachment.name
-        fileSize.text = Formatter.formatShortFileSize(context, attachment.size)
+        fileSize.text = context.humanReadableBinaryBytesCount(attachment.size)
         icon.load(attachment.getFileTypeFromMimeType().icon)
     }
 

--- a/app/src/main/java/com/infomaniak/mail/views/AttachmentDetailsView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/AttachmentDetailsView.kt
@@ -24,8 +24,8 @@ import android.widget.LinearLayout
 import androidx.annotation.DimenRes
 import androidx.annotation.StyleRes
 import coil.load
+import com.infomaniak.lib.core.utils.FormatterFileSize.formatShortFileSize
 import com.infomaniak.lib.core.utils.getAttributes
-import com.infomaniak.lib.core.utils.humanReadableBinaryBytesCount
 import com.infomaniak.lib.core.utils.setMarginsRelative
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Attachment
@@ -65,7 +65,7 @@ class AttachmentDetailsView @JvmOverloads constructor(
 
     fun setDetails(attachment: Attachment) = with(binding) {
         fileName.text = attachment.name
-        fileSize.text = context.humanReadableBinaryBytesCount(attachment.size)
+        fileSize.text = context.formatShortFileSize(attachment.size)
         icon.load(attachment.getFileTypeFromMimeType().icon)
     }
 

--- a/app/src/main/java/com/infomaniak/mail/views/AttachmentDetailsView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/AttachmentDetailsView.kt
@@ -25,11 +25,11 @@ import androidx.annotation.DimenRes
 import androidx.annotation.StyleRes
 import coil.load
 import com.infomaniak.lib.core.utils.getAttributes
+import com.infomaniak.lib.core.utils.humanReadableBinaryBytesCount
 import com.infomaniak.lib.core.utils.setMarginsRelative
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Attachment
 import com.infomaniak.mail.databinding.ViewAttachmentDetailsBinding
-import com.infomaniak.mail.utils.extensions.humanReadableBinaryBytesCount
 import com.infomaniak.lib.core.R as RCore
 
 class AttachmentDetailsView @JvmOverloads constructor(


### PR DESCRIPTION
Depends on https://github.com/Infomaniak/android-core/pull/173

Since Android O, Google decided to use SI format (1000) instead of binary one (1024) to display bytes.

Source : https://stackoverflow.com/a/3758880

Unit tests are here : https://github.com/Infomaniak/android-core/pull/175