### PR TITLE
Move some Realm functions to Controllers' companions

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -78,6 +78,7 @@ class FolderController @Inject constructor(
     }
     //endregion
 
+    //region Edit data
     fun update(mailbox: Mailbox, remoteFolders: List<Folder>, realm: Realm) {
         val remoteFoldersWithChildren = remoteFolders.flattenFolderChildren()
 
@@ -89,11 +90,6 @@ class FolderController @Inject constructor(
             SentryLog.d(RealmDatabase.TAG, "Folders: Save new data")
             upsertFolders(remoteFoldersWithChildren)
         }
-    }
-
-    fun deleteSearchFolderData(realm: MutableRealm) = with(getOrCreateSearchFolder(realm)) {
-        messages = realmListOf()
-        threads = realmListOf()
     }
 
     private fun MutableRealm.deleteOutdatedFolders(mailbox: Mailbox, remoteFolders: List<Folder>) {
@@ -214,6 +210,11 @@ class FolderController @Inject constructor(
             realm.writeBlocking {
                 getFolder(id, realm = this)?.let { folder -> updateChildrenRecursively(mutableListOf(folder)) }
             }
+        }
+
+        fun deleteSearchFolderData(realm: MutableRealm) = with(getOrCreateSearchFolder(realm)) {
+            messages = realmListOf()
+            threads = realmListOf()
         }
         //endregion
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
@@ -150,12 +150,6 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
     }
     //endregion
 
-    //region Edit data
-    fun deleteSearchMessages(realm: MutableRealm) = with(realm) {
-        delete(query<Message>("${Message::isFromSearch.name} == true").find())
-    }
-    //endregion
-
     companion object {
         private val isNotDraft = "${Message::isDraft.name} == false"
         private val isNotScheduled = "${Message::isScheduled.name} == false"
@@ -244,6 +238,10 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
             messages.reversed().forEach { message ->
                 deleteMessage(context, mailbox, message, realm)
             }
+        }
+
+        fun deleteSearchMessages(realm: MutableRealm) = with(realm) {
+            delete(query<Message>("${Message::isFromSearch.name} == true").find())
         }
         //endregion
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -151,10 +151,6 @@ class ThreadController @Inject constructor(
     //endregion
 
     //region Edit data
-    fun deleteSearchThreads(realm: MutableRealm) = with(realm) {
-        delete(query<Thread>("${Thread::isFromSearch.name} == true").find())
-    }
-
     fun saveThreads(searchMessages: List<Message>) {
         mailboxContentRealm().writeBlocking {
             FolderController.getOrCreateSearchFolder(realm = this).apply {
@@ -308,6 +304,10 @@ class ThreadController @Inject constructor(
         // its `draftLocalUuid`, otherwise we'll lose the link between them.
         private fun Message.getDraftLocalUuid(realm: TypedRealm): String? {
             return if (isDraft) DraftController.getDraftByMessageUid(uid, realm)?.localUuid else null
+        }
+
+        fun deleteSearchThreads(realm: MutableRealm) = with(realm) {
+            delete(query<Thread>("${Thread::isFromSearch.name} == true").find())
         }
         //endregion
     }

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -34,9 +34,6 @@ import javax.inject.Singleton
 @Singleton
 class SearchUtils @Inject constructor(
     private val mailboxContentRealm: RealmDatabase.MailboxContent,
-    private val folderController: FolderController,
-    private val messageController: MessageController,
-    private val threadController: ThreadController,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
 
@@ -77,9 +74,9 @@ class SearchUtils @Inject constructor(
     suspend fun deleteRealmSearchData() = withContext(ioDispatcher) {
         mailboxContentRealm().writeBlocking {
             SentryLog.i(TAG, "SearchUtils>deleteRealmSearchData: remove old search data")
-            messageController.deleteSearchMessages(realm = this)
-            threadController.deleteSearchThreads(realm = this)
-            folderController.deleteSearchFolderData(realm = this)
+            MessageController.deleteSearchMessages(realm = this)
+            ThreadController.deleteSearchThreads(realm = this)
+            FolderController.deleteSearchFolderData(realm = this)
         }
     }
 


### PR DESCRIPTION
Depends on #1873

Some functions in Realms controllers that are using a given Realm are not in the companion.
Shouldn't they all be in it ?