### PR TITLE
Add Sentry to check if the API can send us a Message from another Folder

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -186,7 +186,7 @@ class FolderController @Inject constructor(
         }
 
         fun getOrCreateSearchFolder(realm: MutableRealm): Folder {
-            return getFolderQuery(Folder::id.name, SEARCH_FOLDER_ID, realm).find() ?: let {
+            return getFolderQuery(Folder::id.name, SEARCH_FOLDER_ID, realm).find() ?: run {
                 realm.copyToRealm(Folder().apply { id = SEARCH_FOLDER_ID })
             }
         }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -665,6 +665,10 @@ class RefreshController @Inject constructor(
         remoteMessages.forEach { remoteMessage ->
             scope.ensureActive()
 
+            if (remoteMessage.uid.substringAfter('@') != folder.id) {
+                SentryDebug.sendMessageInWrongFolder(remoteMessage, folder, realm = this)
+            }
+
             val shouldSkipThisMessage = addRemoteMessageToFolder(remoteMessage, folder, folderMessages)
             if (shouldSkipThisMessage) return@forEach
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -186,6 +186,7 @@ class Message : RealmObject {
                 _folders.first()
             }
         }
+    val foldersForSentry get() = _folders // TODO: Remove this when no Sentry needs it.
 
     inline val sender get() = from.firstOrNull()
 

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import androidx.navigation.NavController
 import com.infomaniak.mail.BuildConfig
 import com.infomaniak.mail.data.cache.mailboxContent.DraftController
+import com.infomaniak.mail.data.cache.mailboxContent.MessageController
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.draft.Draft
@@ -190,6 +191,23 @@ object SentryDebug {
                     )
                 }
             }
+        }
+    }
+
+    fun sendMessageInWrongFolder(remoteMessage: Message, folder: Folder, realm: TypedRealm) {
+        val localMessage = MessageController.getMessage(remoteMessage.uid, realm)
+        Sentry.withScope { scope ->
+            scope.setExtra(
+                "localMessageFolders",
+                "${localMessage?.foldersForSentry?.joinToString { "${it.role?.name} | ${it.id}" }}",
+            )
+            scope.setExtra("remoteMessageUid", remoteMessage.uid)
+            scope.setExtra("folderRole", "${folder.role?.name}")
+            scope.setExtra("folderId", folder.id)
+            Sentry.captureMessage(
+                "Message is in wrong Folder (related to 'Message has multiple parent folders'",
+                SentryLevel.ERROR,
+            )
         }
     }
 


### PR DESCRIPTION
We have Messages with several parent Folders, which shouldn't be possible.

For example, we have Messages that are in the same time in INBOX & Trash, or INBOX & another Folder.
Non-exhaustive list of other Folders :
- Trash
- Drafts
- Promotions
- Social networks
- Custom folders that are children of INBOX.
- probably more…

This Sentry is here to check if the issue comes from the API.