### PR TITLE
Changing the way we log the version of WebViews and also handling only official WebViews from Google

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -299,10 +299,11 @@ object SentryDebug {
         }
     }
 
-    fun sendWebViewVersionName(webViewVersionName: String?, majorVersion: Int) {
+    fun sendWebViewVersionName(webViewPackageName: String?, webViewVersionName: String?, majorVersion: Int) {
         Sentry.withScope { scope ->
-            scope.setExtra("webViewVersionName", webViewVersionName.toString())
-            scope.setExtra("majorVersion", "$majorVersion")
+            scope.setTag("webViewPackageName", "$webViewPackageName")
+            scope.setTag("webViewVersionName", "$webViewVersionName")
+            scope.setTag("majorVersion", "$majorVersion")
             Sentry.captureMessage(
                 "WebView version name might be null on some devices. Checking that the version name is ok.",
                 SentryLevel.INFO,


### PR DESCRIPTION
Sadly, I couldn't find a way to redirect to the Huawei AppGallery in case the Huawei WebView is outdated. So we are only checking the WebView version of Google WebViews.