### PR TITLE
Log jsoup parsing ram usage

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardFooterManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ReplyForwardFooterManager.kt
@@ -23,6 +23,7 @@ import com.infomaniak.mail.data.models.Attachment
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.ui.main.thread.MessageWebViewClient
+import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseBodyFragmentWithLog
 import com.infomaniak.mail.utils.MailDateFormatUtils.formatForHeader
 import com.infomaniak.mail.utils.MessageBodyUtils
 import com.infomaniak.mail.utils.SharedUtils
@@ -159,7 +160,7 @@ class ReplyForwardFooterManager @Inject constructor(private val appContext: Cont
     }
 
     private fun parseAndWrapElementInNewDocument(elementHtml: String): Element {
-        val doc = Jsoup.parseBodyFragment(elementHtml)
+        val doc = jsoupParseBodyFragmentWithLog(elementHtml)
         return doc.body().firstElementChild()!!
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -68,13 +68,10 @@ import com.infomaniak.mail.di.MainDispatcher
 import com.infomaniak.mail.ui.main.SnackbarManager
 import com.infomaniak.mail.ui.newMessage.NewMessageEditorManager.EditorAction
 import com.infomaniak.mail.ui.newMessage.NewMessageRecipientFieldsManager.FieldType
-import com.infomaniak.mail.ui.newMessage.NewMessageViewModel.SignatureScore.EXACT_MATCH
-import com.infomaniak.mail.ui.newMessage.NewMessageViewModel.SignatureScore.EXACT_MATCH_AND_IS_DEFAULT
-import com.infomaniak.mail.ui.newMessage.NewMessageViewModel.SignatureScore.NO_MATCH
-import com.infomaniak.mail.ui.newMessage.NewMessageViewModel.SignatureScore.ONLY_EMAIL_MATCH
-import com.infomaniak.mail.ui.newMessage.NewMessageViewModel.SignatureScore.ONLY_EMAIL_MATCH_AND_IS_DEFAULT
+import com.infomaniak.mail.ui.newMessage.NewMessageViewModel.SignatureScore.*
 import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.ContactUtils.arrangeMergedContacts
+import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
 import com.infomaniak.mail.utils.LocalStorageUtils
 import com.infomaniak.mail.utils.MessageBodyUtils
 import com.infomaniak.mail.utils.SentryDebug
@@ -98,14 +95,13 @@ import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.ext.toRealmList
 import io.realm.kotlin.types.RealmList
 import io.sentry.Sentry
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import javax.inject.Inject
 
 @HiltViewModel
 class NewMessageViewModel @Inject constructor(
@@ -317,7 +313,7 @@ class NewMessageViewModel @Inject constructor(
             return if (index == -1) Int.MAX_VALUE else index
         }
 
-        val doc = Jsoup.parse(draft.body).also { it.outputSettings().prettyPrint(false) }
+        val doc = jsoupParseWithLog(draft.body).also { it.outputSettings().prettyPrint(false) }
 
         val (bodyWithQuote, signature) = doc.split(MessageBodyUtils.INFOMANIAK_SIGNATURE_HTML_CLASS_NAME, draft.body)
 

--- a/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/HtmlFormatter.kt
@@ -22,9 +22,9 @@ import androidx.annotation.RawRes
 import com.infomaniak.html.cleaner.HtmlSanitizer
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.message.Message
+import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
 import com.infomaniak.mail.utils.extensions.getAttributeColor
 import com.infomaniak.mail.utils.extensions.readRawResource
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
@@ -63,7 +63,7 @@ class HtmlFormatter(private val html: String) {
         printData = data
     }
 
-    fun inject(): String = with(HtmlSanitizer.getInstance().sanitize(Jsoup.parse(html))) {
+    fun inject(): String = with(HtmlSanitizer.getInstance().sanitize(jsoupParseWithLog(html))) {
         outputSettings().prettyPrint(true)
         head().apply {
             injectCss()

--- a/app/src/main/java/com/infomaniak/mail/utils/JsoupParserUtil.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/JsoupParserUtil.kt
@@ -27,27 +27,27 @@ object JsoupParserUtil {
     private const val BYTE_TO_MEGABYTE_DIVIDER: Float = 1024f * 1024f
 
     fun jsoupParseWithLog(value: String): Document {
-        val (usedMemoryBefore, maxMemoryBefore) = getMemoryUsage()
-        SentryLog.i(SENTRY_LOG_TAG, "Before parsing, used / available: $usedMemoryBefore / $maxMemoryBefore MB")
-
-        val doc = Jsoup.parse(value)
-
-        val (usedMemoryAfter, maxMemoryAfter) = getMemoryUsage()
-        SentryLog.i(SENTRY_LOG_TAG, "After parsing, used / available: $usedMemoryAfter / $maxMemoryAfter MB")
-
-        return doc
+        return measureMemoryUsage(SENTRY_LOG_TAG, actionName = "parsing") {
+            Jsoup.parse(value)
+        }
     }
 
     fun jsoupParseBodyFragmentWithLog(value: String): Document {
-        val (usedMemoryBefore, maxMemoryBefore) = getMemoryUsage()
-        SentryLog.i(SENTRY_LOG_TAG, "Before parsing body fragment, used / available: $usedMemoryBefore / $maxMemoryBefore MB")
+        return measureMemoryUsage(SENTRY_LOG_TAG, actionName = "parsing body fragment") {
+            Jsoup.parseBodyFragment(value)
+        }
+    }
 
-        val doc = Jsoup.parseBodyFragment(value)
+    fun <R> measureMemoryUsage(tag: String, actionName: String, block: () -> R): R {
+        val (usedMemoryBefore, maxMemoryBefore) = getMemoryUsage()
+        SentryLog.i(tag, "Before $actionName, used / available: $usedMemoryBefore / $maxMemoryBefore MB")
+
+        val result = block()
 
         val (usedMemoryAfter, maxMemoryAfter) = getMemoryUsage()
-        SentryLog.i(SENTRY_LOG_TAG, "After parsing body fragment, used / available: $usedMemoryAfter / $maxMemoryAfter MB")
+        SentryLog.i(tag, "After $actionName, used / available: $usedMemoryAfter / $maxMemoryAfter MB")
 
-        return doc
+        return result
     }
 
     private fun getMemoryUsage(): Pair<Float, Float> {

--- a/app/src/main/java/com/infomaniak/mail/utils/JsoupParserUtil.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/JsoupParserUtil.kt
@@ -27,18 +27,21 @@ object JsoupParserUtil {
     private const val BYTE_TO_MEGABYTE_DIVIDER: Float = 1024f * 1024f
 
     fun jsoupParseWithLog(value: String): Document {
-        return measureMemoryUsage(SENTRY_LOG_TAG, actionName = "parsing") {
+        return measureAndLogMemoryUsage(SENTRY_LOG_TAG, actionName = "parsing") {
             Jsoup.parse(value)
         }
     }
 
     fun jsoupParseBodyFragmentWithLog(value: String): Document {
-        return measureMemoryUsage(SENTRY_LOG_TAG, actionName = "parsing body fragment") {
+        return measureAndLogMemoryUsage(SENTRY_LOG_TAG, actionName = "parsing body fragment") {
             Jsoup.parseBodyFragment(value)
         }
     }
-
-    fun <R> measureMemoryUsage(tag: String, actionName: String, block: () -> R): R {
+    
+    /**
+     * Measures and logs to sentry the used and available RAM of the JVM
+     */
+    fun <R> measureAndLogMemoryUsage(tag: String, actionName: String, block: () -> R): R {
         val (usedMemoryBefore, maxMemoryBefore) = getMemoryUsage()
         SentryLog.i(tag, "Before $actionName, used / available: $usedMemoryBefore / $maxMemoryBefore MB")
 

--- a/app/src/main/java/com/infomaniak/mail/utils/JsoupParserUtil.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/JsoupParserUtil.kt
@@ -37,18 +37,18 @@ object JsoupParserUtil {
             Jsoup.parseBodyFragment(value)
         }
     }
-    
+
     /**
      * Measures and logs to sentry the used and available RAM of the JVM
      */
     fun <R> measureAndLogMemoryUsage(tag: String, actionName: String, block: () -> R): R {
         val (usedMemoryBefore, maxMemoryBefore) = getMemoryUsage()
-        SentryLog.i(tag, "Before $actionName, used / available: $usedMemoryBefore / $maxMemoryBefore MB")
+        SentryLog.i(tag, "Before $actionName, used / available - $usedMemoryBefore / $maxMemoryBefore MB")
 
         val result = block()
 
         val (usedMemoryAfter, maxMemoryAfter) = getMemoryUsage()
-        SentryLog.i(tag, "After $actionName, used / available: $usedMemoryAfter / $maxMemoryAfter MB")
+        SentryLog.i(tag, "After $actionName, used / available - $usedMemoryAfter / $maxMemoryAfter MB")
 
         return result
     }

--- a/app/src/main/java/com/infomaniak/mail/utils/JsoupParserUtil.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/JsoupParserUtil.kt
@@ -1,0 +1,59 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.utils
+
+import com.infomaniak.lib.core.utils.SentryLog
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+
+object JsoupParserUtil {
+
+    private const val SENTRY_LOG_TAG = "Jsoup memory usage"
+    private const val BYTE_TO_MEGABYTE_DIVIDER: Float = 1024f * 1024f
+
+    fun jsoupParseWithLog(value: String): Document {
+        val (usedMemoryBefore, maxMemoryBefore) = getMemoryUsage()
+        SentryLog.i(SENTRY_LOG_TAG, "Before parsing, used / available: $usedMemoryBefore / $maxMemoryBefore MB")
+
+        val doc = Jsoup.parse(value)
+
+        val (usedMemoryAfter, maxMemoryAfter) = getMemoryUsage()
+        SentryLog.i(SENTRY_LOG_TAG, "After parsing, used / available: $usedMemoryAfter / $maxMemoryAfter MB")
+
+        return doc
+    }
+
+    fun jsoupParseBodyFragmentWithLog(value: String): Document {
+        val (usedMemoryBefore, maxMemoryBefore) = getMemoryUsage()
+        SentryLog.i(SENTRY_LOG_TAG, "Before parsing body fragment, used / available: $usedMemoryBefore / $maxMemoryBefore MB")
+
+        val doc = Jsoup.parseBodyFragment(value)
+
+        val (usedMemoryAfter, maxMemoryAfter) = getMemoryUsage()
+        SentryLog.i(SENTRY_LOG_TAG, "After parsing body fragment, used / available: $usedMemoryAfter / $maxMemoryAfter MB")
+
+        return doc
+    }
+
+    private fun getMemoryUsage(): Pair<Float, Float> {
+        val runtime: Runtime = Runtime.getRuntime()
+        val usedMemInMegaBytes = (runtime.totalMemory() - runtime.freeMemory()) / BYTE_TO_MEGABYTE_DIVIDER
+        val maxHeapSizeInMegaBytes = runtime.maxMemory() / BYTE_TO_MEGABYTE_DIVIDER
+        return usedMemInMegaBytes to maxHeapSizeInMegaBytes
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
@@ -21,8 +21,9 @@ import android.content.Context
 import com.infomaniak.mail.data.models.message.Body
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.message.SubBody
-import com.infomaniak.mail.utils.PrintHeaderUtils.createPrintHeader
 import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
+import com.infomaniak.mail.utils.JsoupParserUtil.measureAndLogMemoryUsage
+import com.infomaniak.mail.utils.PrintHeaderUtils.createPrintHeader
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.CoroutineScope
@@ -67,7 +68,13 @@ object MessageBodyUtils {
             timeout = QUOTE_DETECTION_TIMEOUT,
             defaultValue = SplitBody(bodyContent),
             block = {
-                val (content, quotes) = splitContentAndQuotes(htmlDocument = jsoupParseWithLog(bodyContent))
+                // Do not nest jsoupParseWithLog and measureAndLogMemoryUsage so logs are independent from one another
+                val htmlDocument = jsoupParseWithLog(bodyContent)
+                val (content, quotes) = measureAndLogMemoryUsage(
+                    tag = "Split signature and quote memory usage",
+                    actionName = "splitting",
+                ) { splitContentAndQuotes(htmlDocument = htmlDocument) }
+
                 if (quotes.isEmpty() || quotes.all { it.isBlank() }) SplitBody(bodyContent) else SplitBody(content, bodyContent)
             },
             onTimeout = {

--- a/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
@@ -22,11 +22,11 @@ import com.infomaniak.mail.data.models.message.Body
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.message.SubBody
 import com.infomaniak.mail.utils.PrintHeaderUtils.createPrintHeader
+import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ensureActive
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
 object MessageBodyUtils {
@@ -67,7 +67,7 @@ object MessageBodyUtils {
             timeout = QUOTE_DETECTION_TIMEOUT,
             defaultValue = SplitBody(bodyContent),
             block = {
-                val (content, quotes) = splitContentAndQuotes(htmlDocument = Jsoup.parse(bodyContent))
+                val (content, quotes) = splitContentAndQuotes(htmlDocument = jsoupParseWithLog(bodyContent))
                 if (quotes.isEmpty() || quotes.all { it.isBlank() }) SplitBody(bodyContent) else SplitBody(content, bodyContent)
             },
             onTimeout = {

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -34,12 +34,12 @@ import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.ui.main.settings.SettingRadioGroupView
+import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
 import com.infomaniak.mail.utils.extensions.getApiException
 import com.infomaniak.mail.utils.extensions.getFoldersIds
 import com.infomaniak.mail.utils.extensions.getUids
 import io.realm.kotlin.Realm
 import io.sentry.Sentry
-import org.jsoup.Jsoup
 import javax.inject.Inject
 
 class SharedUtils @Inject constructor(
@@ -173,7 +173,7 @@ class SharedUtils @Inject constructor(
         }
 
         fun createHtmlForPlainText(text: String): String {
-            Jsoup.parse("").apply {
+            jsoupParseWithLog("").apply {
                 body().appendElement("pre").text(text).attr("style", "word-wrap: break-word; white-space: pre-wrap;")
                 return html()
             }

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -107,6 +107,7 @@ import com.infomaniak.mail.utils.UiUtils
 import com.infomaniak.mail.utils.Utils
 import com.infomaniak.mail.utils.Utils.TAG_SEPARATOR
 import com.infomaniak.mail.utils.Utils.isPermanentDeleteFolder
+import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
 import com.infomaniak.mail.utils.Utils.kSyncAccountUri
 import com.infomaniak.mail.utils.WebViewUtils
 import io.realm.kotlin.MutableRealm
@@ -138,7 +139,7 @@ fun Activity.notYetImplemented(anchor: View? = null) = showSnackbar(getString(R.
 
 fun String.isEmail(): Boolean = Patterns.EMAIL_ADDRESS.matcher(this).matches()
 
-fun String.removeLineBreaksFromHtml(): Document = Jsoup.parse(replace("\r", "").replace("\n", ""))
+fun String.removeLineBreaksFromHtml(): Document = jsoupParseWithLog(replace("\r", "").replace("\n", ""))
 
 fun String.htmlToText(): String = removeLineBreaksFromHtml().wholeText()
 


### PR DESCRIPTION
Add sentry logs to record memory consumption by jsoup parsing and the method splitContentAndQuotes()

Example usage:
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/68959575-265d-4bd8-9676-013fd6701efc">
