### PR TITLE
Remove nesting of bodies when sanitizing html

### DIFF
--- a/HtmlCleaner/src/main/java/com/infomaniak/html/cleaner/BodyCleaner.kt
+++ b/HtmlCleaner/src/main/java/com/infomaniak/html/cleaner/BodyCleaner.kt
@@ -97,6 +97,14 @@ internal class BodyCleaner {
 
     fun clean(dirtyDocument: Document): Document {
         val cleanedDocument = cleaner.clean(dirtyDocument)
+
+        // Cleaner.clean() nests two bodies inside one-another. To fix this, unwrap one of them so we don't end up with nested bodies
+        val body = cleanedDocument.body()
+        val hasNestedBodies = body.childNodeSize() == 1
+                && body.childrenSize() == 1
+                && body.children()[0].tagName().lowercase() == "body"
+        if (hasNestedBodies) body.unwrap()
+
         copyDocumentType(dirtyDocument, cleanedDocument)
         return cleanedDocument
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -806,6 +806,10 @@ class NewMessageViewModel @Inject constructor(
          */
         messageUid?.let { MessageController.getMessage(uid = it, realm)?.draftLocalUuid = localUuid }
 
+        // If we opened a text/plain draft, we will now convert it as text/html as we send it because we only support editing
+        // text/html drafts.
+        mimeType = Utils.TEXT_HTML
+
         // Only if `!isFinishing`, because if we are finishing, well… We're out of here so we don't care about all of that.
         if (!isFinishing) {
             copyFromRealm()


### PR DESCRIPTION
Previously, sanitization using Jsoup would output a html document with one body nested inside another for no reason. To fix this and output clean code after sanitization, remove one of the two extra bodies if we detect this exact situation