### PR TITLE
Update gradle to 8.7 and plugin gradle to 8.5.0

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/NotificationUtils.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.mail.utils
 
+import android.annotation.SuppressLint
 import android.app.*
 import android.content.Context
 import android.content.Intent
@@ -161,6 +162,7 @@ class NotificationUtils @Inject constructor(
         showNotifications(scope, mailboxId, notificationManagerCompat)
     }
 
+    @SuppressLint("WrongConstant")
     private fun getContentIntent(
         payload: NotificationPayload,
         isUndo: Boolean,
@@ -240,6 +242,7 @@ class NotificationUtils @Inject constructor(
         }
     }
 
+    @SuppressLint("WrongConstant")
     private fun NotificationCompat.Builder.addActions(payload: NotificationPayload) {
 
         fun createBroadcastAction(@StringRes title: Int, intent: Intent): NotificationCompat.Action {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.2.2"
+androidGradlePlugin = "8.5.0"
 dotsindicator = "5.0"
 dragdropswipeRecyclerview = "1.2.0"
 firebaseMessagingKtx = "23.4.1" # Doesn't build when bumped to 24.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Mar 31 08:35:17 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The error was:

Error: Must be one or more of: PendingIntent.FLAG_ONE_SHOT, PendingIntent.FLAG_NO_CREATE, PendingIntent.FLAG_CANCEL_CURRENT, PendingIntent.FLAG_UPDATE_CURRENT, PendingIntent.FLAG_IMMUTABLE, PendingIntent.FLAG_MUTABLE, PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT, Intent.FILL_IN_ACTION, Intent.FILL_IN_DATA, Intent.FILL_IN_CATEGORIES, Intent.FILL_IN_COMPONENT, Intent.FILL_IN_PACKAGE, Intent.FILL_IN_SOURCE_BOUNDS, Intent.FILL_IN_SELECTOR, Intent.FILL_IN_CLIP_DATA [WrongConstant]
          return PendingIntent.getActivity(appContext, requestCode.hashCode(), intent, pendingIntentFlags)
          
But pendingFlags was a constant based on API version so Lint was throwing an error.