### PR TITLE
Fix uncatched NPE in RecipientFieldView

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/RecipientFieldView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/RecipientFieldView.kt
@@ -261,7 +261,7 @@ class RecipientFieldView @JvmOverloads constructor(
     private fun focusLastChip() {
         val count = contactChipAdapter.itemCount
         // chipsRecyclerView.children.last() won't work because they are not always ordered correctly
-        if (count > 0) binding.chipsRecyclerView.getChildAt(count - 1).requestFocusFromTouch()
+        if (count > 0) binding.chipsRecyclerView.getChildAt(count - 1)?.requestFocusFromTouch()
     }
 
     private fun focusTextField() {


### PR DESCRIPTION
Closes MAIL-ANDROID-331
https://sentry-mobile.infomaniak.com/organizations/sentry/issues/15856/

This seems like a very odd case, when the adapter itemCount is not synchronized with the recyclerView children count
As it is rare, not that important and doesn't seem to be caused by a bigger flow, I just added the null Check