### PR TITLE
Return a copy of the list instead of the reference to avoid crash if this list is modified by another threads.

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/NotificationUtils.kt
@@ -48,7 +48,6 @@ import io.realm.kotlin.Realm
 import io.sentry.SentryLevel
 import kotlinx.coroutines.*
 import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 import com.infomaniak.lib.core.R as RCore
@@ -61,7 +60,7 @@ class NotificationUtils @Inject constructor(
     private val globalCoroutineScope: CoroutineScope,
 ) {
 
-    private val notificationsByMailboxId = ConcurrentHashMap<Int, MutableList<NotificationWithIdAndTag>>()
+    private val notificationsByMailboxId = mutableMapOf<Int, MutableList<NotificationWithIdAndTag>>()
     private val notificationsJobByMailboxId = mutableMapOf<Int, Job?>()
 
     fun initNotificationChannel() = with(appContext) {
@@ -235,7 +234,7 @@ class NotificationUtils @Inject constructor(
 
             @Suppress("MissingPermission")
             notificationsByMailboxId[mailboxId]?.let { notifications ->
-                notificationManagerCompat.notify(notifications)
+                notificationManagerCompat.notify(notifications.toList())
                 notifications.clear()
             }
         }


### PR DESCRIPTION
Fixes MAIL-ANDROID-7Z2