### PR TITLE
Reduce Bimi priority (it should only be displayed if we couldn't find an avatar)

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/Bimi.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Bimi.kt
@@ -41,8 +41,6 @@ class Bimi() : EmbeddedRealmObject, Parcelable {
         this.isCertified = isCertified
     }
 
-    fun isDisplayable(): Boolean = isCertified && svgContentUrl?.isNotEmpty() == true
-
     companion object : Parceler<Bimi> {
 
         override fun create(parcel: Parcel): Bimi = with(parcel) {

--- a/app/src/main/java/com/infomaniak/mail/data/models/Bimi.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Bimi.kt
@@ -41,6 +41,8 @@ class Bimi() : EmbeddedRealmObject, Parcelable {
         this.isCertified = isCertified
     }
 
+    fun isDisplayable(): Boolean = isCertified && svgContentUrl?.isNotEmpty() == true
+
     companion object : Parceler<Bimi> {
 
         override fun create(parcel: Parcel): Bimi = with(parcel) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -49,6 +49,7 @@ import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.data.LocalSettings.SwipeAction
 import com.infomaniak.mail.data.LocalSettings.ThreadDensity
+import com.infomaniak.mail.data.api.ApiRoutes
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.data.models.thread.Thread
@@ -401,7 +402,11 @@ class ThreadListAdapter @Inject constructor(
 
     private fun CardviewThreadItemBinding.displayAvatar(thread: Thread) {
         val (recipient, bimi) = thread.computeAvatarRecipient()
-        expeditorAvatar.loadAvatar(recipient, bimi)
+        if (bimi?.isCertified == true) {
+            expeditorAvatar.loadBimiAvatar(ApiRoutes.bimi(bimi.svgContentUrl.toString()), recipient)
+        } else {
+            expeditorAvatar.loadAvatar(recipient)
+        }
     }
 
     private fun CardviewThreadItemBinding.formatRecipientNames(recipients: List<Recipient>): String {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -49,7 +49,6 @@ import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.data.LocalSettings.SwipeAction
 import com.infomaniak.mail.data.LocalSettings.ThreadDensity
-import com.infomaniak.mail.data.api.ApiRoutes
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.data.models.thread.Thread
@@ -402,11 +401,7 @@ class ThreadListAdapter @Inject constructor(
 
     private fun CardviewThreadItemBinding.displayAvatar(thread: Thread) {
         val (recipient, bimi) = thread.computeAvatarRecipient()
-        if (bimi?.isCertified == true) {
-            expeditorAvatar.loadBimiAvatar(ApiRoutes.bimi(bimi.svgContentUrl.toString()), recipient)
-        } else {
-            expeditorAvatar.loadAvatar(recipient)
-        }
+        expeditorAvatar.loadAvatar(recipient, bimi)
     }
 
     private fun CardviewThreadItemBinding.formatRecipientNames(recipients: List<Recipient>): String {

--- a/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
@@ -58,16 +58,25 @@ class AvatarView @JvmOverloads constructor(
     private val binding by lazy { ViewAvatarBinding.inflate(LayoutInflater.from(context), this, true) }
 
     private var currentCorrespondent: Correspondent? = null
-    private var isBimiShown: Boolean = false
+    private var currentBimi: Bimi? = null
 
     private val mergedContactObserver = Observer<MergedContactDictionary> { contacts ->
-        currentCorrespondent?.let { correspondent ->
-            if (!isBimiShown) loadAvatarUsingDictionary(correspondent, contacts)
+        val displayType = getAvatarDisplayType(currentCorrespondent, currentBimi)
+
+        if (displayType == AvatarDisplayType.MERGED_AVATAR || displayType == AvatarDisplayType.DEFAULT) {
+            loadAvatarUsingDictionary(currentCorrespondent!!, contacts)
         }
     }
 
     @Inject
-    lateinit var avatarMergedContactData: AvatarMergedContactData
+    lateinit var _avatarMergedContactData: AvatarMergedContactData
+
+    private val contactsFromViewModel: MergedContactDictionary
+        get() {
+            // Avoid lateinit property has not been initialized in preview
+            return if (isInEditMode) emptyMap() else _avatarMergedContactData.mergedContactLiveData.value ?: emptyMap()
+        }
+
 
     @Inject
     lateinit var svgImageLoader: ImageLoader
@@ -103,13 +112,13 @@ class AvatarView @JvmOverloads constructor(
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         if (isInEditMode) return // Avoid lateinit property has not been initialized in preview
-        avatarMergedContactData.mergedContactLiveData.observeForever(mergedContactObserver)
+        _avatarMergedContactData.mergedContactLiveData.observeForever(mergedContactObserver)
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         if (isInEditMode) return // Avoid lateinit property has not been initialized in preview
-        avatarMergedContactData.mergedContactLiveData.removeObserver(mergedContactObserver)
+        _avatarMergedContactData.mergedContactLiveData.removeObserver(mergedContactObserver)
     }
 
     override fun setOnClickListener(onClickListener: OnClickListener?) = binding.root.setOnClickListener(onClickListener)
@@ -129,14 +138,28 @@ class AvatarView @JvmOverloads constructor(
         )
     }
 
-    fun loadAvatar(correspondent: Correspondent?) {
-        if (correspondent == null) {
-            loadUnknownUserAvatar()
-        } else {
-            // Avoid lateinit property has not been initialized in preview
-            val contactsFromViewModel = if (isInEditMode) emptyMap() else avatarMergedContactData.mergedContactLiveData.value
-            loadAvatarUsingDictionary(correspondent, contacts = contactsFromViewModel ?: emptyMap())
+    fun loadAvatar(correspondent: Correspondent?, bimi: Bimi? = null) {
+        currentBimi = bimi
+
+        fun loadSimpleCorrespondent(correspondent: Correspondent) {
+            loadAvatarUsingDictionary(correspondent, contacts = contactsFromViewModel)
             currentCorrespondent = correspondent
+        }
+
+        when (getAvatarDisplayType(correspondent, bimi)) {
+            AvatarDisplayType.UNKNOWN -> loadUnknownUserAvatar()
+            AvatarDisplayType.MERGED_AVATAR -> loadSimpleCorrespondent(correspondent!!)
+            AvatarDisplayType.BIMI -> loadBimiAvatar(ApiRoutes.bimi(bimi!!.svgContentUrl!!), correspondent!!)
+            AvatarDisplayType.DEFAULT -> loadSimpleCorrespondent(correspondent!!)
+        }
+    }
+
+    private fun getAvatarDisplayType(correspondent: Correspondent?, bimi: Bimi?): AvatarDisplayType {
+        return when {
+            correspondent == null -> AvatarDisplayType.UNKNOWN
+            correspondent.hasMergedContactAvatar(contactsFromViewModel) -> AvatarDisplayType.MERGED_AVATAR
+            bimi?.isDisplayable() == true -> AvatarDisplayType.BIMI
+            else -> AvatarDisplayType.DEFAULT
         }
     }
 
@@ -149,16 +172,15 @@ class AvatarView @JvmOverloads constructor(
         binding.avatarImage.load(R.drawable.ic_unknown_user_avatar)
     }
 
-    fun loadBimiAvatar(bimiUrl: String, correspondent: Correspondent?) = with(binding.avatarImage) {
-        contentDescription = correspondent?.email.orEmpty()
-        isBimiShown = bimiUrl.isNotEmpty()
+    private fun loadBimiAvatar(bimiUrl: String, correspondent: Correspondent) = with(binding.avatarImage) {
+        contentDescription = correspondent.email
         loadAvatar(
             backgroundColor = context.getBackgroundColorBasedOnId(
-                correspondent?.email.orEmpty().hashCode(),
+                correspondent.email.hashCode(),
                 R.array.AvatarColors,
             ),
             avatarUrl = bimiUrl,
-            initials = correspondent?.initials.orEmpty(),
+            initials = correspondent.initials,
             imageLoader = svgImageLoader,
             initialsColor = context.getColor(R.color.onColorfulBackground),
         )
@@ -169,6 +191,10 @@ class AvatarView @JvmOverloads constructor(
     private fun searchInMergedContact(correspondent: Correspondent, contacts: MergedContactDictionary): MergedContact? {
         val recipientsForEmail = contacts[correspondent.email]
         return recipientsForEmail?.getOrElse(correspondent.name) { recipientsForEmail.entries.elementAt(0).value }
+    }
+
+    private fun Correspondent.hasMergedContactAvatar(contacts: MergedContactDictionary): Boolean {
+        return searchInMergedContact(this, contacts)?.avatar != null
     }
 
     private fun loadAvatarUsingDictionary(correspondent: Correspondent, contacts: MergedContactDictionary) {
@@ -192,12 +218,5 @@ class AvatarView @JvmOverloads constructor(
         }
     }
 
-    fun loadAvatar(correspondent: Correspondent?, bimi: Bimi?) {
-        val svgContentUrl = bimi?.svgContentUrl
-        if (bimi == null || !bimi.isCertified || svgContentUrl.isNullOrEmpty()) {
-            loadAvatar(correspondent)
-        } else {
-            loadBimiAvatar(ApiRoutes.bimi(svgContentUrl), correspondent)
-        }
-    }
+    enum class AvatarDisplayType { UNKNOWN, MERGED_AVATAR, BIMI, DEFAULT }
 }

--- a/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
@@ -69,12 +69,12 @@ class AvatarView @JvmOverloads constructor(
     }
 
     @Inject
-    lateinit var _avatarMergedContactData: AvatarMergedContactData
+    lateinit var avatarMergedContactData: AvatarMergedContactData
 
     private val contactsFromViewModel: MergedContactDictionary
         get() {
             // Avoid lateinit property has not been initialized in preview
-            return if (isInEditMode) emptyMap() else _avatarMergedContactData.mergedContactLiveData.value ?: emptyMap()
+            return if (isInEditMode) emptyMap() else avatarMergedContactData.mergedContactLiveData.value ?: emptyMap()
         }
 
     @Inject
@@ -111,13 +111,13 @@ class AvatarView @JvmOverloads constructor(
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         if (isInEditMode) return // Avoid lateinit property has not been initialized in preview
-        _avatarMergedContactData.mergedContactLiveData.observeForever(mergedContactObserver)
+        avatarMergedContactData.mergedContactLiveData.observeForever(mergedContactObserver)
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         if (isInEditMode) return // Avoid lateinit property has not been initialized in preview
-        _avatarMergedContactData.mergedContactLiveData.removeObserver(mergedContactObserver)
+        avatarMergedContactData.mergedContactLiveData.removeObserver(mergedContactObserver)
     }
 
     override fun setOnClickListener(onClickListener: OnClickListener?) = binding.root.setOnClickListener(onClickListener)


### PR DESCRIPTION
When we received a Bimi, we displayed it automatically.
But we should only do that if we can't find an avatar.