### PR TITLE
chores(Sentry): Remove useless Sentry

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
@@ -186,7 +186,6 @@ class FetchMessagesManager @Inject constructor(
 
         // If the Message has already been seen before receiving the Notification, we don't want to display it.
         // We can leave safely.
-        // It can happened very simply if you open a message on the webmail for example
         if (message.isSeen) return
 
         val formattedPreview = message.preview.ifBlank { null }?.let { "\n${it.trim()}" } ?: ""

--- a/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
@@ -183,19 +183,11 @@ class FetchMessagesManager @Inject constructor(
             )
             return
         }
-        if (message.isSeen) {
-            // If the Message has already been seen before receiving the Notification, we don't want to display it.
-            // We can leave safely.
-            SentryDebug.sendFailedNotification(
-                reason = "Message already seen",
-                sentryLevel = SentryLevel.INFO,
-                userId = userId,
-                mailboxId = mailbox.mailboxId,
-                messageUid = sentryMessageUid,
-                mailbox = mailbox,
-            )
-            return
-        }
+
+        // If the Message has already been seen before receiving the Notification, we don't want to display it.
+        // We can leave safely.
+        // It can happened very simply if you open a message on the webmail for example
+        if (message.isSeen) return
 
         val formattedPreview = message.preview.ifBlank { null }?.let { "\n${it.trim()}" } ?: ""
         val body = if (message.body?.value.isNullOrBlank()) {


### PR DESCRIPTION
This sentry is useless because it is a totally normal case. 
You can trigger it by opening a message on the webmail before the notif was fetched