### PR TITLE
Fix clickListener not being recycled correctly if thread doesn't have sender

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -19,7 +19,6 @@
 
 package com.infomaniak.mail.data.models.message
 
-import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.lib.core.utils.Utils.enumValueOfOrNull
 import com.infomaniak.mail.data.api.RealmInstantSerializer
 import com.infomaniak.mail.data.api.UnwrappingJsonListSerializer
@@ -170,10 +169,7 @@ class Message : RealmObject {
             }
         }
 
-    inline val sender
-        get() = from.firstOrNull().also {
-            if (it == null) SentryLog.e("ThreadAdapter", "Message $uid has empty from")
-        }
+    inline val sender get() = from.firstOrNull()
 
     val calendarAttachment: Attachment? get() = if (isDraft) null else attachments.firstOrNull(Attachment::isCalendarEvent)
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -22,6 +22,7 @@ import android.net.Uri
 import android.text.format.Formatter
 import android.view.LayoutInflater
 import android.view.ScaleGestureDetector
+import android.view.View.OnClickListener
 import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.webkit.WebView
@@ -349,12 +350,14 @@ class ThreadAdapter(
             shortMessageDate.text = mailFormattedDate(context, messageDate)
         }
 
-        message.sender?.let { recipient ->
-            userAvatar.setOnClickListener {
+        val listener: OnClickListener? = message.sender?.let { recipient ->
+            OnClickListener {
                 context.trackMessageEvent("selectAvatar")
                 threadAdapterCallbacks?.onContactClicked?.invoke(recipient)
             }
         }
+
+        userAvatar.setOnClickListener(listener)
 
         setDetailedFieldsVisibility(message)
 


### PR DESCRIPTION
The click listener of a thread was recycled without being updated if the thread doesn't have any from Recipient

The Sentry also wasn't useFul as it is normal that a thread can have an empty from (a draft for example)