### PR TITLE
Delete Drafts orphans after sending the Sentry about them

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -75,8 +75,8 @@ class ThreadController @Inject constructor(
 
     /**
      * Initialize and retrieve the search Threads obtained from the API.
-     * - Format the remote threads to make them compatible with the existing logic.
-     * - Preserve old message data if it already exists locally.
+     * - Format the remote Threads to make them compatible with the existing logic.
+     * - Preserve old Messages data if it already exists locally.
      * - Handle duplicates using the existing logic.
      * @param remoteThreads The list of API Threads that need to be processed.
      * @param filterFolder The selected Folder on which we filter the Search.

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -242,7 +242,7 @@ object SentryDebug {
         return orphanThreads
     }
 
-    fun sendOrphanDrafts(realm: TypedRealm) {
+    fun sendOrphanDrafts(realm: TypedRealm): RealmResults<Draft> {
         val orphanDrafts = DraftController.getOrphanDrafts(realm)
         if (orphanDrafts.isNotEmpty()) {
             Sentry.withScope { scope ->
@@ -259,6 +259,7 @@ object SentryDebug {
                 Sentry.captureMessage("We found some orphan Drafts.", SentryLevel.ERROR)
             }
         }
+        return orphanDrafts
     }
 
     fun sendOverScrolledMessage(clientWidth: Int, scrollWidth: Int, messageUid: String) {

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -20,7 +20,6 @@ package com.infomaniak.mail.utils
 import android.os.Bundle
 import androidx.navigation.NavController
 import com.infomaniak.mail.BuildConfig
-import com.infomaniak.mail.data.cache.mailboxContent.DraftController
 import com.infomaniak.mail.data.cache.mailboxContent.MessageController
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.models.Folder
@@ -242,13 +241,12 @@ object SentryDebug {
         return orphanThreads
     }
 
-    fun sendOrphanDrafts(realm: TypedRealm): RealmResults<Draft> {
-        val orphanDrafts = DraftController.getOrphanDrafts(realm)
-        if (orphanDrafts.isNotEmpty()) {
+    fun sendOrphanDrafts(orphans: List<Draft>) {
+        if (orphans.isNotEmpty()) {
             Sentry.withScope { scope ->
                 scope.setExtra(
                     "orphanDrafts",
-                    orphanDrafts.joinToString {
+                    orphans.joinToString {
                         if (it.messageUid == null) {
                             "${Draft::localUuid.name}: [${it.localUuid}]"
                         } else {
@@ -259,7 +257,6 @@ object SentryDebug {
                 Sentry.captureMessage("We found some orphan Drafts.", SentryLevel.ERROR)
             }
         }
-        return orphanDrafts
     }
 
     fun sendOverScrolledMessage(clientWidth: Int, scrollWidth: Int, messageUid: String) {

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -198,7 +198,8 @@ class DraftsActionsWorker @AssistedInject constructor(
         mailboxContentRealm.executeRealmCallbacks(realmActionsOnDraft)
 
         mailboxContentRealm.writeBlocking {
-            val orphans = SentryDebug.sendOrphanDrafts(realm = this)
+            val orphans = DraftController.getOrphanDrafts(realm = this)
+            SentryDebug.sendOrphanDrafts(orphans)
             delete(orphans)
         }
 

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -197,7 +197,10 @@ class DraftsActionsWorker @AssistedInject constructor(
 
         mailboxContentRealm.executeRealmCallbacks(realmActionsOnDraft)
 
-        SentryDebug.sendOrphanDrafts(mailboxContentRealm)
+        mailboxContentRealm.writeBlocking {
+            val orphans = SentryDebug.sendOrphanDrafts(realm = this)
+            delete(orphans)
+        }
 
         showDraftErrorNotification(isTrackedDraftSuccess, trackedDraftErrorMessageResId, trackedDraftAction)
 


### PR DESCRIPTION
Sending the Sentry about orphan Drafts is nice, but if we don't delete them… They'll just keep sending Sentry that we are already aware about, until the end of times.