### PR TITLE
After editing text/plain drafts save them as text/html which was missing

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -806,6 +806,10 @@ class NewMessageViewModel @Inject constructor(
          */
         messageUid?.let { MessageController.getMessage(uid = it, realm)?.draftLocalUuid = localUuid }
 
+        // If we opened a text/plain draft, we will now convert it as text/html as we send it because we only support editing
+        // text/html drafts.
+        mimeType = Utils.TEXT_HTML
+
         // Only if `!isFinishing`, because if we are finishing, well… We're out of here so we don't care about all of that.
         if (!isFinishing) {
             copyFromRealm()


### PR DESCRIPTION
When editing a draft of mimeType "text/plain", we save the draft with the same mimeType (i.e. text/plain) even if we send a content representing a text/html which completely breaks the draft's content.

This PR forces the mimeType to text/html which is what we always send
