### PR TITLE
Fix NPE when getting email in `getDummySignature`

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/signature/Signature.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/signature/Signature.kt
@@ -63,11 +63,15 @@ class Signature : RealmObject {
 
     companion object {
 
-        fun getDummySignature(context: Context, isDefault: Boolean = false) = Signature().apply {
+        fun getDummySignature(
+            context: Context,
+            email: String = AccountUtils.currentMailboxEmail!!,
+            isDefault: Boolean = false,
+        ) = Signature().apply {
             id = Draft.NO_IDENTITY
             isDummy = true
             name = context.getString(R.string.selectSignatureNone)
-            senderEmailIdn = AccountUtils.currentMailboxEmail!!
+            senderEmailIdn = email
             this.isDefault = isDefault
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -182,7 +182,7 @@ class NewMessageViewModel @Inject constructor(
             signatures = SignatureController.getAllSignatures(realm)
                 .also { signaturesCount = it.count() }
                 .toMutableList()
-                .apply { add(index = 0, element = Signature.getDummySignature(appContext)) }
+                .apply { add(index = 0, element = Signature.getDummySignature(appContext, email = currentMailbox.email)) }
 
             isNewMessage = !arrivedFromExistingDraft && draftLocalUuid == null
 
@@ -256,7 +256,7 @@ class NewMessageViewModel @Inject constructor(
 
         signatureUtils.initSignature(
             draft = this,
-            signature = signature ?: Signature.getDummySignature(appContext, isDefault = true),
+            signature = signature ?: Signature.getDummySignature(appContext, email = currentMailbox.email, isDefault = true),
         )
 
         populateWithExternalMailDataIfNeeded(draft = this, intent)


### PR DESCRIPTION
We were trying to get the `AccountUtils.currentMailboxEmail` too early when creating the NewMessageActivity via shortcuts.

Instead, we are now using the `currentMailbox.email` that is already available.

Fixes MAIL-ANDROID-ASZ