### PR TITLE
Delete Thread in Realm if it's empty and we're trying to display it in ThreadsList

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -102,6 +102,9 @@ class RefreshController @Inject constructor(
         setupConfiguration(refreshMode, mailbox, folder, realm, okHttpClient, callbacks)
 
         return refreshWithRunCatching(refreshThreadsJob!!).also { (threads, _) ->
+
+            ThreadController.deleteEmptyThreadsInFolder(folder.id, realm)
+
             if (threads != null) {
                 onStop?.invoke()
                 SentryLog.d("API", "End of refreshing threads with mode: $refreshMode | (${folder.displayForSentry()})")

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -159,6 +159,12 @@ class ThreadController @Inject constructor(
             }
         }
     }
+
+    fun deleteThread(threadUid: String) {
+        mailboxContentRealm().writeBlocking {
+            delete(getThreadQuery(threadUid, realm = this))
+        }
+    }
     //endregion
 
     companion object {

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -228,8 +228,9 @@ class Thread : RealmObject {
 
     }.getOrElse { throwable ->
         Sentry.withScope { scope ->
-            scope.setExtra("thread.folder.role", "${folder.role?.name}")
+            scope.setExtra("thread.folder.role", folder.role?.name.toString())
             scope.setExtra("thread.folder.id", folder.id)
+            scope.setExtra("thread.folderId", folderId)
             scope.setExtra("thread.uid", uid)
             scope.setExtra("thread.messages.count", "${messages.count()}")
             scope.setExtra("thread.duplicates.count", "${duplicates.count()}")

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -1047,6 +1047,10 @@ class MainViewModel @Inject constructor(
         snackbarManager.postValue(appContext.getString(snackbarTitleRes))
     }
 
+    fun deleteThreadInRealm(threadUid: String) = viewModelScope.launch(ioCoroutineContext) {
+        threadController.deleteThread(threadUid)
+    }
+
     private fun shouldAutoAdvance(message: Message?, threadsUids: List<String>): Boolean {
         val isWorkingWithThread = message == null
         return isWorkingWithThread || threadHasOnlyOneMessageLeftInCurrentFolder(threadsUids.first())

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -195,7 +195,7 @@ class ThreadListAdapter @Inject constructor(
         // If we are trying to display an empty Thread, don't. Just delete it.
         if (thread.messages.isEmpty()) {
             // TODO: Find why we are sometimes displaying empty Threads, and fix it instead of just deleting them.
-            //  It's possibly because we are out of sync, and the situation will resolve itself shortly? ¯\_(ツ)_/¯
+            //  It's possibly because we are out of sync, and the situation will resolve by itself shortly?
             threadListAdapterCallback?.deleteThreadInRealm?.invoke(thread.uid)
             SentryDebug.sendEmptyThread(thread, "No Message in the Thread when displaying it in ThreadList")
             return

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -191,6 +191,14 @@ class ThreadListAdapter @Inject constructor(
 
     private fun CardviewThreadItemBinding.displayThread(thread: Thread, position: Int) {
 
+        // If we are trying to display an empty Thread, don't. Just delete it.
+        if (thread.messages.isEmpty()) {
+            // TODO: Find why we are sometimes displaying empty Threads, and fix it instead of just deleting them.
+            //  It's possibly because we are out of sync, and the situation will resolve itself shortly? ¯\_(ツ)_/¯
+            threadListAdapterCallback?.deleteThreadInRealm?.invoke(thread.uid)
+            return
+        }
+
         refreshCachedSelectedPosition(thread.uid, position) // If item changed position, update cached position.
         setupThreadDensityDependentUi()
         displayAvatar(thread)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -60,6 +60,7 @@ import com.infomaniak.mail.ui.main.folder.ThreadListAdapter.ThreadListViewHolder
 import com.infomaniak.mail.ui.main.thread.SubjectFormatter
 import com.infomaniak.mail.ui.main.thread.SubjectFormatter.TagColor
 import com.infomaniak.mail.utils.RealmChangesBinding
+import com.infomaniak.mail.utils.SentryDebug
 import com.infomaniak.mail.utils.Utils.runCatchingRealm
 import com.infomaniak.mail.utils.extensions.*
 import dagger.hilt.android.qualifiers.ActivityContext
@@ -196,6 +197,7 @@ class ThreadListAdapter @Inject constructor(
             // TODO: Find why we are sometimes displaying empty Threads, and fix it instead of just deleting them.
             //  It's possibly because we are out of sync, and the situation will resolve itself shortly? ¯\_(ツ)_/¯
             threadListAdapterCallback?.deleteThreadInRealm?.invoke(thread.uid)
+            SentryDebug.sendEmptyThread(thread, "No Message in the Thread when displaying it in ThreadList")
             return
         }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapterCallback.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapterCallback.kt
@@ -25,4 +25,5 @@ interface ThreadListAdapterCallback {
     var onFlushClicked: ((dialogTitle: String) -> Unit)?
     var onLoadMoreClicked: () -> Unit
     var onPositionClickedChanged: (position: Int, previousPosition: Int) -> Unit
+    var deleteThreadInRealm: (threadUid: String) -> Unit
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -717,7 +717,7 @@ class ThreadListFragment : TwoPaneFragment(), SwipeRefreshLayout.OnRefreshListen
                     val currentFolder = mainViewModel.currentFolder.value
                     Sentry.withScope { scope ->
                         scope.setExtra("cursor", "$currentFolderCursor")
-                        scope.setExtra("folderRole", "${currentFolder?.role?.name}")
+                        scope.setExtra("folderRole", currentFolder?.role?.name.toString())
                         scope.setExtra("folderThreadsCount", "${currentFolder?.threads?.count()}")
                         Sentry.captureMessage(
                             "Should display threads is true but there are no threads to display",

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -322,6 +322,8 @@ class ThreadListFragment : TwoPaneFragment(), SwipeRefreshLayout.OnRefreshListen
                 }
 
                 override var onPositionClickedChanged: (Int, Int) -> Unit = ::updateAutoAdvanceNaturalThread
+
+                override var deleteThreadInRealm: (String) -> Unit = { threadUid -> mainViewModel.deleteThreadInRealm(threadUid) }
             },
             multiSelection = object : MultiSelectionListener<Thread> {
                 override var isEnabled by mainViewModel::isMultiSelectOn

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
@@ -172,6 +172,8 @@ class SearchFragment : TwoPaneFragment() {
                 }
 
                 override var onPositionClickedChanged: (Int, Int) -> Unit = ::updateAutoAdvanceNaturalThread
+
+                override var deleteThreadInRealm: (String) -> Unit = { threadUid -> mainViewModel.deleteThreadInRealm(threadUid) }
             },
         )
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -274,7 +274,7 @@ class ThreadViewModel @Inject constructor(
         appContext.trackUserInfo("nbMessagesInThread", nbMessages)
 
         when (nbMessages) {
-            0 -> SentryDebug.sendEmptyThread(thread)
+            0 -> SentryDebug.sendEmptyThread(thread, "No Message in the Thread when opening it")
             1 -> appContext.trackUserInfo("oneMessagesInThread")
             else -> appContext.trackUserInfo("multipleMessagesInThread", nbMessages)
         }

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -117,14 +117,21 @@ object SentryDebug {
     //region Send Sentry
     // TODO: Added the 04/09/23. It's not supposed to be possible, but we never know…
     //  If this doesn't trigger after a certain amount of time, you can remove it.
-    fun sendEmptyThread(thread: Thread) {
+    //
+    //  Also added in ThreadListAdapter the 31/05/24.
+    fun sendEmptyThread(thread: Thread, message: String) = with(thread) {
         Sentry.withScope { scope ->
-            scope.setExtra("currentUserId", "[${AccountUtils.currentUserId}]")
-            scope.setExtra("currentMailboxEmail", "[${AccountUtils.currentMailboxEmail}]")
-            scope.setExtra("folder.role", thread.folder.role?.name.toString())
-            scope.setExtra("folder.id", thread.folder.id)
-            scope.setExtra("thread.uid", "[${thread.uid}]")
-            Sentry.captureMessage("No Message in the Thread when opening it", SentryLevel.ERROR)
+            scope.setExtra("currentUserId", "${AccountUtils.currentUserId}")
+            scope.setExtra("currentMailboxEmail", AccountUtils.currentMailboxEmail.toString())
+            scope.setExtra("folderId", folderId)
+            scope.setExtra("folder.id", folder.id)
+            scope.setExtra("folder.role", folder.role?.name.toString())
+            scope.setExtra("uid", uid)
+            scope.setExtra("messages.count", "${messages.count()}")
+            scope.setExtra("duplicates.count", "${duplicates.count()}")
+            scope.setExtra("isFromSearch", "$isFromSearch")
+            scope.setExtra("hasDrafts", "$hasDrafts")
+            Sentry.captureMessage(message, SentryLevel.ERROR)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -118,7 +118,7 @@ object SentryDebug {
     // TODO: Added the 04/09/23. It's not supposed to be possible, but we never know…
     //  If this doesn't trigger after a certain amount of time, you can remove it.
     //
-    //  Also added in ThreadListAdapter the 31/05/24.
+    //  Also added in ThreadListAdapter & ThreadController the 04/06/24.
     fun sendEmptyThread(thread: Thread, message: String) = with(thread) {
         Sentry.withScope { scope ->
             scope.setExtra("currentUserId", "${AccountUtils.currentUserId}")


### PR DESCRIPTION
Depends on #1875

Sometimes, we display an empty Thread in the ThreadsList.

The cause isn't known yet, but in the meantime we just delete them in Realm.
It's possibly because we are out of sync, and the situation will resolve itself shortly.