### PR TITLE
Fix external banner text color in dark mode

### DIFF
--- a/app/src/main/res/layout/fragment_new_message.xml
+++ b/app/src/main/res/layout/fragment_new_message.xml
@@ -486,7 +486,7 @@
                 android:minHeight="0dp"
                 android:paddingVertical="0dp"
                 android:text="@string/externalDialogTitleRecipient"
-                android:textColor="@color/primaryTextColor"
+                android:textColor="@color/externalTagOnBackground"
                 app:icon="@drawable/ic_external_information"
                 app:iconGravity="end"
                 app:iconTint="@color/externalTagOnBackground" />


### PR DESCRIPTION
Color was white on a light yellow background in dark mode. It's an oversight when replacing the TextView with a MaterialButton, I've put back the old textColor