### PR TITLE
Temp fix attachments

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -305,15 +305,7 @@ class ThreadController @Inject constructor(
                     }
 
                     // TODO: Remove this when the API returns the good value for `has_attachments`.
-                    if (!hasAttachmentsInThread) {
-                        messages.flatMapTo(mutableSetOf()) { it.threads }.forEach { thread ->
-                            if (thread.hasAttachments) {
-                                updateThread(thread.uid, realm = this@writeBlocking) {
-                                    it?.hasAttachments = false
-                                }
-                            }
-                        }
-                    }
+                    verifyAttachmentsValues(hasAttachmentsInThread, messages, this@writeBlocking)
                 }
             }
 
@@ -328,6 +320,18 @@ class ThreadController @Inject constructor(
 
         fun deleteSearchThreads(realm: MutableRealm) = with(realm) {
             delete(query<Thread>("${Thread::isFromSearch.name} == true").find())
+        }
+
+        private fun verifyAttachmentsValues(hasAttachmentsInThread: Boolean, messages: List<Message>, realm: MutableRealm) {
+            if (!hasAttachmentsInThread) {
+                messages.flatMapTo(mutableSetOf()) { it.threads }.forEach { thread ->
+                    if (thread.hasAttachments) {
+                        updateThread(thread.uid, realm) {
+                            it?.hasAttachments = false
+                        }
+                    }
+                }
+            }
         }
         //endregion
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -304,6 +304,7 @@ class ThreadController @Inject constructor(
                         handleFailure(localMessage.uid)
                     }
 
+                    // TODO: Remove this when the API returns the good value for `has_attachments`.
                     if (!hasAttachmentsInThread) {
                         messages.flatMapTo(mutableSetOf()) { it.threads }.forEach { thread ->
                             if (thread.hasAttachments) {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -323,12 +323,10 @@ class ThreadController @Inject constructor(
         }
 
         private fun verifyAttachmentsValues(hasAttachmentsInThread: Boolean, messages: List<Message>, realm: MutableRealm) {
-            if (!hasAttachmentsInThread) {
-                messages.flatMapTo(mutableSetOf()) { it.threads }.forEach { thread ->
-                    if (thread.hasAttachments) {
-                        updateThread(thread.uid, realm) {
-                            it?.hasAttachments = false
-                        }
+            messages.flatMapTo(mutableSetOf()) { it.threads }.forEach { thread ->
+                if (thread.hasAttachments != hasAttachmentsInThread) {
+                    updateThread(thread.uid, realm) {
+                        it?.hasAttachments = hasAttachmentsInThread
                     }
                 }
             }


### PR DESCRIPTION
Set manually the 'has_attachments' while loading heavy data, this fix is temporary and will be remove when the API returns the good value.

The value return by the API for the lite version of the message is sometimes false, the API can return that they're are attachments but actually not and it can occurred in the two way. The API will probably be fixed but not soon.