### PR TITLE
Remove `reason` in `sendFailedNotification()` to dissociate Sentries

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -148,7 +148,6 @@ object SentryDebug {
 
             scope.level = sentryLevel
 
-            scope.setTag("reason", reason)
             scope.setExtra("userId", "${userId?.toString()}")
             scope.setExtra("currentUserId", "[${AccountUtils.currentUserId}]")
             scope.setExtra("mailboxId", "${mailboxId?.toString()}")
@@ -156,7 +155,7 @@ object SentryDebug {
             scope.setExtra("currentMailboxEmail", "[${AccountUtils.currentMailboxEmail}]")
             scope.setExtra("messageUid", "$messageUid")
 
-            val message = "We received a Notification, but we failed to show it"
+            val message = "Failed Notif : $reason"
 
             throwable?.let {
                 scope.setExtra("message", message)


### PR DESCRIPTION
All Sentries about failed notifications are merged into one.
It's hard to really see what's happening.

The reason will now be in the Sentry's message, so we'll have 1 different Sentry by reason.