### PR TITLE
Prevent showing and hiding progress crashes by using showProgressCatching() and hideProgressCatching()

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/BaseAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/BaseAlertDialog.kt
@@ -26,7 +26,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.google.android.material.button.MaterialButton
 import com.infomaniak.lib.core.utils.Utils
-import com.infomaniak.lib.core.utils.hideProgress
+import com.infomaniak.lib.core.utils.hideProgressCatching
 import com.infomaniak.lib.core.utils.initProgress
 import com.infomaniak.lib.core.utils.showProgressCatching
 import com.infomaniak.mail.R
@@ -50,7 +50,7 @@ abstract class BaseAlertDialog(activityContext: Context) : DefaultLifecycleObser
 
     fun resetLoadingAndDismiss() = with(alertDialog) {
         if (isShowing) {
-            positiveButton.hideProgress(R.string.buttonCreate)
+            positiveButton.hideProgressCatching(R.string.buttonCreate)
             negativeButton.isEnabled = true
             setCancelable(true)
             dismiss()

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/BaseAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/BaseAlertDialog.kt
@@ -28,7 +28,7 @@ import com.google.android.material.button.MaterialButton
 import com.infomaniak.lib.core.utils.Utils
 import com.infomaniak.lib.core.utils.hideProgress
 import com.infomaniak.lib.core.utils.initProgress
-import com.infomaniak.lib.core.utils.showProgress
+import com.infomaniak.lib.core.utils.showProgressCatching
 import com.infomaniak.mail.R
 
 abstract class BaseAlertDialog(activityContext: Context) : DefaultLifecycleObserver {
@@ -45,7 +45,7 @@ abstract class BaseAlertDialog(activityContext: Context) : DefaultLifecycleObser
     fun startLoading() {
         alertDialog.setCancelable(false)
         negativeButton.isEnabled = false
-        Utils.createRefreshTimer(onTimerFinish = positiveButton::showProgress).start()
+        Utils.createRefreshTimer(onTimerFinish = positiveButton::showProgressCatching).start()
     }
 
     fun resetLoadingAndDismiss() = with(alertDialog) {

--- a/app/src/main/java/com/infomaniak/mail/ui/login/LoginFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/login/LoginFragment.kt
@@ -187,7 +187,7 @@ class LoginFragment : Fragment() {
 
     private fun resetLoginButtons() = with(binding) {
         connectButtonProgressTimer.cancel()
-        connectButton.hideProgress(RCore.string.connect)
+        connectButton.hideProgressCatching(RCore.string.connect)
         signInButton.isEnabled = true
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/login/LoginFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/login/LoginFragment.kt
@@ -198,7 +198,7 @@ class LoginFragment : Fragment() {
     }
 
     private fun startProgress() {
-        binding.connectButton.showProgress(getCurrentOnPrimary())
+        binding.connectButton.showProgressCatching(getCurrentOnPrimary())
     }
 
     private fun getCurrentOnPrimary(): Int? = introViewModel.updatedAccentColor.value?.first?.getOnPrimary(requireContext())

--- a/app/src/main/java/com/infomaniak/mail/ui/main/InvalidPasswordFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/InvalidPasswordFragment.kt
@@ -142,6 +142,6 @@ class InvalidPasswordFragment : Fragment() {
     }
 
     private fun startProgress() {
-        binding.confirmButton.showProgress()
+        binding.confirmButton.showProgressCatching()
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/InvalidPasswordFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/InvalidPasswordFragment.kt
@@ -110,7 +110,7 @@ class InvalidPasswordFragment : Fragment() {
             passwordInputLayout.error = getString(error)
             passwordInput.text = null
             updatePasswordButtonProgressTimer.cancel()
-            confirmButton.hideProgress(R.string.buttonConfirm)
+            confirmButton.hideProgressCatching(R.string.buttonConfirm)
         }
 
         invalidPasswordViewModel.detachMailboxResult.observe(viewLifecycleOwner) { error ->

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/RestoreEmailsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/RestoreEmailsBottomSheetDialog.kt
@@ -114,7 +114,7 @@ class RestoreEmailsBottomSheetDialog : BottomSheetDialogFragment() {
         val formattedDate = formattedDates?.get(date) ?: date
         restoreEmailViewModel.restoreEmails(formattedDate).observe(viewLifecycleOwner) { apiResponse ->
             restoreEmailsButtonProgressTimer.cancel()
-            binding.restoreMailsButton.hideProgress(R.string.buttonConfirmRestoreEmails)
+            binding.restoreMailsButton.hideProgressCatching(R.string.buttonConfirmRestoreEmails)
             showSnackbar(if (apiResponse.isSuccess()) R.string.snackbarRestorationLaunched else apiResponse.translatedError)
             findNavController().popBackStack()
         }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menu/RestoreEmailsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menu/RestoreEmailsBottomSheetDialog.kt
@@ -126,6 +126,6 @@ class RestoreEmailsBottomSheetDialog : BottomSheetDialogFragment() {
     }
 
     private fun startProgress() {
-        binding.restoreMailsButton.showProgress()
+        binding.restoreMailsButton.showProgressCatching()
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/user/AttachMailboxFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/user/AttachMailboxFragment.kt
@@ -131,6 +131,6 @@ class AttachMailboxFragment : Fragment() {
     }
 
     private fun startProgress() {
-        binding.attachMailboxButton.showProgress()
+        binding.attachMailboxButton.showProgressCatching()
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/user/AttachMailboxFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/user/AttachMailboxFragment.kt
@@ -126,7 +126,7 @@ class AttachMailboxFragment : Fragment() {
 
             passwordInput.text = null
             attachMailboxButtonProgressTimer.cancel()
-            attachMailboxButton.hideProgress(R.string.buttonAttachMailbox)
+            attachMailboxButton.hideProgressCatching(R.string.buttonAttachMailbox)
         }
     }
 


### PR DESCRIPTION
The methods showProgress() and hideProgress() keep crashing on many occasions despite our best efforts to do things correctly. This PR uses showProgressCatching() and showProgressCatching() to avoid crashing

Depends on https://github.com/Infomaniak/android-core/pull/201