### PR TITLE
Fix calendar event canceled detection

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -162,7 +162,7 @@ object RealmDatabase {
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 1L
         const val MAILBOX_INFO_SCHEMA_VERSION = 5L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 12L
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 13L
         //endregion
 
         //region Configurations names

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
@@ -102,8 +102,8 @@ class CalendarEvent() : EmbeddedRealmObject {
         result = 31 * result + isFullDay.hashCode()
         result = 31 * result + start.hashCode()
         result = 31 * result + end.hashCode()
-        result = 31 * result + _status.hashCode()
         result = 31 * result + attendees.hashCode()
+        result = 31 * result + _status.hashCode()
 
         return result
     }

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEvent.kt
@@ -19,6 +19,7 @@
 
 package com.infomaniak.mail.data.models.calendar
 
+import com.infomaniak.lib.core.utils.Utils
 import com.infomaniak.mail.data.api.CalendarRealmInstantSerializer
 import com.infomaniak.mail.utils.extensions.toRealmInstant
 import io.realm.kotlin.ext.realmListOf
@@ -46,7 +47,11 @@ class CalendarEvent() : EmbeddedRealmObject {
     var start: RealmInstant = Date(0).toRealmInstant()
     var end: RealmInstant = Date(0).toRealmInstant()
     var attendees: RealmList<Attendee> = realmListOf()
+    @SerialName("status")
+    private var _status: String? = null
     //endregion
+
+    val status: CalendarEventStatus? get() = Utils.enumValueOfOrNull<CalendarEventStatus>(_status)
 
     constructor(
         id: Int,
@@ -76,6 +81,7 @@ class CalendarEvent() : EmbeddedRealmObject {
         if (location != other.location) return false
         if (isFullDay != other.isFullDay) return false
         if (start != other.start) return false
+        if (_status != other._status) return false
 
         return end == other.end
     }
@@ -96,8 +102,15 @@ class CalendarEvent() : EmbeddedRealmObject {
         result = 31 * result + isFullDay.hashCode()
         result = 31 * result + start.hashCode()
         result = 31 * result + end.hashCode()
+        result = 31 * result + _status.hashCode()
         result = 31 * result + attendees.hashCode()
 
         return result
+    }
+
+    enum class CalendarEventStatus(val apiValue: String) {
+        CONFIRMED("CONFIRMED"),
+        TENTATIVE("TENTATIVE"),
+        CANCELLED("CANCELLED"),
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.data.models.calendar
 
 import com.infomaniak.lib.core.utils.Utils
+import com.infomaniak.mail.data.models.calendar.CalendarEvent.CalendarEventStatus
 import com.infomaniak.mail.utils.extensions.isUserIn
 import io.realm.kotlin.types.EmbeddedRealmObject
 import kotlinx.serialization.SerialName
@@ -54,7 +55,7 @@ class CalendarEventResponse() : EmbeddedRealmObject {
 
     val calendarEvent get() = userStoredEvent ?: attachmentEvent
 
-    val isCanceled get() = isUserStoredEventDeleted || attachmentEventMethod == AttachmentEventMethod.CANCEL
+    val isCanceled get() = calendarEvent?.status == CalendarEventStatus.CANCELLED
 
     fun isReplyAuthorized(): Boolean {
         return (attachmentEventMethod == null || attachmentEventMethod == AttachmentEventMethod.REQUEST)

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/CalendarEventResponse.kt
@@ -40,12 +40,10 @@ class CalendarEventResponse() : EmbeddedRealmObject {
 
     constructor(
         userStoredEvent: CalendarEvent?,
-        isUserStoredEventDeleted: Boolean,
         attachmentEvent: CalendarEvent?,
         attachmentEventMethod: String?,
     ) : this() {
         this.userStoredEvent = userStoredEvent
-        this.isUserStoredEventDeleted = isUserStoredEventDeleted
         this.attachmentEvent = attachmentEvent
         this._attachmentEventMethod = attachmentEventMethod
     }
@@ -70,7 +68,6 @@ class CalendarEventResponse() : EmbeddedRealmObject {
     fun everythingButAttendeesIsTheSame(other: CalendarEventResponse?): Boolean {
         if (other == null) return false
 
-        if (isUserStoredEventDeleted != other.isUserStoredEventDeleted) return false
         if (_attachmentEventMethod != other._attachmentEventMethod) return false
 
         val c1 = calendarEvent
@@ -89,7 +86,6 @@ class CalendarEventResponse() : EmbeddedRealmObject {
         other as CalendarEventResponse
 
         if (userStoredEvent != other.userStoredEvent) return false
-        if (isUserStoredEventDeleted != other.isUserStoredEventDeleted) return false
         if (attachmentEvent != other.attachmentEvent) return false
 
         return _attachmentEventMethod == other._attachmentEventMethod
@@ -97,7 +93,6 @@ class CalendarEventResponse() : EmbeddedRealmObject {
 
     override fun hashCode(): Int {
         var result = userStoredEvent?.hashCode() ?: 0
-        result = 31 * result + isUserStoredEventDeleted.hashCode()
         result = 31 * result + (attachmentEvent?.hashCode() ?: 0)
         result = 31 * result + (_attachmentEventMethod?.hashCode() ?: 0)
 

--- a/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
+++ b/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
@@ -21,6 +21,7 @@ import com.infomaniak.mail.data.models.calendar.Attendee
 import com.infomaniak.mail.data.models.calendar.Attendee.AttendanceState
 import com.infomaniak.mail.data.models.calendar.CalendarEvent
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
+import com.infomaniak.mail.data.models.calendar.CalendarEventResponse.AttachmentEventMethod
 import com.infomaniak.mail.data.models.message.Body
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter
@@ -141,10 +142,11 @@ class CalendarEventResponseTest {
 
     private fun getBasicCalendarEventResponse(
         userStoredEvent: CalendarEvent,
-        isUserStoredEventDeleted: Boolean,
+        hasCanceledEventMethod: Boolean,
     ): CalendarEventResponse {
         val attachmentEvent = getBasicCalendarEvent(AttendanceState.NEEDS_ACTION)
-        return CalendarEventResponse(userStoredEvent, isUserStoredEventDeleted, attachmentEvent, "REQUEST")
+        val method = if (hasCanceledEventMethod) AttachmentEventMethod.CANCEL.name else AttachmentEventMethod.REQUEST.name
+        return CalendarEventResponse(userStoredEvent, attachmentEvent, method)
     }
 
     companion object {


### PR DESCRIPTION
The previous condition wasn't really needed and in veeeery extrem case might even have been wrong. This PR makes it so the detection logic is inline with iOS and the web