### PR TITLE
Replace this throw expression with error("").

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -199,7 +199,7 @@ class ThreadController @Inject constructor(
                     ThreadFilter.STARRED -> "${Thread::isFavorite.name} == true"
                     ThreadFilter.ATTACHMENTS -> "${Thread::hasAttachments.name} == true"
                     ThreadFilter.FOLDER -> TODO()
-                    else -> throw IllegalStateException("`${ThreadFilter::class.simpleName}` cannot be `${ThreadFilter.ALL.name}` here.")
+                    else -> error("`${ThreadFilter::class.simpleName}` cannot be `${ThreadFilter.ALL.name}` here.")
                 }
                 realmQuery.query(withFilter)
             }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -388,7 +388,7 @@ class ThreadListFragment : TwoPaneFragment(), SwipeRefreshLayout.OnRefreshListen
                 val swipeAction = when (direction) {
                     SwipeDirection.LEFT_TO_RIGHT -> localSettings.swipeRight
                     SwipeDirection.RIGHT_TO_LEFT -> localSettings.swipeLeft
-                    else -> throw IllegalStateException("Only SwipeDirection.LEFT_TO_RIGHT and SwipeDirection.RIGHT_TO_LEFT can be triggered")
+                    else -> error("Only SwipeDirection.LEFT_TO_RIGHT and SwipeDirection.RIGHT_TO_LEFT can be triggered")
                 }
 
                 val isPermanentDeleteFolder = isPermanentDeleteFolder(item.folder.role)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
@@ -168,7 +168,7 @@ class FolderAdapter @Inject constructor(
                 onCollapseTransition?.invoke(false)
             }
             is SelectableMailboxItemView, is UnreadItemView -> {
-                throw IllegalStateException("`${this::class.simpleName}` cannot exists here. Only Folder classes are allowed")
+                error("`${this::class.simpleName}` cannot exists here. Only Folder classes are allowed")
             }
         }
 


### PR DESCRIPTION
`throw IllegalStateException("")` can be simply written as `error("")`.