### PR TITLE
Simplify Attachment IDs usage

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/Attachment.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Attachment.kt
@@ -63,6 +63,8 @@ class Attachment : EmbeddedRealmObject {
     var uploadLocalUri: String? = null
     //endregion
 
+    val isAlreadyUploaded: Boolean get() = uuid.isNotBlank()
+
     val isCalendarEvent: Boolean get() = AttachmentMimeTypeUtils.calendarMatches.contains(mimeType)
 
     val disposition: AttachmentDisposition?

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -816,12 +816,12 @@ class NewMessageViewModel @Inject constructor(
         /**
          * If :
          * - we are in FORWARD mode,
-         * - all Attachments have no `uploadLocalUri` (meaning they are all from the original forwarded Message),
-         * - there quantity is the same in UI and in Realm,
+         * - none got added (all Attachments are already uploaded, meaning they are all from the original forwarded Message),
+         * - none got removed (their quantity is the same in UI and in Realm),
          * Then it means the Attachments list hasn't been edited by the user, so we have nothing to do here.
          */
         val isForwardingUneditedAttachmentsList = draftMode == DraftMode.FORWARD &&
-                uiAttachments.all { it.uploadLocalUri == null } &&
+                uiAttachments.all { it.isAlreadyUploaded } &&
                 uiAttachments.count() == attachments.count()
         if (isForwardingUneditedAttachmentsList) return
 
@@ -844,7 +844,7 @@ class NewMessageViewModel @Inject constructor(
              * some data for Attachments in Realm (for example, the `uuid`). If we don't take back the Realm version of
              * the Attachment, this data will be lost forever and we won't be able to save/send the Draft.
              */
-            return@map if (localAttachment?.uuid != null) localAttachment.copyFromRealm() else uiAttachment
+            return@map if (localAttachment?.isAlreadyUploaded == true) localAttachment.copyFromRealm() else uiAttachment
         }
 
         attachments.apply {

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -60,6 +60,7 @@ import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.ContactUtils.arrangeMergedContacts
 import com.infomaniak.mail.utils.Utils
 import com.infomaniak.mail.utils.extensions.*
+import com.infomaniak.mail.utils.extensions.AttachmentExtensions.findSpecificAttachment
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
@@ -826,18 +827,8 @@ class NewMessageViewModel @Inject constructor(
         if (isForwardingUneditedAttachmentsList) return
 
         val updatedAttachments = uiAttachments.map { uiAttachment ->
-            val localAttachment = attachments
-                /**
-                 * If a localAttachment has the same `uploadLocalUri` than a UI one, it means it represents the same Attachment.
-                 * But an Attachment only has an `uploadLocalUri` if the user added it by himself to the Draft.
-                 * If it was added by Message forwarding, it won't have any `uploadLocalUri`, so we don't check this.
-                 */
-                .filter { it.uploadLocalUri != null && it.uploadLocalUri == uiAttachment.uploadLocalUri }
-                .also {
-                    // If this Sentry never triggers, remove it and replace the
-                    // `attachments.filter { … }.also { … }.firstOrNull()` with `attachments.singleOrNull { … }`
-                    if (it.count() > 1) Sentry.captureMessage("Found several Attachments with the same uploadLocalUri")
-                }.firstOrNull()
+
+            val localAttachment = attachments.findSpecificAttachment(uiAttachment)
 
             /**
              * The DraftsActionWorker will possibly upload the Attachments beforehand, so there will possibly already be

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/DraftExtensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/DraftExtensions.kt
@@ -53,4 +53,4 @@ suspend fun Draft.uploadAttachments(mailbox: Mailbox, draftController: DraftCont
     return true
 }
 
-private fun Draft.getNotUploadedAttachments(): List<Attachment> = attachments.filter { !it.isAlreadyUploaded }
+private fun Draft.getNotUploadedAttachments(): List<Attachment> = attachments.filterNot { it.isAlreadyUploaded }

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/DraftExtensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/DraftExtensions.kt
@@ -53,4 +53,4 @@ suspend fun Draft.uploadAttachments(mailbox: Mailbox, draftController: DraftCont
     return true
 }
 
-private fun Draft.getNotUploadedAttachments(): List<Attachment> = attachments.filter { it.uuid.isEmpty() }
+private fun Draft.getNotUploadedAttachments(): List<Attachment> = attachments.filter { !it.isAlreadyUploaded }

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -285,7 +285,7 @@ class DraftsActionsWorker @AssistedInject constructor(
         val updatedDraft = DraftController.getDraft(draft.localUuid, mailboxContentRealm)!!
         // TODO: Remove this whole `draft.attachments.forEach { … }` when the Attachment issue is fixed.
         updatedDraft.attachments.forEach { attachment ->
-            if (attachment.uuid.isBlank()) {
+            if (!attachment.isAlreadyUploaded) {
 
                 Sentry.withScope { scope ->
                     scope.setExtra("attachmentUuid", attachment.uuid)


### PR DESCRIPTION
Depends on #1923

Replace `Attachment.uuid` usage with `Attachment.isAlreadyUploaded` when possible
Replace usage of `uploadLocalUri` with `localUuid` when possible