### PR TITLE
Send current textColor to `initProgress()` so it'll be able to restore it when progress is done

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/login/LoginFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/login/LoginFragment.kt
@@ -109,8 +109,8 @@ class LoginFragment : Fragment() {
         nextButton.setOnClickListener { introViewpager.currentItem += 1 }
 
         connectButton.apply {
-            initProgress(viewLifecycleOwner)
             setOnClickListener {
+                initProgress(viewLifecycleOwner, getCurrentOnPrimary())
                 signInButton.isEnabled = false
                 connectButtonProgressTimer.start()
                 requireContext().trackAccountEvent("openLoginWebview")

--- a/app/src/main/java/com/infomaniak/mail/ui/login/LoginFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/login/LoginFragment.kt
@@ -109,8 +109,9 @@ class LoginFragment : Fragment() {
         nextButton.setOnClickListener { introViewpager.currentItem += 1 }
 
         connectButton.apply {
+            initProgress(viewLifecycleOwner, getCurrentOnPrimary())
             setOnClickListener {
-                initProgress(viewLifecycleOwner, getCurrentOnPrimary())
+                updateTextColor(getCurrentOnPrimary())
                 signInButton.isEnabled = false
                 connectButtonProgressTimer.start()
                 requireContext().trackAccountEvent("openLoginWebview")


### PR DESCRIPTION
Depends on #1865
Depends on https://github.com/Infomaniak/android-core/pull/183
Depends on https://github.com/Infomaniak/android-core/pull/184

When going to the Login WebView, then coming back to LoginFragment, the LoginButton color was reset to the default PINK theme.