### PR TITLE
Add Sentry to check if the WebView version name is well formatted

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -305,6 +305,17 @@ object SentryDebug {
             Sentry.captureMessage("Credentials issue when trying to auto-sync user", SentryLevel.ERROR)
         }
     }
+
+    fun sendWebViewVersionName(webViewVersionName: String?, majorVersion: Int) {
+        Sentry.withScope { scope ->
+            scope.setExtra("webViewVersionName", webViewVersionName.toString())
+            scope.setExtra("majorVersion", "$majorVersion")
+            Sentry.captureMessage(
+                "WebView version name might be null on some devices. Checking that the version name is ok.",
+                SentryLevel.INFO,
+            )
+        }
+    }
     //endregion
 
     //region Utils


### PR DESCRIPTION
Some user have the banner saying the WebView is outdated. Adding a sentry to understand what we have as version will help to understand the problem.