### PR TITLE
Nested #1: Remove NestedScrollView in Move fragmentes

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -162,7 +162,7 @@ object RealmDatabase {
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 1L
         const val MAILBOX_INFO_SCHEMA_VERSION = 5L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 13L
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 14L
         //endregion
 
         //region Configurations names

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -45,10 +45,6 @@ class FolderController @Inject constructor(
 ) {
 
     //region Get data
-    fun getCustomFolders(): RealmResults<Folder> {
-        return getCustomFoldersQuery(mailboxContentRealm()).find()
-    }
-
     fun getMoveFolders(): RealmResults<Folder> {
         return getMoveFoldersQuery(mailboxContentRealm()).find()
     }
@@ -151,7 +147,9 @@ class FolderController @Inject constructor(
 
         private fun getDefaultFoldersQuery(realm: TypedRealm): RealmQuery<Folder> {
             val hasRole = "${Folder.rolePropertyName} != nil"
-            return realm.query("$isNotSearch AND $hasRole")
+            return realm
+                .query<Folder>("$isNotSearch AND $hasRole")
+                .sort(Folder::roleOrder.name, Sort.DESCENDING)
         }
 
         private fun getCustomFoldersQuery(realm: TypedRealm): RealmQuery<Folder> {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -49,6 +49,10 @@ class FolderController @Inject constructor(
         return getCustomFoldersQuery(mailboxContentRealm()).find()
     }
 
+    fun getMoveFolders(): RealmResults<Folder> {
+        return getMoveFoldersQuery(mailboxContentRealm()).find()
+    }
+
     fun getRootsFoldersAsync(): Flow<ResultsChange<Folder>> {
         return getFoldersQuery(mailboxContentRealm(), onlyRoots = true).asFlow()
     }
@@ -160,6 +164,15 @@ class FolderController @Inject constructor(
 
         private fun getFoldersQuery(exceptionsFoldersIds: List<String>, realm: TypedRealm): RealmQuery<Folder> {
             return realm.query("NOT ${Folder::id.name} IN $0 AND $isNotSearch", exceptionsFoldersIds)
+        }
+
+        private fun getMoveFoldersQuery(realm: TypedRealm): RealmQuery<Folder> {
+            val isNotDraft = "${Folder.rolePropertyName} != '${FolderRole.DRAFT.name}'"
+            return realm
+                .query<Folder>("$isNotSearch AND $isRootFolder AND $isNotDraft")
+                .sort(Folder::name.name, Sort.ASCENDING)
+                .sort(Folder::isFavorite.name, Sort.DESCENDING)
+                .sort(Folder::roleOrder.name, Sort.DESCENDING)
         }
 
         private fun getFolderQuery(key: String, value: String, realm: TypedRealm): RealmSingleQuery<Folder> {

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -177,6 +177,6 @@ class Folder : RealmObject, Cloneable {
         const val DEFAULT_IS_HISTORY_COMPLETE = false
 
         const val INBOX_FOLDER_ID = "eJzz9HPyjwAABGYBgQ--"
-        const val CUSTOM_FOLDER_ROLE_ORDER = 0
+        private const val CUSTOM_FOLDER_ROLE_ORDER = 0
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -147,7 +147,11 @@ class Folder : RealmObject, Cloneable {
 
     override fun hashCode(): Int = id.hashCode()
 
-    public override fun clone(): Folder = super.clone() as Folder
+    /**
+     * We've had a reference issue when modifying the `shouldDisplayDivider` of a Folder before sending it to the Adapter.
+     * Cloning it to do a deep copy resolved the issue.
+     */
+    public override fun clone() = super.clone() as Folder
 
     enum class FolderRole(
         @StringRes val folderNameRes: Int,

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -44,7 +44,7 @@ import kotlinx.serialization.UseSerializers
 import kotlin.math.max
 
 @Serializable
-class Folder : RealmObject {
+class Folder : RealmObject, Cloneable {
 
     //region Remote data
     @PrimaryKey
@@ -143,6 +143,8 @@ class Folder : RealmObject {
     override fun equals(other: Any?) = other === this || (other is Folder && other.id == id)
 
     override fun hashCode(): Int = id.hashCode()
+
+    public override fun clone(): Folder = super.clone() as Folder
 
     enum class FolderRole(
         @StringRes val folderNameRes: Int,

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -82,6 +82,8 @@ class Folder : RealmObject, Cloneable {
     var isHidden: Boolean = false // For children only (a children Folder is hidden if its parent is collapsed)
     @Transient
     var isCollapsed: Boolean = false // For parents only (collapsing a parent Folder will hide its children)
+    @Transient
+    var roleOrder: Int = CUSTOM_FOLDER_ROLE_ORDER
     //endregion
 
     //region UI data (Transient & Ignore)
@@ -129,6 +131,7 @@ class Folder : RealmObject, Cloneable {
         this.isHistoryComplete = isHistoryComplete
         this.isHidden = isHidden
         this.isCollapsed = isCollapsed
+        this.roleOrder = role?.order ?: CUSTOM_FOLDER_ROLE_ORDER
     }
 
     fun getLocalizedName(context: Context): String {
@@ -152,14 +155,14 @@ class Folder : RealmObject, Cloneable {
         val order: Int,
         val matomoValue: String,
     ) {
-        INBOX(R.string.inboxFolder, R.drawable.ic_drawer_inbox, 0, "inboxFolder"),
+        INBOX(R.string.inboxFolder, R.drawable.ic_drawer_inbox, 8, "inboxFolder"),
+        COMMERCIAL(R.string.commercialFolder, R.drawable.ic_promotions, 7, "commercialFolder"),
+        SOCIALNETWORKS(R.string.socialNetworksFolder, R.drawable.ic_social_media, 6, "socialNetworksFolder"),
+        SENT(R.string.sentFolder, R.drawable.ic_sent_messages, 5, "sentFolder"),
         DRAFT(R.string.draftFolder, R.drawable.ic_draft, 4, "draftFolder"),
-        SENT(R.string.sentFolder, R.drawable.ic_sent_messages, 3, "sentFolder"),
-        SPAM(R.string.spamFolder, R.drawable.ic_spam, 5, "spamFolder"),
-        TRASH(R.string.trashFolder, R.drawable.ic_bin, 6, "trashFolder"),
-        ARCHIVE(R.string.archiveFolder, R.drawable.ic_archive_folder, 7, "archiveFolder"),
-        COMMERCIAL(R.string.commercialFolder, R.drawable.ic_promotions, 1, "commercialFolder"),
-        SOCIALNETWORKS(R.string.socialNetworksFolder, R.drawable.ic_social_media, 2, "socialNetworksFolder"),
+        SPAM(R.string.spamFolder, R.drawable.ic_spam, 3, "spamFolder"),
+        TRASH(R.string.trashFolder, R.drawable.ic_bin, 2, "trashFolder"),
+        ARCHIVE(R.string.archiveFolder, R.drawable.ic_archive_folder, 1, "archiveFolder"),
     }
 
     companion object {
@@ -170,5 +173,6 @@ class Folder : RealmObject, Cloneable {
         const val DEFAULT_IS_HISTORY_COMPLETE = false
 
         const val INBOX_FOLDER_ID = "eJzz9HPyjwAABGYBgQ--"
+        const val CUSTOM_FOLDER_ROLE_ORDER = 0
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -35,6 +35,7 @@ import io.realm.kotlin.serializers.RealmListKSerializer
 import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.annotations.Ignore
 import io.realm.kotlin.types.annotations.PrimaryKey
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -81,6 +82,12 @@ class Folder : RealmObject {
     var isHidden: Boolean = false // For children only (a children Folder is hidden if its parent is collapsed)
     @Transient
     var isCollapsed: Boolean = false // For parents only (collapsing a parent Folder will hide its children)
+    //endregion
+
+    //region UI data (Transient & Ignore)
+    @Transient
+    @Ignore
+    var shouldDisplayDivider: Boolean = false
     //endregion
 
     private val _parents by backlinks(Folder::children)

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -138,12 +138,12 @@ class MainViewModel @Inject constructor(
     }.asLiveData(ioCoroutineContext)
 
     val currentDefaultFoldersLive = _currentMailboxObjectId.flatMapLatest { objectId ->
-        objectId?.let { folderController.getDefaultFoldersAsync().map { it.list.getDefaultMenuFolders() } } ?: emptyFlow()
+        objectId?.let { folderController.getDefaultFoldersAsync().map { it.list.flattenFolderChildren() } } ?: emptyFlow()
     }.asLiveData(ioCoroutineContext)
 
     val currentCustomFoldersLive = _currentMailboxObjectId.flatMapLatest { objectId ->
         objectId
-            ?.let { folderController.getCustomFoldersAsync().map { it.list.getCustomMenuFolders(dismissHiddenChildren = true) } }
+            ?.let { folderController.getCustomFoldersAsync().map { it.list.flattenFolderChildren(dismissHiddenChildren = true) } }
             ?: emptyFlow()
     }.asLiveData(ioCoroutineContext)
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
@@ -195,6 +195,9 @@ class FolderAdapter @Inject constructor(
             }
         }
 
+        /**
+         * If there was no Folder with children, and then now there's at least one, we need to indent the whole Folders list.
+         */
         fun notifyCollapsableFolders() {
             setFoldersJob?.cancel()
             setFoldersJob = globalCoroutineScope.launch {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
@@ -99,8 +99,6 @@ class FolderAdapter @Inject constructor(
     override fun onBindViewHolder(holder: FolderViewHolder, position: Int) = with(holder.binding) {
         val folder = folders[position]
 
-        root.tag = if (folder.shouldDisplayDivider) null else UiUtils.IGNORE_DIVIDER_TAG
-
         when (getItemViewType(position)) {
             DisplayType.SELECTABLE_FOLDER.layout -> (this as ItemSelectableFolderBinding).root.displayFolder(folder)
             DisplayType.MENU_DRAWER.layout -> (this as ItemFolderMenuDrawerBinding).root.displayMenuDrawerFolder(folder)
@@ -150,6 +148,7 @@ class FolderAdapter @Inject constructor(
     ) {
         val folderName = folder.getLocalizedName(context)
 
+        tag = if (folder.shouldDisplayDivider) null else UiUtils.IGNORE_DIVIDER_TAG
         text = folderName
         icon = AppCompatResources.getDrawable(context, iconId)
         setSelectedState(currentFolderId == folder.id)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
@@ -45,7 +45,7 @@ class FolderAdapter @Inject constructor(
     private val globalCoroutineScope: CoroutineScope,
 ) : ListAdapter<Folder, FolderViewHolder>(FolderDiffCallback()) {
 
-    private inline val items: List<Folder> get() = currentList
+    private inline val folders: List<Folder> get() = currentList
 
     private var setFoldersJob: Job? = null
 
@@ -87,7 +87,7 @@ class FolderAdapter @Inject constructor(
 
     override fun onBindViewHolder(holder: FolderViewHolder, position: Int, payloads: MutableList<Any>) = runCatchingRealm {
         if (payloads.firstOrNull() == Unit) {
-            val folder = items[position]
+            val folder = folders[position]
             if (getItemViewType(position) == DisplayType.SELECTABLE_FOLDER.layout) {
                 (holder.binding as ItemSelectableFolderBinding).root.setSelectedState(currentFolderId == folder.id)
             }
@@ -97,7 +97,7 @@ class FolderAdapter @Inject constructor(
     }.getOrDefault(Unit)
 
     override fun onBindViewHolder(holder: FolderViewHolder, position: Int) = with(holder.binding) {
-        val folder = items[position]
+        val folder = folders[position]
 
         root.tag = if (folder.shouldDisplayDivider) null else UiUtils.IGNORE_DIVIDER_TAG
 
@@ -111,7 +111,7 @@ class FolderAdapter @Inject constructor(
         return if (isInMenuDrawer) DisplayType.MENU_DRAWER.layout else DisplayType.SELECTABLE_FOLDER.layout
     }
 
-    override fun getItemCount(): Int = runCatchingRealm { items.size }.getOrDefault(0)
+    override fun getItemCount(): Int = runCatchingRealm { folders.size }.getOrDefault(0)
 
     private fun UnreadFolderItemView.displayMenuDrawerFolder(folder: Folder) {
 
@@ -226,7 +226,7 @@ class FolderAdapter @Inject constructor(
     }
 
     private fun notifyCurrentItem(folderId: String) {
-        val position = items.indexOfFirst { it.id == folderId }
+        val position = folders.indexOfFirst { it.id == folderId }
         notifyItemChanged(position)
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/FolderAdapter.kt
@@ -188,7 +188,7 @@ class FolderAdapter @Inject constructor(
 
         var isFirstCustomFolder = true
         val foldersWithDivider = newFolders.map { folder ->
-            folder.apply {
+            folder.clone().apply {
                 shouldDisplayDivider = if (folder.role == null && isFirstCustomFolder) {
                     isFirstCustomFolder = false
                     true

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveFragment.kt
@@ -133,7 +133,7 @@ class MoveFragment : Fragment() {
     }
 
     private fun observeFolders() {
-        moveViewModel.getFolders(mainViewModel.currentDefaultFoldersLive.value!!).observe(viewLifecycleOwner, ::setSearchBarUi)
+        moveViewModel.getFolders().observe(viewLifecycleOwner, ::setSearchBarUi)
     }
 
     private fun setSearchBarUi(allFolders: List<Folder>) = with(binding) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveFragment.kt
@@ -17,27 +17,33 @@
  */
 package com.infomaniak.mail.ui.main.menu
 
+import android.graphics.drawable.InsetDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isGone
-import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.RecyclerView
 import com.infomaniak.lib.core.utils.hideKeyboard
 import com.infomaniak.lib.core.utils.safeBinding
+import com.infomaniak.lib.core.views.DividerItemDecorator
 import com.infomaniak.mail.MatomoMail.SEARCH_DELETE_NAME
 import com.infomaniak.mail.MatomoMail.SEARCH_VALIDATE_NAME
 import com.infomaniak.mail.MatomoMail.trackCreateFolderEvent
 import com.infomaniak.mail.MatomoMail.trackMoveSearchEvent
 import com.infomaniak.mail.R
+import com.infomaniak.mail.data.cache.mailboxContent.FolderController
 import com.infomaniak.mail.data.models.Folder
-import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.databinding.FragmentMoveBinding
+import com.infomaniak.mail.ui.MainViewModel
+import com.infomaniak.mail.ui.alertDialogs.InputAlertDialog
+import com.infomaniak.mail.utils.UiUtils
+import com.infomaniak.mail.utils.extensions.bindAlertToViewLifecycle
 import com.infomaniak.mail.utils.extensions.handleEditorSearchAction
 import com.infomaniak.mail.utils.extensions.setOnClearTextClickListener
 import com.infomaniak.mail.utils.extensions.setSystemBarsColors
@@ -45,27 +51,42 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class MoveFragment : MenuFoldersFragment() {
+class MoveFragment : Fragment() {
 
     private var binding: FragmentMoveBinding by safeBinding()
     private val navigationArgs: MoveFragmentArgs by navArgs()
     private val moveViewModel: MoveViewModel by viewModels()
+    private val mainViewModel: MainViewModel by activityViewModels()
+
+    // @Inject
+    // lateinit var searchFolderAdapter: FolderAdapter
 
     @Inject
-    lateinit var searchFolderAdapter: FolderAdapter
+    lateinit var moveFolderAdapter: FolderAdapter
 
-    private val searchResultsAdapter by lazy {
-        searchFolderAdapter(isInMenuDrawer, shouldIndent = false, onFolderClicked = ::onFolderSelected)
+    @Inject
+    lateinit var inputDialog: InputAlertDialog
+
+    @Inject
+    lateinit var folderController: FolderController
+
+    // private val searchResultsAdapter by lazy {
+    //     searchFolderAdapter(isInMenuDrawer, shouldIndent = false, onFolderClicked = ::onFolderSelected)
+    // }
+
+    private var isSearching = false
+    private var hasAlreadyTrackedSearch = false
+
+    private val moveFoldersLists: RecyclerView by lazy { binding.moveFoldersLists }
+
+    private val moveFoldersAdapter: FolderAdapter by lazy {
+        moveFolderAdapter(
+            isInMenuDrawer = false,
+            onFolderClicked = ::onFolderSelected,
+        )
     }
 
-    private var hasAlreadyTrackedFolderSearch = false
-
-    private var currentFolderId: String? = null
-
-    override val defaultFoldersList: RecyclerView by lazy { binding.defaultFoldersList }
-    override val customFoldersList: RecyclerView by lazy { binding.customFoldersList }
-
-    override val isInMenuDrawer = false
+    // private val isInMenuDrawer = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return FragmentMoveBinding.inflate(inflater, container, false).also { binding = it }.root
@@ -75,11 +96,26 @@ class MoveFragment : MenuFoldersFragment() {
         super.onViewCreated(view, savedInstanceState)
         setSystemBarsColors()
 
+        bindAlertToViewLifecycle(inputDialog)
+        setupAdapters()
         setupListeners()
         setupFolderAdapters()
         setupCreateFolderDialog()
         observeNewFolderCreation()
         observeSearchResults()
+    }
+
+    private fun setupAdapters() {
+
+        moveFoldersLists.adapter = moveFoldersAdapter
+
+        val margin = resources.getDimensionPixelSize(R.dimen.dividerHorizontalPadding)
+        binding.moveFoldersLists.addItemDecoration(
+            DividerItemDecorator(
+                divider = InsetDrawable(UiUtils.dividerDrawable(requireContext()), margin, 0, margin, 0),
+                shouldIgnoreView = { view -> view.tag == UiUtils.IGNORE_DIVIDER_TAG },
+            ),
+        )
     }
 
     override fun onStop() {
@@ -110,18 +146,13 @@ class MoveFragment : MenuFoldersFragment() {
         )
     }
 
+
     private fun setupFolderAdapters() {
-        moveViewModel.getFolderIdAndCustomFolders().observe(viewLifecycleOwner) { (folderId, customFolders) ->
+        moveViewModel.getFolders(mainViewModel.currentDefaultFoldersLive.value!!).observe(viewLifecycleOwner) { allFolders ->
 
-            currentFolderId = folderId
-
-            val defaultFoldersWithoutDraft = mainViewModel.currentDefaultFoldersLive.value!!.let { folders ->
-                folders.filterNot { it.role == FolderRole.DRAFT }
-            }
-
-            defaultFoldersAdapter.setFolders(defaultFoldersWithoutDraft, folderId)
-            customFoldersAdapter.setFolders(customFolders, folderId)
-            setSearchBarUi(allFolders = defaultFoldersWithoutDraft + customFolders)
+            // moveFoldersAdapter.setFolders(allFolders, folderId)
+            // customFoldersAdapter.setFolders(customFolders, folderId)
+            setSearchBarUi(allFolders)
         }
     }
 
@@ -132,29 +163,30 @@ class MoveFragment : MenuFoldersFragment() {
         }
     }
 
-    override fun onFolderSelected(folderId: String): Unit = with(navigationArgs) {
+    private fun onFolderSelected(folderId: String): Unit = with(navigationArgs) {
         mainViewModel.moveThreadsOrMessageTo(folderId, threadsUids.toList(), messageUid)
         findNavController().popBackStack()
     }
 
-    override fun onFolderCollapse(folderId: String, shouldCollapse: Boolean) = Unit
+    private fun onFolderCollapse(folderId: String, shouldCollapse: Boolean) = Unit
 
     private fun setSearchBarUi(allFolders: List<Folder>) = with(binding) {
-        searchResultsList.adapter = searchResultsAdapter
+        // searchResultsList.adapter = searchResultsAdapter
 
         searchInputLayout.setOnClearTextClickListener { trackMoveSearchEvent(SEARCH_DELETE_NAME) }
 
         searchTextInput.apply {
-            toggleFolderListsVisibility(!text.isNullOrBlank())
+            toggleFolderListsVisibility(text?.toString())
+
             doOnTextChanged { newQuery, _, _, _ ->
-                toggleFolderListsVisibility(!newQuery.isNullOrBlank())
+                toggleFolderListsVisibility(newQuery?.toString())
                 if (newQuery?.isNotBlank() == true) {
                     moveViewModel.filterFolders(newQuery.toString(), allFolders, shouldDebounce = true)
                 }
 
-                if (!hasAlreadyTrackedFolderSearch) {
+                if (!hasAlreadyTrackedSearch) {
                     trackMoveSearchEvent("executeSearch")
-                    hasAlreadyTrackedFolderSearch = true
+                    hasAlreadyTrackedSearch = true
                 }
             }
 
@@ -165,14 +197,29 @@ class MoveFragment : MenuFoldersFragment() {
         }
     }
 
-    private fun toggleFolderListsVisibility(isSearching: Boolean) = with(binding) {
-        searchResultsList.isVisible = isSearching
-        moveFoldersLists.isGone = isSearching
+    private fun toggleFolderListsVisibility(query: String?) = with(moveViewModel) {
+        isSearching = !query.isNullOrBlank()
+        if (!isSearching) moveFoldersAdapter.setFolders(allFolders, currentFolderId)
     }
 
-    private fun observeSearchResults() {
-        moveViewModel.filterResults.observe(viewLifecycleOwner) { folders ->
-            searchResultsAdapter.setFolders(folders, currentFolderId)
+    private fun observeSearchResults() = with(moveViewModel) {
+        filterResults.observe(viewLifecycleOwner) { folders ->
+            if (isSearching) moveFoldersAdapter.setFolders(folders, currentFolderId)
         }
+    }
+
+    /**
+     * Asynchronously validate folder name locally
+     * @return error string, otherwise null
+     */
+    private fun checkForFolderCreationErrors(folderName: CharSequence): String? = when {
+        folderName.length > 255 -> getString(R.string.errorNewFolderNameTooLong)
+        folderName.contains(Regex(INVALID_CHARACTERS_PATTERN)) -> getString(R.string.errorNewFolderInvalidCharacter)
+        folderController.getRootFolder(folderName.toString()) != null -> context?.getString(R.string.errorNewFolderAlreadyExists)
+        else -> null
+    }
+
+    companion object {
+        private const val INVALID_CHARACTERS_PATTERN = "[/'\"]"
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveFragment.kt
@@ -62,6 +62,7 @@ class MoveFragment : Fragment() {
 
     @Inject
     lateinit var folderController: FolderController
+
     @Inject
     lateinit var injectedFolderAdapter: FolderAdapter
 
@@ -140,10 +141,10 @@ class MoveFragment : Fragment() {
         searchInputLayout.setOnClearTextClickListener { trackMoveSearchEvent(SEARCH_DELETE_NAME) }
 
         searchTextInput.apply {
-            toggleFolderListsVisibility(text?.toString())
+            toggleFolderListsVisibility(text?.toString(), allFolders)
 
             doOnTextChanged { newQuery, _, _, _ ->
-                toggleFolderListsVisibility(newQuery?.toString())
+                toggleFolderListsVisibility(newQuery?.toString(), allFolders)
                 if (newQuery?.isNotBlank() == true) {
                     moveViewModel.filterFolders(newQuery.toString(), allFolders, shouldDebounce = true)
                 }
@@ -161,9 +162,9 @@ class MoveFragment : Fragment() {
         }
     }
 
-    private fun toggleFolderListsVisibility(query: String?) = with(moveViewModel) {
+    private fun toggleFolderListsVisibility(query: String?, allFolders: List<Folder>) {
         isSearching = !query.isNullOrBlank()
-        if (!isSearching) folderAdapter.setFolders(allFolders, currentFolderId)
+        if (!isSearching) folderAdapter.setFolders(allFolders, moveViewModel.currentFolderId)
     }
 
     private fun observeSearchResults() = with(moveViewModel) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveFragment.kt
@@ -64,9 +64,7 @@ class MoveFragment : Fragment() {
     lateinit var folderController: FolderController
 
     @Inject
-    lateinit var injectedFolderAdapter: FolderAdapter
-
-    private val folderAdapter inline get() = binding.foldersRecyclerView.adapter as FolderAdapter
+    lateinit var folderAdapter: FolderAdapter
 
     private var isSearching = false
     private var hasAlreadyTrackedSearch = false
@@ -90,7 +88,7 @@ class MoveFragment : Fragment() {
 
     private fun setupRecyclerView() = with(binding.foldersRecyclerView) {
 
-        adapter = injectedFolderAdapter(
+        adapter = folderAdapter(
             isInMenuDrawer = false,
             onFolderClicked = ::onFolderSelected,
         )

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveFragment.kt
@@ -88,10 +88,7 @@ class MoveFragment : Fragment() {
 
     private fun setupRecyclerView() = with(binding.foldersRecyclerView) {
 
-        adapter = folderAdapter(
-            isInMenuDrawer = false,
-            onFolderClicked = ::onFolderSelected,
-        )
+        adapter = folderAdapter(isInMenuDrawer = false, onFolderClicked = ::onFolderSelected)
 
         val margin = resources.getDimensionPixelSize(R.dimen.dividerHorizontalPadding)
         addItemDecoration(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveViewModel.kt
@@ -23,7 +23,6 @@ import com.infomaniak.mail.data.cache.mailboxContent.FolderController
 import com.infomaniak.mail.data.cache.mailboxContent.MessageController
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.models.Folder
-import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.utils.coroutineContext
 import com.infomaniak.mail.utils.extensions.appContext
@@ -57,15 +56,14 @@ class MoveViewModel @Inject constructor(
         filterJob?.cancel()
     }
 
-    fun getFolders(defaultFolders: List<Folder>) = liveData(ioCoroutineContext) {
+    fun getFolders() = liveData(ioCoroutineContext) {
 
         currentFolderId = messageUid?.let(messageController::getMessage)?.folderId
             ?: threadController.getThread(threadsUids.first())!!.folderId
 
-        val defaultFoldersWithoutDraft = defaultFolders.filterNot { it.role == FolderRole.DRAFT }
-        val customFolders = folderController.getCustomFolders().getCustomMenuFolders()
+        val folders = folderController.getMoveFolders().getCustomMenuFolders()
 
-        emit(defaultFoldersWithoutDraft + customFolders)
+        emit(folders)
     }
 
     fun filterFolders(query: String, folders: List<Folder>, shouldDebounce: Boolean) = viewModelScope.launch(ioCoroutineContext) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveViewModel.kt
@@ -26,7 +26,7 @@ import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.utils.coroutineContext
 import com.infomaniak.mail.utils.extensions.appContext
-import com.infomaniak.mail.utils.extensions.getCustomMenuFolders
+import com.infomaniak.mail.utils.extensions.flattenFolderChildren
 import com.infomaniak.mail.utils.extensions.standardize
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
@@ -61,7 +61,7 @@ class MoveViewModel @Inject constructor(
         currentFolderId = messageUid?.let(messageController::getMessage)?.folderId
             ?: threadController.getThread(threadsUids.first())!!.folderId
 
-        val folders = folderController.getMoveFolders().getCustomMenuFolders()
+        val folders = folderController.getMoveFolders().flattenFolderChildren()
 
         emit(folders)
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/MoveViewModel.kt
@@ -51,7 +51,6 @@ class MoveViewModel @Inject constructor(
     private val threadsUids inline get() = savedStateHandle.get<Array<String>>(MoveFragmentArgs::threadsUids.name)!!
 
     var currentFolderId: String? = null
-    val allFolders = mutableListOf<Folder>()
     var filterResults: MutableLiveData<List<Folder>> = MutableLiveData()
 
     fun cancelSearch() {
@@ -65,9 +64,8 @@ class MoveViewModel @Inject constructor(
 
         val defaultFoldersWithoutDraft = defaultFolders.filterNot { it.role == FolderRole.DRAFT }
         val customFolders = folderController.getCustomFolders().getCustomMenuFolders()
-        allFolders.addAll(defaultFoldersWithoutDraft + customFolders)
 
-        emit(allFolders)
+        emit(defaultFoldersWithoutDraft + customFolders)
     }
 
     fun filterFolders(query: String, folders: List<Folder>, shouldDebounce: Boolean) = viewModelScope.launch(ioCoroutineContext) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -168,7 +168,7 @@ class ThreadAdapter(
         val item = items[position]
 
         holder.binding.root.tag = if (item is SuperCollapsedBlock || (item is Message && item.shouldHideDivider)) {
-            IGNORE_DIVIDER_TAG
+            UiUtils.IGNORE_DIVIDER_TAG
         } else {
             null
         }
@@ -784,9 +784,6 @@ class ThreadAdapter(
     }
 
     companion object {
-
-        const val IGNORE_DIVIDER_TAG = "ignoreDividerTag"
-
         private val contextMenuTypeForHitTestResultType = mapOf(
             HitTestResult.PHONE_TYPE to ContextMenuType.PHONE,
             HitTestResult.EMAIL_TYPE to ContextMenuType.EMAIL,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -75,7 +75,7 @@ class ThreadAdapter(
     private var threadAdapterCallbacks: ThreadAdapterCallbacks? = null,
 ) : ListAdapter<Any, ThreadAdapterViewHolder>(MessageDiffCallback()) {
 
-    inline val items: MutableList<Any> get() = currentList
+    inline val items: List<Any> get() = currentList
 
     //region Auto-scroll at Thread opening
     private val currentSetOfLoadedExpandedMessagesUids = mutableSetOf<String>()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -74,6 +74,7 @@ import com.infomaniak.mail.ui.main.thread.actions.ReplyBottomSheetDialogArgs
 import com.infomaniak.mail.ui.main.thread.actions.ThreadActionsBottomSheetDialogArgs
 import com.infomaniak.mail.ui.main.thread.calendar.AttendeesBottomSheetDialogArgs
 import com.infomaniak.mail.utils.PermissionUtils
+import com.infomaniak.mail.utils.UiUtils
 import com.infomaniak.mail.utils.UiUtils.dividerDrawable
 import com.infomaniak.mail.utils.extensions.*
 import com.infomaniak.mail.utils.extensions.AttachmentExtensions.openAttachment
@@ -317,7 +318,7 @@ class ThreadFragment : Fragment() {
         binding.messagesList.addItemDecoration(
             DividerItemDecorator(
                 divider = InsetDrawable(dividerDrawable(requireContext()), 0),
-                shouldIgnoreView = { view -> view.tag == ThreadAdapter.IGNORE_DIVIDER_TAG },
+                shouldIgnoreView = { view -> view.tag == UiUtils.IGNORE_DIVIDER_TAG },
             ),
         )
 

--- a/app/src/main/java/com/infomaniak/mail/utils/UiUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/UiUtils.kt
@@ -37,6 +37,7 @@ import com.infomaniak.mail.utils.extensions.updateNavigationBarColor
 object UiUtils {
 
     const val FULLY_SLID = 1.0f
+    const val IGNORE_DIVIDER_TAG = "ignoreDividerTag"
 
     @ColorInt
     fun pointBetweenColors(@ColorInt from: Int, @ColorInt to: Int, percent: Float): Int {

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -301,14 +301,6 @@ fun List<Folder>.getMenuFolders(): Pair<List<Folder>, List<Folder>> {
     }
 }
 
-fun List<Folder>.getDefaultMenuFolders(): List<Folder> {
-    return sortedBy { it.role?.order }.flattenFolderChildren()
-}
-
-fun List<Folder>.getCustomMenuFolders(dismissHiddenChildren: Boolean = false): List<Folder> {
-    return flattenFolderChildren(dismissHiddenChildren)
-}
-
 fun List<Folder>.flattenFolderChildren(dismissHiddenChildren: Boolean = false): List<Folder> {
 
     if (isEmpty()) return this

--- a/app/src/main/res/layout/fragment_move.xml
+++ b/app/src/main/res/layout/fragment_move.xml
@@ -91,11 +91,11 @@
                     android:hint="@string/moveSearchFieldPlaceholder" />
             </com.google.android.material.textfield.TextInputLayout>
 
-            <FrameLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+            <!--<FrameLayout-->
+            <!--    android:layout_width="match_parent"-->
+            <!--    android:layout_height="match_parent">-->
 
-                <androidx.core.widget.NestedScrollView
+                <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/moveFoldersLists"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
@@ -103,50 +103,22 @@
                     android:clipToPadding="false"
                     android:fillViewport="true"
                     android:paddingBottom="@dimen/marginStandardMedium"
-                    android:scrollbars="none">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:orientation="vertical">
-
-                        <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/defaultFoldersList"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:nestedScrollingEnabled="false"
-                            android:overScrollMode="never"
-                            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                            tools:itemCount="4"
-                            tools:listitem="@layout/item_folder_menu_drawer" />
-
-                        <com.google.android.material.divider.MaterialDivider
-                            style="@style/ItemDivider"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content" />
-
-                        <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/customFoldersList"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:nestedScrollingEnabled="false"
-                            android:overScrollMode="never"
-                            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                            tools:itemCount="6"
-                            tools:listitem="@layout/item_folder_menu_drawer" />
-                    </LinearLayout>
-                </androidx.core.widget.NestedScrollView>
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/searchResultsList"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:paddingBottom="@dimen/marginStandardMedium"
-                    android:visibility="gone"
+                    android:scrollbars="none"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     tools:itemCount="6"
                     tools:listitem="@layout/item_folder_menu_drawer" />
-            </FrameLayout>
+                    <!--android:visibility="gone"-->
+
+                <!--<androidx.recyclerview.widget.RecyclerView-->
+                <!--    android:id="@+id/searchResultsList"-->
+                <!--    android:layout_width="match_parent"-->
+                <!--    android:layout_height="match_parent"-->
+                <!--    android:paddingBottom="@dimen/marginStandardMedium"-->
+                <!--    android:visibility="gone"-->
+                <!--    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"-->
+                <!--    tools:itemCount="6"-->
+                <!--    tools:listitem="@layout/item_folder_menu_drawer" />-->
+            <!--</FrameLayout>-->
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_move.xml
+++ b/app/src/main/res/layout/fragment_move.xml
@@ -91,34 +91,18 @@
                     android:hint="@string/moveSearchFieldPlaceholder" />
             </com.google.android.material.textfield.TextInputLayout>
 
-            <!--<FrameLayout-->
-            <!--    android:layout_width="match_parent"-->
-            <!--    android:layout_height="match_parent">-->
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/moveFoldersLists"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:background="@color/backgroundColor"
-                    android:clipToPadding="false"
-                    android:fillViewport="true"
-                    android:paddingBottom="@dimen/marginStandardMedium"
-                    android:scrollbars="none"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    tools:itemCount="6"
-                    tools:listitem="@layout/item_folder_menu_drawer" />
-                    <!--android:visibility="gone"-->
-
-                <!--<androidx.recyclerview.widget.RecyclerView-->
-                <!--    android:id="@+id/searchResultsList"-->
-                <!--    android:layout_width="match_parent"-->
-                <!--    android:layout_height="match_parent"-->
-                <!--    android:paddingBottom="@dimen/marginStandardMedium"-->
-                <!--    android:visibility="gone"-->
-                <!--    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"-->
-                <!--    tools:itemCount="6"-->
-                <!--    tools:listitem="@layout/item_folder_menu_drawer" />-->
-            <!--</FrameLayout>-->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/foldersRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/backgroundColor"
+                android:clipToPadding="false"
+                android:fillViewport="true"
+                android:paddingBottom="@dimen/marginStandardMedium"
+                android:scrollbars="none"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:itemCount="6"
+                tools:listitem="@layout/item_folder_menu_drawer" />
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 </LinearLayout>


### PR DESCRIPTION
Remove the nested scrollView, and merge the 3 recycler views into only 1.

Also, the MoveFragment is no longer a `MenuFoldersFragment`, it's only a `Fragment` now.
In the end, the `MenuFoldersFragment` will probably be deleted.