### PR TITLE
Fix Bimi when recycling

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/AvatarView.kt
@@ -174,6 +174,7 @@ class AvatarView @JvmOverloads constructor(
 
     private fun loadBimiAvatar(bimiUrl: String, correspondent: Correspondent) = with(binding.avatarImage) {
         contentDescription = correspondent.email
+        currentCorrespondent = null
         loadAvatar(
             backgroundColor = context.getBackgroundColorBasedOnId(
                 correspondent.email.hashCode(),


### PR DESCRIPTION
The avatar image was sometimes wrong when recycling because when it was a Bimi the currentCorrespondent value was not set to null.

<img width="459" alt="Screenshot 2024-06-27 at 13 19 19" src="https://github.com/Infomaniak/android-kMail/assets/167090505/ccb3df5e-77bd-4ea7-a787-0aad696b3013">
