### PR TITLE
Menu drawer actions as items

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -36,7 +36,6 @@ import io.realm.kotlin.query.RealmQuery
 import io.realm.kotlin.query.RealmResults
 import io.realm.kotlin.query.RealmSingleQuery
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.mapNotNull
 import javax.inject.Inject
 
@@ -50,13 +49,12 @@ class FolderController @Inject constructor(
         return getFoldersQuery(mailboxContentRealm(), withoutChildren = true).asFlow()
     }
 
-    fun getMenuDrawerFolders(): Flow<Pair<ResultsChange<Folder>, ResultsChange<Folder>>> {
-        val defaultFoldersFlow = getDefaultFoldersQuery(mailboxContentRealm()).asFlow()
-        val customFoldersFlow = getCustomFoldersQuery(mailboxContentRealm()).asFlow()
-        return defaultFoldersFlow.combine(
-            flow = customFoldersFlow,
-            transform = { defaultFolders, customFolders -> defaultFolders to customFolders }
-        )
+    fun getMenuDrawerDefaultFolders(): Flow<ResultsChange<Folder>> {
+        return getDefaultFoldersQuery(mailboxContentRealm()).asFlow()
+    }
+
+    fun getMenuDrawerCustomFolders(): Flow<ResultsChange<Folder>> {
+        return getCustomFoldersQuery(mailboxContentRealm()).asFlow()
     }
 
     fun getMoveFolders(): RealmResults<Folder> {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -158,7 +158,14 @@ class MainViewModel @Inject constructor(
 
     val currentFoldersLive = _currentMailboxObjectId.flatMapLatest { objectId ->
         objectId
-            ?.let { folderController.getRootFoldersAsync().map { it.list.flattenFolderChildren(dismissHiddenChildren = true) } }
+            ?.let {
+                folderController.getMenuDrawerFolders().map { (defaultFolders, customFolders) ->
+                    Pair(
+                        defaultFolders.list.flattenFolderChildren(dismissHiddenChildren = true),
+                        customFolders.list.flattenFolderChildren(dismissHiddenChildren = true),
+                    )
+                }
+            }
             ?: emptyFlow()
     }.asLiveData(ioCoroutineContext)
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -83,7 +83,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -158,16 +157,12 @@ class MainViewModel @Inject constructor(
         it?.let(mailboxController::getMailbox)
     }.asLiveData(ioCoroutineContext)
 
-    private val currentDefaultFoldersLive = _currentMailboxObjectId.filterNotNull().flatMapLatest {
-        folderController.getMenuDrawerDefaultFolders().map { it.list.flattenFolderChildren(dismissHiddenChildren = true) }
-    }
+    val defaultFoldersLive = _currentMailboxObjectId.filterNotNull().flatMapLatest {
+        folderController.getMenuDrawerDefaultFoldersAsync().map { it.list.flattenFolderChildren(dismissHiddenChildren = true) }
+    }.asLiveData(ioCoroutineContext)
 
-    private val currentCustomFoldersLive = _currentMailboxObjectId.filterNotNull().flatMapLatest {
-        folderController.getMenuDrawerCustomFolders().map { it.list.flattenFolderChildren(dismissHiddenChildren = true) }
-    }
-
-    val currentFoldersLive = currentDefaultFoldersLive.combine(currentCustomFoldersLive) { defaultFolders, customFolders ->
-        defaultFolders to customFolders
+    val customFoldersLive = _currentMailboxObjectId.filterNotNull().flatMapLatest {
+        folderController.getMenuDrawerCustomFoldersAsync().map { it.list.flattenFolderChildren(dismissHiddenChildren = true) }
     }.asLiveData(ioCoroutineContext)
 
     val currentQuotasLive = _currentMailboxObjectId.flatMapLatest {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
@@ -62,6 +62,7 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
 
     fun formatList(mediatorContainer: MediatorContainer) = buildList {
         runCatchingRealm {
+
             val (
                 mailboxes,
                 areMailboxesExpanded,
@@ -79,7 +80,7 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
             hasCollapsableDefaultFolder = addDefaultFolders(defaultFolders)
 
             add(ItemType.DIVIDER)
-            hasCollapsableCustomFolder = addCustomFoldersFrom(customFolders, areCustomFoldersExpanded)
+            hasCollapsableCustomFolder = addCustomFolders(customFolders, areCustomFoldersExpanded)
 
             add(ItemType.DIVIDER)
             addAdvancedActions(areActionsExpanded, permissions)
@@ -88,13 +89,11 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
         }
     }
 
-    private fun MutableList<Any>.addMailboxes(
-        mailboxes: List<Mailbox>,
-        areMailboxesExpanded: Boolean
-    ) {
+    private fun MutableList<Any>.addMailboxes(mailboxes: List<Mailbox>, areMailboxesExpanded: Boolean) {
         val currentMailboxIndex = mailboxes.indexOfFirst { it.mailboxId == AccountUtils.currentMailboxId }
         val otherMailboxes = mailboxes.toMutableList()
         val currentMailbox = otherMailboxes.removeAt(currentMailboxIndex)
+
         add(MailboxesHeader(currentMailbox, otherMailboxes.isNotEmpty(), areMailboxesExpanded))
         if (areMailboxesExpanded) addAll(otherMailboxes)
     }
@@ -110,7 +109,7 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
         return atLeastOneFolderIsIndented
     }
 
-    private fun MutableList<Any>.addCustomFoldersFrom(customFolders: List<Folder>, areCustomFoldersExpanded: Boolean): Boolean {
+    private fun MutableList<Any>.addCustomFolders(customFolders: List<Folder>, areCustomFoldersExpanded: Boolean): Boolean {
         var atLeastOneFolderIsIndented = false
 
         add(ItemType.FOLDERS_HEADER)
@@ -128,11 +127,10 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
         return atLeastOneFolderIsIndented
     }
 
-    private fun MutableList<Any>.addAdvancedActions(
-        areActionsExpanded: Boolean,
-        permissions: MailboxPermissions?
-    ) {
+    private fun MutableList<Any>.addAdvancedActions(areActionsExpanded: Boolean, permissions: MailboxPermissions?) {
+
         add(ItemType.ACTIONS_HEADER)
+
         if (areActionsExpanded) {
             add(SYNC_AUTO_CONFIG_ACTION)
             add(IMPORT_MAILS_ACTION)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
@@ -239,7 +239,7 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
         }
     }
 
-    abstract class MenuDrawerViewHolder(val binding: ViewBinding) : ViewHolder(binding.root)
+    abstract class MenuDrawerViewHolder(open val binding: ViewBinding) : ViewHolder(binding.root)
 
     enum class ItemType {
         DIVIDER,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
@@ -73,8 +73,8 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
             ) = mediatorContainer
 
             var count = 0
-            var temporaryHasCollapsableDefaultFolder = false
-            var temporaryHasCollapsableCustomFolder = false
+            hasCollapsableDefaultFolder = false
+            hasCollapsableCustomFolder = false
 
             // Mailboxes
             val currentMailboxIndex = mailboxes.indexOfFirst { it.mailboxId == AccountUtils.currentMailboxId }
@@ -87,7 +87,7 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
             add(ItemType.DIVIDER)
             while (count < allFolders.count() && (allFolders[count].role != null || !allFolders[count].isRoot)) {
                 val defaultFolder = allFolders[count]
-                if (defaultFolder.canBeCollapsed) temporaryHasCollapsableDefaultFolder = true
+                if (defaultFolder.canBeCollapsed) hasCollapsableDefaultFolder = true
                 add(defaultFolder)
                 count++
             }
@@ -101,14 +101,12 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
                 } else {
                     while (count < allFolders.count()) {
                         val customFolder = allFolders[count]
-                        if (customFolder.canBeCollapsed) temporaryHasCollapsableCustomFolder = true
+                        if (customFolder.canBeCollapsed) hasCollapsableCustomFolder = true
                         add(customFolder)
                         count++
                     }
                 }
             }
-            hasCollapsableDefaultFolder = temporaryHasCollapsableDefaultFolder
-            hasCollapsableCustomFolder = temporaryHasCollapsableCustomFolder
 
             // Actions
             add(ItemType.DIVIDER)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
@@ -114,6 +114,7 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
     }
 
     private fun MutableList<Any>.addCustomFoldersFrom(allFolders: List<Folder>, areCustomFoldersExpanded: Boolean): Boolean {
+        var isFirstCustomFolderEncountered = false
         var atLeastOneFolderIsIndented = false
         var areCustomFoldersEmpty = true
 
@@ -121,7 +122,9 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
         if (!areCustomFoldersExpanded) return false
 
         for (folder in allFolders) {
-            if (!folder.isDefaultFolder()) {
+            if (!isFirstCustomFolderEncountered && !folder.isDefaultFolder()) isFirstCustomFolderEncountered = true
+
+            if (isFirstCustomFolderEncountered) {
                 areCustomFoldersEmpty = false
                 if (folder.canBeCollapsed) atLeastOneFolderIsIndented = true
                 add(folder)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
@@ -114,9 +114,9 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
             add(ItemType.DIVIDER)
             add(ItemType.ACTIONS_HEADER)
             if (areActionsExpanded) {
-                add(syncAutoConfigAction)
-                add(importMailsAction)
-                if (permissions?.canRestoreEmails == true) add(restoreMailsAction)
+                add(SYNC_AUTO_CONFIG_ACTION)
+                add(IMPORT_MAILS_ACTION)
+                if (permissions?.canRestoreEmails == true) add(RESTORE_MAILS_ACTION)
             }
 
             // Footer
@@ -309,19 +309,19 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
     }
 
     companion object {
-        private val syncAutoConfigAction = MenuDrawerAction(
+        private val SYNC_AUTO_CONFIG_ACTION = MenuDrawerAction(
             type = ActionType.SYNC_AUTO_CONFIG,
             icon = R.drawable.ic_synchronize,
             text = R.string.syncCalendarsAndContactsTitle,
             maxLines = 2,
         )
-        private val importMailsAction = MenuDrawerAction(
+        private val IMPORT_MAILS_ACTION = MenuDrawerAction(
             type = ActionType.IMPORT_MAILS,
             icon = R.drawable.ic_drawer_download,
             text = R.string.buttonImportEmails,
             maxLines = 1,
         )
-        private val restoreMailsAction = MenuDrawerAction(
+        private val RESTORE_MAILS_ACTION = MenuDrawerAction(
             type = ActionType.RESTORE_MAILS,
             icon = R.drawable.ic_restore_arrow,
             text = R.string.buttonRestoreEmails,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
@@ -319,13 +319,11 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
 
         override fun areContentsTheSame(oldItem: Any, newItem: Any) = runCatchingRealm {
             when (oldItem) {
-                ItemType.DIVIDER -> true
                 is MailboxesHeader -> newItem is MailboxesHeader
                         && newItem.hasMoreThanOneMailbox == oldItem.hasMoreThanOneMailbox
                         && newItem.isExpanded == oldItem.isExpanded
                         && newItem.mailbox?.unreadCountDisplay?.count == oldItem.mailbox?.unreadCountDisplay?.count
                 is Mailbox -> newItem is Mailbox && newItem.unreadCountDisplay.count == oldItem.unreadCountDisplay.count
-                ItemType.FOLDERS_HEADER -> true
                 is Folder -> newItem is Folder &&
                         newItem.name == oldItem.name &&
                         newItem.isFavorite == oldItem.isFavorite &&
@@ -333,10 +331,12 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
                         newItem.unreadCountDisplay == oldItem.unreadCountDisplay &&
                         newItem.threads.count() == oldItem.threads.count() &&
                         newItem.canBeCollapsed == oldItem.canBeCollapsed
-                ItemType.EMPTY_FOLDERS -> true
-                ItemType.ACTIONS_HEADER -> true
-                is MenuDrawerAction -> true
                 is MenuDrawerFooter -> newItem is MenuDrawerFooter && newItem.quotas?.size == oldItem.quotas?.size
+                ItemType.DIVIDER,
+                ItemType.FOLDERS_HEADER,
+                ItemType.EMPTY_FOLDERS,
+                ItemType.ACTIONS_HEADER,
+                is MenuDrawerAction -> true
                 else -> error("oldItem wasn't any known item type (in MenuDrawer `areContentsTheSame`)")
             }
         }.getOrDefault(false)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
@@ -114,32 +114,9 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
             add(ItemType.DIVIDER)
             add(ItemType.ACTIONS_HEADER)
             if (areActionsExpanded) {
-                add(
-                    MenuDrawerAction(
-                        type = ActionType.SYNC_AUTO_CONFIG,
-                        icon = R.drawable.ic_synchronize,
-                        text = R.string.syncCalendarsAndContactsTitle,
-                        maxLines = 2,
-                    ),
-                )
-                add(
-                    MenuDrawerAction(
-                        type = ActionType.IMPORT_MAILS,
-                        icon = R.drawable.ic_drawer_download,
-                        text = R.string.buttonImportEmails,
-                        maxLines = 1,
-                    ),
-                )
-                if (permissions?.canRestoreEmails == true) {
-                    add(
-                        MenuDrawerAction(
-                            type = ActionType.RESTORE_MAILS,
-                            icon = R.drawable.ic_restore_arrow,
-                            text = R.string.buttonRestoreEmails,
-                            maxLines = 1,
-                        ),
-                    )
-                }
+                add(syncAutoConfigAction)
+                add(importMailsAction)
+                if (permissions?.canRestoreEmails == true) add(restoreMailsAction)
             }
 
             // Footer
@@ -329,5 +306,26 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
                 null
             }
         }
+    }
+
+    companion object {
+        private val syncAutoConfigAction = MenuDrawerAction(
+            type = ActionType.SYNC_AUTO_CONFIG,
+            icon = R.drawable.ic_synchronize,
+            text = R.string.syncCalendarsAndContactsTitle,
+            maxLines = 2,
+        )
+        private val importMailsAction = MenuDrawerAction(
+            type = ActionType.IMPORT_MAILS,
+            icon = R.drawable.ic_drawer_download,
+            text = R.string.buttonImportEmails,
+            maxLines = 1,
+        )
+        private val restoreMailsAction = MenuDrawerAction(
+            type = ActionType.RESTORE_MAILS,
+            icon = R.drawable.ic_restore_arrow,
+            text = R.string.buttonRestoreEmails,
+            maxLines = 1,
+        )
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
@@ -26,14 +26,6 @@ import androidx.viewbinding.ViewBinding
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.mailbox.Mailbox
-import com.infomaniak.mail.databinding.ItemInvalidMailboxBinding
-import com.infomaniak.mail.databinding.ItemMenuDrawerActionBinding
-import com.infomaniak.mail.databinding.ItemMenuDrawerActionsHeaderBinding
-import com.infomaniak.mail.databinding.ItemMenuDrawerCustomFoldersHeaderBinding
-import com.infomaniak.mail.databinding.ItemMenuDrawerFolderBinding
-import com.infomaniak.mail.databinding.ItemMenuDrawerFooterBinding
-import com.infomaniak.mail.databinding.ItemMenuDrawerMailboxBinding
-import com.infomaniak.mail.databinding.ItemMenuDrawerMailboxesHeaderBinding
 import com.infomaniak.mail.ui.main.menuDrawer.MenuDrawerAdapter.MenuDrawerViewHolder
 import com.infomaniak.mail.ui.main.menuDrawer.MenuDrawerFragment.MediatorContainer
 import com.infomaniak.mail.ui.main.menuDrawer.items.ActionViewHolder
@@ -220,60 +212,49 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
 
     override fun onBindViewHolder(holder: MenuDrawerViewHolder, position: Int, payloads: MutableList<Any>) {
         if (payloads.firstOrNull() == NotifyType.MAILBOXES_HEADER_CLICKED) {
-            (holder as MailboxesHeaderViewHolder).updateCollapseState(
-                header = currentList[position] as MailboxesHeader,
-                binding = holder.binding as ItemMenuDrawerMailboxesHeaderBinding,
-            )
+            (holder as MailboxesHeaderViewHolder).updateCollapseState(header = currentList[position] as MailboxesHeader)
         } else {
             super.onBindViewHolder(holder, position, payloads)
         }
     }
 
-    override fun onBindViewHolder(holder: MenuDrawerViewHolder, position: Int): Unit = with(holder.binding) {
+    override fun onBindViewHolder(holder: MenuDrawerViewHolder, position: Int) {
         val item = currentList[position]
 
         when (holder) {
             is MailboxesHeaderViewHolder -> holder.displayMailboxesHeader(
                 header = item as MailboxesHeader,
-                binding = this as ItemMenuDrawerMailboxesHeaderBinding,
                 onMailboxesHeaderClicked = callbacks.onMailboxesHeaderClicked,
             )
             is MailboxViewHolder -> holder.displayMailbox(
                 mailbox = item as Mailbox,
-                binding = this as ItemMenuDrawerMailboxBinding,
                 onValidMailboxClicked = callbacks.onValidMailboxClicked,
             )
             is InvalidMailboxViewHolder -> holder.displayInvalidMailbox(
                 mailbox = item as Mailbox,
-                binding = this as ItemInvalidMailboxBinding,
                 onLockedMailboxClicked = callbacks.onLockedMailboxClicked,
                 onInvalidPasswordMailboxClicked = callbacks.onInvalidPasswordMailboxClicked,
             )
             is FoldersHeaderViewHolder -> holder.displayFoldersHeader(
-                binding = this as ItemMenuDrawerCustomFoldersHeaderBinding,
                 onFoldersHeaderClicked = callbacks.onFoldersHeaderClicked,
                 onCreateFolderClicked = callbacks.onCreateFolderClicked,
             )
             is FolderViewHolder -> holder.displayFolder(
                 folder = item as Folder,
-                binding = this as ItemMenuDrawerFolderBinding,
                 currentFolderId = currentFolderId,
                 hasCollapsableFolder = if (item.role == null) hasCollapsableCustomFolder else hasCollapsableDefaultFolder,
                 onFolderClicked = callbacks.onFolderClicked,
                 onCollapseChildrenClicked = callbacks.onCollapseChildrenClicked,
             )
             is ActionsHeaderViewHolder -> holder.displayActionsHeader(
-                binding = this as ItemMenuDrawerActionsHeaderBinding,
                 onActionsHeaderClicked = callbacks.onActionsHeaderClicked,
             )
             is ActionViewHolder -> holder.displayAction(
                 action = item as MenuDrawerAction,
-                binding = this as ItemMenuDrawerActionBinding,
                 onActionClicked = callbacks.onActionClicked,
             )
             is FooterViewHolder -> holder.displayFooter(
                 footer = item as MenuDrawerFooter,
-                binding = this as ItemMenuDrawerFooterBinding,
                 onFeedbackClicked = callbacks.onFeedbackClicked,
                 onHelpClicked = callbacks.onHelpClicked,
                 onAppVersionClicked = callbacks.onAppVersionClicked,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapter.kt
@@ -65,7 +65,8 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
             val (
                 mailboxes,
                 areMailboxesExpanded,
-                allFolders,
+                defaultFolders,
+                customFolders,
                 areCustomFoldersExpanded,
                 areActionsExpanded,
                 permissions,
@@ -75,10 +76,10 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
             addMailboxes(mailboxes, areMailboxesExpanded)
 
             add(ItemType.DIVIDER)
-            hasCollapsableDefaultFolder = addDefaultFolders(allFolders)
+            hasCollapsableDefaultFolder = addDefaultFolders(defaultFolders)
 
             add(ItemType.DIVIDER)
-            hasCollapsableCustomFolder = addCustomFoldersFrom(allFolders, areCustomFoldersExpanded)
+            hasCollapsableCustomFolder = addCustomFoldersFrom(customFolders, areCustomFoldersExpanded)
 
             add(ItemType.DIVIDER)
             addAdvancedActions(areActionsExpanded, permissions)
@@ -98,45 +99,34 @@ class MenuDrawerAdapter @Inject constructor() : ListAdapter<Any, MenuDrawerViewH
         if (areMailboxesExpanded) addAll(otherMailboxes)
     }
 
-    private fun MutableList<Any>.addDefaultFolders(allFolders: List<Folder>): Boolean {
+    private fun MutableList<Any>.addDefaultFolders(defaultFolders: List<Folder>): Boolean {
         var atLeastOneFolderIsIndented = false
 
-        for (folder in allFolders) {
-            if (folder.isDefaultFolder()) {
-                if (folder.canBeCollapsed) atLeastOneFolderIsIndented = true
-                add(folder)
-            } else {
-                break
-            }
+        defaultFolders.forEach { defaultFolder ->
+            if (defaultFolder.canBeCollapsed) atLeastOneFolderIsIndented = true
+            add(defaultFolder)
         }
 
         return atLeastOneFolderIsIndented
     }
 
-    private fun MutableList<Any>.addCustomFoldersFrom(allFolders: List<Folder>, areCustomFoldersExpanded: Boolean): Boolean {
-        var isFirstCustomFolderEncountered = false
+    private fun MutableList<Any>.addCustomFoldersFrom(customFolders: List<Folder>, areCustomFoldersExpanded: Boolean): Boolean {
         var atLeastOneFolderIsIndented = false
-        var areCustomFoldersEmpty = true
 
         add(ItemType.FOLDERS_HEADER)
         if (!areCustomFoldersExpanded) return false
 
-        for (folder in allFolders) {
-            if (!isFirstCustomFolderEncountered && !folder.isDefaultFolder()) isFirstCustomFolderEncountered = true
-
-            if (isFirstCustomFolderEncountered) {
-                areCustomFoldersEmpty = false
-                if (folder.canBeCollapsed) atLeastOneFolderIsIndented = true
-                add(folder)
+        if (customFolders.isEmpty()) {
+            add(ItemType.EMPTY_FOLDERS)
+        } else {
+            customFolders.forEach { customFolder ->
+                if (customFolder.canBeCollapsed) atLeastOneFolderIsIndented = true
+                add(customFolder)
             }
         }
 
-        if (areCustomFoldersEmpty) add(ItemType.EMPTY_FOLDERS)
-
         return atLeastOneFolderIsIndented
     }
-
-    private fun Folder.isDefaultFolder() = role != null || !isRoot
 
     private fun MutableList<Any>.addAdvancedActions(
         areActionsExpanded: Boolean,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapterCallbacks.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerAdapterCallbacks.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.ui.main.menuDrawer
 
 import com.infomaniak.mail.data.models.mailbox.Mailbox
+import com.infomaniak.mail.ui.main.menuDrawer.items.ActionViewHolder.MenuDrawerAction.ActionType
 
 interface MenuDrawerAdapterCallbacks {
 
@@ -33,9 +34,9 @@ interface MenuDrawerAdapterCallbacks {
     var onFolderClicked: (folderId: String) -> Unit
     var onCollapseChildrenClicked: (folderId: String, shouldCollapse: Boolean) -> Unit
 
-    var onSyncAutoConfigClicked: () -> Unit
-    var onImportMailsClicked: () -> Unit
-    var onRestoreMailsClicked: () -> Unit
+    var onActionsHeaderClicked: () -> Unit
+    var onActionClicked: (ActionType) -> Unit
+
     var onFeedbackClicked: () -> Unit
     var onHelpClicked: () -> Unit
     var onAppVersionClicked: () -> Unit

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
@@ -276,11 +276,13 @@ class MenuDrawerFragment : Fragment() {
             currentPermissionsLive,
             currentQuotasLive,
             constructor = {
+                val (defaultFolders, customFolders) = it[2] as Pair<List<Folder>, List<Folder>>
                 @Suppress("UNCHECKED_CAST")
                 MediatorContainer(
                     it[0] as List<Mailbox>,
                     it[1] as Boolean,
-                    it[2] as List<Folder>,
+                    defaultFolders,
+                    customFolders,
                     it[3] as Boolean,
                     it[4] as Boolean,
                     it[5] as MailboxPermissions?,
@@ -323,7 +325,8 @@ class MenuDrawerFragment : Fragment() {
     data class MediatorContainer(
         val mailboxes: List<Mailbox>,
         val areMailboxesExpanded: Boolean,
-        val allFolders: List<Folder>,
+        val defaultFolders: List<Folder>,
+        val customFolders: List<Folder>,
         val areCustomFoldersExpanded: Boolean,
         val areActionsExpanded: Boolean,
         val permissions: MailboxPermissions?,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
@@ -270,23 +270,23 @@ class MenuDrawerFragment : Fragment() {
         Utils.waitInitMediator(
             mailboxesLive,
             menuDrawerViewModel.areMailboxesExpanded,
-            currentFoldersLive,
+            defaultFoldersLive,
+            customFoldersLive,
             menuDrawerViewModel.areCustomFoldersExpanded,
             menuDrawerViewModel.areActionsExpanded,
             currentPermissionsLive,
             currentQuotasLive,
             constructor = {
-                val (defaultFolders, customFolders) = it[2] as Pair<List<Folder>, List<Folder>>
                 @Suppress("UNCHECKED_CAST")
                 MediatorContainer(
                     it[0] as List<Mailbox>,
                     it[1] as Boolean,
-                    defaultFolders,
-                    customFolders,
-                    it[3] as Boolean,
+                    it[2] as List<Folder>,
+                    it[3] as List<Folder>,
                     it[4] as Boolean,
-                    it[5] as MailboxPermissions?,
-                    it[6] as Quotas?,
+                    it[5] as Boolean,
+                    it[6] as MailboxPermissions?,
+                    it[7] as Quotas?,
                 )
             }
         )

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
@@ -36,6 +36,7 @@ import com.infomaniak.lib.bugtracker.BugTrackerActivityArgs
 import com.infomaniak.lib.core.utils.UtilsUi.openUrl
 import com.infomaniak.lib.core.utils.safeNavigate
 import com.infomaniak.mail.BuildConfig
+import com.infomaniak.mail.MatomoMail.toFloat
 import com.infomaniak.mail.MatomoMail.trackCreateFolderEvent
 import com.infomaniak.mail.MatomoMail.trackMenuDrawerEvent
 import com.infomaniak.mail.MatomoMail.trackScreen
@@ -52,6 +53,7 @@ import com.infomaniak.mail.ui.alertDialogs.CreateFolderDialog
 import com.infomaniak.mail.ui.bottomSheetDialogs.LockedMailboxBottomSheetDialogArgs
 import com.infomaniak.mail.ui.main.InvalidPasswordFragmentArgs
 import com.infomaniak.mail.ui.main.folder.ThreadListFragmentDirections
+import com.infomaniak.mail.ui.main.menuDrawer.items.ActionViewHolder.MenuDrawerAction.ActionType
 import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.ConfettiUtils
 import com.infomaniak.mail.utils.ConfettiUtils.ConfettiType.INFOMANIAK
@@ -129,9 +131,8 @@ class MenuDrawerFragment : Fragment() {
                 override var onCreateFolderClicked: () -> Unit = ::onCreateFolderClicked
                 override var onFolderClicked: (folderId: String) -> Unit = ::onFolderSelected
                 override var onCollapseChildrenClicked: (folderId: String, shouldCollapse: Boolean) -> Unit = ::onFolderCollapsed
-                override var onSyncAutoConfigClicked: () -> Unit = ::onSyncAutoConfigClicked
-                override var onImportMailsClicked: () -> Unit = ::onImportMailsClicked
-                override var onRestoreMailsClicked: () -> Unit = ::onRestoreMailsClicked
+                override var onActionsHeaderClicked: () -> Unit = ::onActionsHeaderClicked
+                override var onActionClicked: (ActionType) -> Unit = ::onActionClicked
                 override var onFeedbackClicked: () -> Unit = ::onFeedbackClicked
                 override var onHelpClicked: () -> Unit = ::onHelpClicked
                 override var onAppVersionClicked: () -> Unit = ::onAppVersionClicked
@@ -197,6 +198,19 @@ class MenuDrawerFragment : Fragment() {
         menuDrawerViewModel.toggleFolderCollapsingState(folderId, shouldCollapse)
     }
 
+    private fun onActionsHeaderClicked() {
+        context?.trackMenuDrawerEvent("advancedActions", value = (!menuDrawerViewModel.areActionsExpanded.value!!).toFloat())
+        menuDrawerViewModel.toggleActionsCollapsingState()
+    }
+
+    private fun onActionClicked(type: ActionType) {
+        when (type) {
+            ActionType.SYNC_AUTO_CONFIG -> onSyncAutoConfigClicked()
+            ActionType.IMPORT_MAILS -> onImportMailsClicked()
+            ActionType.RESTORE_MAILS -> onRestoreMailsClicked()
+        }
+    }
+
     private fun onSyncAutoConfigClicked() {
         trackSyncAutoConfigEvent("openFromMenuDrawer")
         launchSyncAutoConfigActivityForResult()
@@ -258,6 +272,7 @@ class MenuDrawerFragment : Fragment() {
             menuDrawerViewModel.areMailboxesExpanded,
             currentFoldersLive,
             menuDrawerViewModel.areCustomFoldersExpanded,
+            menuDrawerViewModel.areActionsExpanded,
             currentPermissionsLive,
             currentQuotasLive,
             constructor = {
@@ -267,8 +282,9 @@ class MenuDrawerFragment : Fragment() {
                     it[1] as Boolean,
                     it[2] as List<Folder>,
                     it[3] as Boolean,
-                    it[4] as MailboxPermissions?,
-                    it[5] as Quotas?,
+                    it[4] as Boolean,
+                    it[5] as MailboxPermissions?,
+                    it[6] as Quotas?,
                 )
             }
         )
@@ -309,6 +325,7 @@ class MenuDrawerFragment : Fragment() {
         val areMailboxesExpanded: Boolean,
         val allFolders: List<Folder>,
         val areCustomFoldersExpanded: Boolean,
+        val areActionsExpanded: Boolean,
         val permissions: MailboxPermissions?,
         val quotas: Quotas?,
     )

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerViewModel.kt
@@ -39,10 +39,15 @@ class MenuDrawerViewModel @Inject constructor(
 
     val areMailboxesExpanded = MutableLiveData(false)
     val areCustomFoldersExpanded = MutableLiveData(true)
+    val areActionsExpanded = MutableLiveData(false)
 
     fun toggleFolderCollapsingState(folderId: String, shouldCollapse: Boolean) = viewModelScope.launch(ioCoroutineContext) {
         FolderController.updateFolderAndChildren(folderId, mailboxContentRealm()) {
             if (it.isRoot) it.isCollapsed = shouldCollapse else it.isHidden = shouldCollapse
         }
+    }
+
+    fun toggleActionsCollapsingState() {
+        areActionsExpanded.value = !areActionsExpanded.value!!
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/ActionViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/ActionViewHolder.kt
@@ -34,12 +34,11 @@ class ActionViewHolder(
 
     fun displayAction(
         action: MenuDrawerAction,
-        binding: ItemMenuDrawerActionBinding,
         onActionClicked: (ActionType) -> Unit,
     ) {
         SentryLog.d("Bind", "Bind Action : ${action.type.name}")
 
-        binding.root.apply {
+        (binding as ItemMenuDrawerActionBinding).root.apply {
             icon = AppCompatResources.getDrawable(context, action.icon)
             text = context.getString(action.text)
             maxLines = action.maxLines

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/ActionViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/ActionViewHolder.kt
@@ -32,13 +32,15 @@ class ActionViewHolder(
     parent: ViewGroup,
 ) : MenuDrawerViewHolder(ItemMenuDrawerActionBinding.inflate(inflater, parent, false)) {
 
+    override val binding = super.binding as ItemMenuDrawerActionBinding
+
     fun displayAction(
         action: MenuDrawerAction,
         onActionClicked: (ActionType) -> Unit,
     ) {
         SentryLog.d("Bind", "Bind Action : ${action.type.name}")
 
-        (binding as ItemMenuDrawerActionBinding).root.apply {
+        binding.root.apply {
             icon = AppCompatResources.getDrawable(context, action.icon)
             text = context.getString(action.text)
             maxLines = action.maxLines

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/ActionViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/ActionViewHolder.kt
@@ -1,0 +1,63 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.ui.main.menuDrawer.items
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.appcompat.content.res.AppCompatResources
+import com.infomaniak.lib.core.utils.SentryLog
+import com.infomaniak.mail.databinding.ItemMenuDrawerActionBinding
+import com.infomaniak.mail.ui.main.menuDrawer.MenuDrawerAdapter.MenuDrawerViewHolder
+import com.infomaniak.mail.ui.main.menuDrawer.items.ActionViewHolder.MenuDrawerAction.ActionType
+
+class ActionViewHolder(
+    inflater: LayoutInflater,
+    parent: ViewGroup,
+) : MenuDrawerViewHolder(ItemMenuDrawerActionBinding.inflate(inflater, parent, false)) {
+
+    fun displayAction(
+        action: MenuDrawerAction,
+        binding: ItemMenuDrawerActionBinding,
+        onActionClicked: (ActionType) -> Unit,
+    ) {
+        SentryLog.d("Bind", "Bind Action : ${action.type.name}")
+
+        binding.root.apply {
+            icon = AppCompatResources.getDrawable(context, action.icon)
+            text = context.getString(action.text)
+            maxLines = action.maxLines
+            setOnClickListener { onActionClicked(action.type) }
+        }
+    }
+
+    data class MenuDrawerAction(
+        val type: ActionType,
+        @DrawableRes val icon: Int,
+        @StringRes val text: Int,
+        val maxLines: Int,
+    ) {
+
+        enum class ActionType {
+            SYNC_AUTO_CONFIG,
+            IMPORT_MAILS,
+            RESTORE_MAILS,
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/ActionsHeaderViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/ActionsHeaderViewHolder.kt
@@ -28,7 +28,7 @@ class ActionsHeaderViewHolder(
     parent: ViewGroup,
 ) : MenuDrawerViewHolder(ItemMenuDrawerActionsHeaderBinding.inflate(inflater, parent, false)) {
 
-    fun displayActionsHeader(binding: ItemMenuDrawerActionsHeaderBinding, onActionsHeaderClicked: () -> Unit) {
+    fun displayActionsHeader(onActionsHeaderClicked: () -> Unit) {
         SentryLog.d("Bind", "Bind Actions header")
         binding.root.setOnClickListener { onActionsHeaderClicked() }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/ActionsHeaderViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/ActionsHeaderViewHolder.kt
@@ -1,0 +1,35 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.ui.main.menuDrawer.items
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.infomaniak.lib.core.utils.SentryLog
+import com.infomaniak.mail.databinding.ItemMenuDrawerActionsHeaderBinding
+import com.infomaniak.mail.ui.main.menuDrawer.MenuDrawerAdapter.MenuDrawerViewHolder
+
+class ActionsHeaderViewHolder(
+    inflater: LayoutInflater,
+    parent: ViewGroup,
+) : MenuDrawerViewHolder(ItemMenuDrawerActionsHeaderBinding.inflate(inflater, parent, false)) {
+
+    fun displayActionsHeader(binding: ItemMenuDrawerActionsHeaderBinding, onActionsHeaderClicked: () -> Unit) {
+        SentryLog.d("Bind", "Bind Actions header")
+        binding.root.setOnClickListener { onActionsHeaderClicked() }
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FolderViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FolderViewHolder.kt
@@ -37,6 +37,8 @@ class FolderViewHolder(
     parent: ViewGroup,
 ) : MenuDrawerViewHolder(ItemMenuDrawerFolderBinding.inflate(inflater, parent, false)) {
 
+    override val binding = super.binding as ItemMenuDrawerFolderBinding
+
     fun displayFolder(
         folder: Folder,
         currentFolderId: String?,
@@ -69,7 +71,7 @@ class FolderViewHolder(
             else -> folder.unreadCountDisplay
         }
 
-        (binding as ItemMenuDrawerFolderBinding).root.setFolderUi(
+        binding.root.setFolderUi(
             folder,
             roleDependantParameters,
             unread,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FolderViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FolderViewHolder.kt
@@ -39,7 +39,6 @@ class FolderViewHolder(
 
     fun displayFolder(
         folder: Folder,
-        binding: ItemMenuDrawerFolderBinding,
         currentFolderId: String?,
         hasCollapsableFolder: Boolean,
         onFolderClicked: (folderId: String) -> Unit,
@@ -70,7 +69,7 @@ class FolderViewHolder(
             else -> folder.unreadCountDisplay
         }
 
-        binding.root.setFolderUi(
+        (binding as ItemMenuDrawerFolderBinding).root.setFolderUi(
             folder,
             roleDependantParameters,
             unread,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FoldersHeaderViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FoldersHeaderViewHolder.kt
@@ -28,10 +28,12 @@ class FoldersHeaderViewHolder(
     parent: ViewGroup,
 ) : MenuDrawerViewHolder(ItemMenuDrawerCustomFoldersHeaderBinding.inflate(inflater, parent, false)) {
 
+    override val binding = super.binding as ItemMenuDrawerCustomFoldersHeaderBinding
+
     fun displayFoldersHeader(
         onFoldersHeaderClicked: (Boolean) -> Unit,
         onCreateFolderClicked: () -> Unit,
-    ) = with((binding as ItemMenuDrawerCustomFoldersHeaderBinding).root) {
+    ) = with(binding.root) {
         SentryLog.d("Bind", "Bind Custom Folders header")
 
         setOnClickListener { onFoldersHeaderClicked(isCollapsed) }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FoldersHeaderViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FoldersHeaderViewHolder.kt
@@ -29,10 +29,9 @@ class FoldersHeaderViewHolder(
 ) : MenuDrawerViewHolder(ItemMenuDrawerCustomFoldersHeaderBinding.inflate(inflater, parent, false)) {
 
     fun displayFoldersHeader(
-        binding: ItemMenuDrawerCustomFoldersHeaderBinding,
         onFoldersHeaderClicked: (Boolean) -> Unit,
         onCreateFolderClicked: () -> Unit,
-    ) = with(binding.root) {
+    ) = with((binding as ItemMenuDrawerCustomFoldersHeaderBinding).root) {
         SentryLog.d("Bind", "Bind Custom Folders header")
 
         setOnClickListener { onFoldersHeaderClicked(isCollapsed) }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FooterViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FooterViewHolder.kt
@@ -34,11 +34,10 @@ class FooterViewHolder(
 
     fun displayFooter(
         footer: MenuDrawerFooter,
-        binding: ItemMenuDrawerFooterBinding,
         onFeedbackClicked: () -> Unit,
         onHelpClicked: () -> Unit,
         onAppVersionClicked: () -> Unit,
-    ) = with(binding) {
+    ) = with(binding as ItemMenuDrawerFooterBinding) {
         SentryLog.d("Bind", "Bind Footer")
 
         // Feedback

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FooterViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FooterViewHolder.kt
@@ -32,12 +32,14 @@ class FooterViewHolder(
     parent: ViewGroup,
 ) : MenuDrawerViewHolder(ItemMenuDrawerFooterBinding.inflate(inflater, parent, false)) {
 
+    override val binding = super.binding as ItemMenuDrawerFooterBinding
+
     fun displayFooter(
         footer: MenuDrawerFooter,
         onFeedbackClicked: () -> Unit,
         onHelpClicked: () -> Unit,
         onAppVersionClicked: () -> Unit,
-    ) = with(binding as ItemMenuDrawerFooterBinding) {
+    ) = with(binding) {
         SentryLog.d("Bind", "Bind Footer")
 
         // Feedback

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FooterViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FooterViewHolder.kt
@@ -19,15 +19,11 @@ package com.infomaniak.mail.ui.main.menuDrawer.items
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.lib.core.utils.context
 import com.infomaniak.mail.BuildConfig
-import com.infomaniak.mail.MatomoMail.toFloat
-import com.infomaniak.mail.MatomoMail.trackMenuDrawerEvent
 import com.infomaniak.mail.data.models.Quotas
-import com.infomaniak.mail.data.models.mailbox.MailboxPermissions
 import com.infomaniak.mail.databinding.ItemMenuDrawerFooterBinding
 import com.infomaniak.mail.ui.main.menuDrawer.MenuDrawerAdapter.MenuDrawerViewHolder
 
@@ -39,32 +35,11 @@ class FooterViewHolder(
     fun displayFooter(
         footer: MenuDrawerFooter,
         binding: ItemMenuDrawerFooterBinding,
-        onSyncAutoConfigClicked: () -> Unit,
-        onImportMailsClicked: () -> Unit,
-        onRestoreMailsClicked: () -> Unit,
         onFeedbackClicked: () -> Unit,
         onHelpClicked: () -> Unit,
         onAppVersionClicked: () -> Unit,
     ) = with(binding) {
         SentryLog.d("Bind", "Bind Footer")
-
-        // Actions header
-        advancedActions.setOnClickListener {
-            context.trackMenuDrawerEvent("advancedActions", value = (!advancedActions.isCollapsed).toFloat())
-            advancedActionsLayout.isGone = advancedActions.isCollapsed
-        }
-
-        // Calendar & contacts sync
-        syncAutoConfig.setOnClickListener { onSyncAutoConfigClicked() }
-
-        // Import mails
-        importMails.setOnClickListener { onImportMailsClicked() }
-
-        // Restore mails
-        restoreMails.apply {
-            isVisible = footer.permissions?.canRestoreEmails == true
-            setOnClickListener { onRestoreMailsClicked() }
-        }
 
         // Feedback
         feedback.setOnClickListener { onFeedbackClicked() }
@@ -88,5 +63,5 @@ class FooterViewHolder(
         }
     }
 
-    data class MenuDrawerFooter(val permissions: MailboxPermissions?, val quotas: Quotas?)
+    data class MenuDrawerFooter(val quotas: Quotas?)
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/InvalidMailboxViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/InvalidMailboxViewHolder.kt
@@ -30,11 +30,13 @@ class InvalidMailboxViewHolder(
     parent: ViewGroup,
 ) : MenuDrawerViewHolder(ItemInvalidMailboxBinding.inflate(inflater, parent, false)) {
 
+    override val binding = super.binding as ItemInvalidMailboxBinding
+
     fun displayInvalidMailbox(
         mailbox: Mailbox,
         onLockedMailboxClicked: (String) -> Unit,
         onInvalidPasswordMailboxClicked: (Mailbox) -> Unit,
-    ) = with((binding as ItemInvalidMailboxBinding).root) {
+    ) = with(binding.root) {
         SentryLog.d("Bind", "Bind Invalid Mailbox (${mailbox.email})")
 
         text = mailbox.email

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/InvalidMailboxViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/InvalidMailboxViewHolder.kt
@@ -32,10 +32,9 @@ class InvalidMailboxViewHolder(
 
     fun displayInvalidMailbox(
         mailbox: Mailbox,
-        binding: ItemInvalidMailboxBinding,
         onLockedMailboxClicked: (String) -> Unit,
         onInvalidPasswordMailboxClicked: (Mailbox) -> Unit,
-    ) = with(binding.root) {
+    ) = with((binding as ItemInvalidMailboxBinding).root) {
         SentryLog.d("Bind", "Bind Invalid Mailbox (${mailbox.email})")
 
         text = mailbox.email

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/MailboxViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/MailboxViewHolder.kt
@@ -33,9 +33,8 @@ class MailboxViewHolder(
 
     fun displayMailbox(
         mailbox: Mailbox,
-        binding: ItemMenuDrawerMailboxBinding,
         onValidMailboxClicked: (Int) -> Unit,
-    ) = with(binding.root) {
+    ) = with((binding as ItemMenuDrawerMailboxBinding).root) {
         SentryLog.d("Bind", "Bind Mailbox (${mailbox.email})")
 
         text = mailbox.email

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/MailboxViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/MailboxViewHolder.kt
@@ -31,10 +31,12 @@ class MailboxViewHolder(
     parent: ViewGroup,
 ) : MenuDrawerViewHolder(ItemMenuDrawerMailboxBinding.inflate(inflater, parent, false)) {
 
+    override val binding = super.binding as ItemMenuDrawerMailboxBinding
+
     fun displayMailbox(
         mailbox: Mailbox,
         onValidMailboxClicked: (Int) -> Unit,
-    ) = with((binding as ItemMenuDrawerMailboxBinding).root) {
+    ) = with(binding.root) {
         SentryLog.d("Bind", "Bind Mailbox (${mailbox.email})")
 
         text = mailbox.email

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/MailboxesHeaderViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/MailboxesHeaderViewHolder.kt
@@ -32,10 +32,12 @@ class MailboxesHeaderViewHolder(
     parent: ViewGroup,
 ) : MenuDrawerViewHolder(ItemMenuDrawerMailboxesHeaderBinding.inflate(inflater, parent, false)) {
 
+    override val binding = super.binding as ItemMenuDrawerMailboxesHeaderBinding
+
     fun displayMailboxesHeader(
         header: MailboxesHeader,
         onMailboxesHeaderClicked: () -> Unit,
-    ) = with(binding as ItemMenuDrawerMailboxesHeaderBinding) {
+    ) = with(binding) {
         SentryLog.d("Bind", "Bind Mailboxes header")
 
         val (mailbox, hasMoreThanOneMailbox, isExpanded) = header
@@ -54,7 +56,7 @@ class MailboxesHeaderViewHolder(
 
     fun updateCollapseState(
         header: MailboxesHeader,
-    ) = with(binding as ItemMenuDrawerMailboxesHeaderBinding) {
+    ) = with(binding) {
         SentryLog.d("Bind", "Bind Mailboxes header because of collapse change")
 
         mailboxExpandButton.toggleChevron(!header.isExpanded)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/MailboxesHeaderViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/MailboxesHeaderViewHolder.kt
@@ -34,9 +34,8 @@ class MailboxesHeaderViewHolder(
 
     fun displayMailboxesHeader(
         header: MailboxesHeader,
-        binding: ItemMenuDrawerMailboxesHeaderBinding,
         onMailboxesHeaderClicked: () -> Unit,
-    ) = with(binding) {
+    ) = with(binding as ItemMenuDrawerMailboxesHeaderBinding) {
         SentryLog.d("Bind", "Bind Mailboxes header")
 
         val (mailbox, hasMoreThanOneMailbox, isExpanded) = header
@@ -55,8 +54,7 @@ class MailboxesHeaderViewHolder(
 
     fun updateCollapseState(
         header: MailboxesHeader,
-        binding: ItemMenuDrawerMailboxesHeaderBinding,
-    ) = with(binding) {
+    ) = with(binding as ItemMenuDrawerMailboxesHeaderBinding) {
         SentryLog.d("Bind", "Bind Mailboxes header because of collapse change")
 
         mailboxExpandButton.toggleChevron(!header.isExpanded)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -79,7 +79,7 @@ class SearchViewModel @Inject constructor(
     var currentSearchQuery: String = ""
         private set
 
-    val foldersLive = folderController.getRootFoldersAsync()
+    val foldersLive = folderController.getSearchFoldersAsync()
         .map { it.list.flattenFolderChildren() }
         .asLiveData(ioCoroutineContext)
 

--- a/app/src/main/res/layout/item_menu_drawer_action.xml
+++ b/app/src/main/res/layout/item_menu_drawer_action.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Infomaniak Mail - Android
+  ~ Copyright (C) 2024 Infomaniak Network SA
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<com.infomaniak.mail.views.itemViews.SimpleMenuDrawerItemView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:icon="@drawable/ic_synchronize"
+    tools:maxLines="2"
+    tools:text="@string/syncCalendarsAndContactsTitle" />

--- a/app/src/main/res/layout/item_menu_drawer_actions_header.xml
+++ b/app/src/main/res/layout/item_menu_drawer_actions_header.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Infomaniak Mail - Android
+  ~ Copyright (C) 2024 Infomaniak Network SA
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<com.infomaniak.mail.ui.main.menuDrawer.MenuDrawerDropdownView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/advancedActions"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:collapsedByDefault="true"
+    app:title="@string/menuDrawerAdvancedActions" />

--- a/app/src/main/res/layout/item_menu_drawer_footer.xml
+++ b/app/src/main/res/layout/item_menu_drawer_footer.xml
@@ -23,47 +23,6 @@
     android:layout_marginBottom="@dimen/marginStandardSmall"
     android:orientation="vertical">
 
-    <!-- Advanced Actions dropdown -->
-    <com.infomaniak.mail.ui.main.menuDrawer.MenuDrawerDropdownView
-        android:id="@+id/advancedActions"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:collapsedByDefault="true"
-        app:title="@string/menuDrawerAdvancedActions" />
-
-    <!-- Advanced Actions -->
-    <LinearLayout
-        android:id="@+id/advancedActionsLayout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:visibility="gone"
-        tools:visibility="visible">
-
-        <com.infomaniak.mail.views.itemViews.SimpleMenuDrawerItemView
-            android:id="@+id/syncAutoConfig"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_synchronize"
-            app:maxLines="2"
-            app:text="@string/syncCalendarsAndContactsTitle" />
-
-        <com.infomaniak.mail.views.itemViews.SimpleMenuDrawerItemView
-            android:id="@+id/importMails"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_drawer_download"
-            app:text="@string/buttonImportEmails" />
-
-        <com.infomaniak.mail.views.itemViews.SimpleMenuDrawerItemView
-            android:id="@+id/restoreMails"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_restore_arrow"
-            app:text="@string/buttonRestoreEmails" />
-
-    </LinearLayout>
-
     <!-- Divider -->
     <com.google.android.material.divider.MaterialDivider
         style="@style/MenuDrawerDivider"

--- a/fastlane/metadata/android/fr/changelogs/1_04_002_01.txt
+++ b/fastlane/metadata/android/fr/changelogs/1_04_002_01.txt
@@ -1,2 +1,2 @@
-- Bloquage de l'importation de pièces jointes lorsque la limite de taille est atteinte
+- Blocage de l'importation de pièces jointes lorsque la limite de taille est atteinte
 - Correction de la barre d'outils de l'éditeur affichée sous le clavier


### PR DESCRIPTION
Depends on #1989

In the MenuDrawer, the animation when expanding/collapsing AdvancedActions was missing.
We moved the Actions to their own item in the RecyclerView, so we can have the animation back.