### PR TITLE
Move the access of `uiAttachments` liveData to `updateDraftAttachmentsFromLiveData()` parameters

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -496,7 +496,7 @@ class NewMessageFragment : Fragment() {
                 observeImportAttachments()
             } else if (attachments.count() > attachmentAdapter.itemCount) {
                 // If we are adding Attachments, directly upload them to save time when sending/saving the Draft.
-                newMessageViewModel.uploadAttachmentsToServer()
+                newMessageViewModel.uploadAttachmentsToServer(attachments)
             }
 
             // When removing an Attachment, both counts will be the same, because the Adapter is already notified.

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -714,7 +714,7 @@ class NewMessageViewModel @Inject constructor(
     fun uploadAttachmentsToServer(uiAttachments: List<Attachment>) = viewModelScope.launch(ioDispatcher) {
         val localUuid = draftLocalUuid ?: return@launch
         val localDraft = mailboxContentRealm().writeBlocking {
-            DraftController.getDraft(localUuid, realm = this)?.also { it.updateDraftAttachmentsFromLiveData(uiAttachments) }
+            DraftController.getDraft(localUuid, realm = this)?.also { it.updateDraftAttachmentsWithLiveData(uiAttachments) }
         } ?: return@launch
 
         runCatching {
@@ -780,7 +780,7 @@ class NewMessageViewModel @Inject constructor(
         cc = ccLiveData.valueOrEmpty().toRealmList()
         bcc = bccLiveData.valueOrEmpty().toRealmList()
 
-        updateDraftAttachmentsFromLiveData(attachmentsLiveData.valueOrEmpty())
+        updateDraftAttachmentsWithLiveData(attachmentsLiveData.valueOrEmpty())
 
         subject = subjectValue
 
@@ -811,7 +811,7 @@ class NewMessageViewModel @Inject constructor(
         }
     }
 
-    private fun Draft.updateDraftAttachmentsFromLiveData(uiAttachments: List<Attachment>) {
+    private fun Draft.updateDraftAttachmentsWithLiveData(uiAttachments: List<Attachment>) {
 
         val updatedAttachments = uiAttachments.map { uiAttachment ->
             // If a localAttachment has the same `uploadLocalUri` than a UI one, it means it represents the same Attachment.

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -711,10 +711,10 @@ class NewMessageViewModel @Inject constructor(
         }
     }
 
-    fun uploadAttachmentsToServer() = viewModelScope.launch(ioDispatcher) {
+    fun uploadAttachmentsToServer(uiAttachments: List<Attachment>) = viewModelScope.launch(ioDispatcher) {
         val localUuid = draftLocalUuid ?: return@launch
         val localDraft = mailboxContentRealm().writeBlocking {
-            DraftController.getDraft(localUuid, realm = this)?.also { it.updateDraftAttachmentsFromLiveData() }
+            DraftController.getDraft(localUuid, realm = this)?.also { it.updateDraftAttachmentsFromLiveData(uiAttachments) }
         } ?: return@launch
 
         runCatching {
@@ -780,7 +780,7 @@ class NewMessageViewModel @Inject constructor(
         cc = ccLiveData.valueOrEmpty().toRealmList()
         bcc = bccLiveData.valueOrEmpty().toRealmList()
 
-        updateDraftAttachmentsFromLiveData()
+        updateDraftAttachmentsFromLiveData(attachmentsLiveData.valueOrEmpty())
 
         subject = subjectValue
 
@@ -811,8 +811,9 @@ class NewMessageViewModel @Inject constructor(
         }
     }
 
-    private fun Draft.updateDraftAttachmentsFromLiveData() {
-        val updatedAttachments = attachmentsLiveData.valueOrEmpty().map { uiAttachment ->
+    private fun Draft.updateDraftAttachmentsFromLiveData(uiAttachments: List<Attachment>) {
+
+        val updatedAttachments = uiAttachments.map { uiAttachment ->
             // If a localAttachment has the same `uploadLocalUri` than a UI one, it means it represents the same Attachment.
             val localAttachment = attachments.filter { it.uploadLocalUri == uiAttachment.uploadLocalUri }
                 .also {


### PR DESCRIPTION
We already have the info we need, no need to fetch them again from the LiveData.