### PR TITLE
Batch API calls when there is more than 1000 UIDs

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -439,11 +439,10 @@ object ApiRepository : ApiRepositoryCore() {
 
     /**
      * Create batches of the given values to perform the given request
-     * - Parameters:
-     *   - values: Data to batch
-     *   - limit: Chunk size
-     *   - perform: Request to perform
-     * - Returns: Array of the perform return type
+     * @param values Data to batch
+     * @param limit Chunk size
+     * @param perform Request to perform
+     * @return Array of the perform return type
      */
     private fun <T, R> batchOver(
         values: List<T>,

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -57,6 +57,7 @@ import com.infomaniak.mail.data.models.signature.Signature
 import com.infomaniak.mail.data.models.signature.SignaturesResult
 import com.infomaniak.mail.data.models.thread.ThreadResult
 import com.infomaniak.mail.ui.newMessage.AiViewModel.Shortcut
+import com.infomaniak.mail.utils.Utils
 import io.realm.kotlin.ext.copyFromRealm
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -157,12 +158,16 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.externalMailInfo(mailboxHostingId, mailboxName), GET)
     }
 
-    fun markMessagesAsSeen(mailboxUuid: String, messagesUids: List<String>): ApiResponse<Unit> {
-        return callApi(ApiRoutes.messagesSeen(mailboxUuid), POST, mapOf("uids" to messagesUids))
+    fun markMessagesAsSeen(mailboxUuid: String, messagesUids: List<String>): List<ApiResponse<Unit>> {
+        return batchOver(messagesUids) {
+            callApi(ApiRoutes.messagesSeen(mailboxUuid), POST, mapOf("uids" to it))
+        }
     }
 
-    fun markMessagesAsUnseen(mailboxUuid: String, messagesUids: List<String>): ApiResponse<Unit> {
-        return callApi(ApiRoutes.messagesUnseen(mailboxUuid), POST, mapOf("uids" to messagesUids))
+    fun markMessagesAsUnseen(mailboxUuid: String, messagesUids: List<String>): List<ApiResponse<Unit>> {
+        return batchOver(messagesUids) {
+            callApi(ApiRoutes.messagesUnseen(mailboxUuid), POST, mapOf("uids" to it))
+        }
     }
 
     fun saveDraft(mailboxUuid: String, draft: Draft, okHttpClient: OkHttpClient): ApiResponse<SaveDraftResult> {
@@ -210,8 +215,10 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.attachmentToForward(mailboxUuid), POST, body)
     }
 
-    fun deleteMessages(mailboxUuid: String, messagesUids: List<String>): ApiResponse<Unit> {
-        return callApi(ApiRoutes.deleteMessages(mailboxUuid), POST, mapOf("uids" to messagesUids))
+    fun deleteMessages(mailboxUuid: String, messagesUids: List<String>): List<ApiResponse<Unit>> {
+        return batchOver(messagesUids) {
+            callApi(ApiRoutes.deleteMessages(mailboxUuid), POST, mapOf("uids" to it))
+        }
     }
 
     fun moveMessages(
@@ -219,13 +226,15 @@ object ApiRepository : ApiRepositoryCore() {
         messagesUids: List<String>,
         destinationId: String,
         okHttpClient: OkHttpClient = HttpClient.okHttpClient,
-    ): ApiResponse<MoveResult> {
-        return callApi(
-            url = ApiRoutes.moveMessages(mailboxUuid),
-            method = POST,
-            body = mapOf("uids" to messagesUids, "to" to destinationId),
-            okHttpClient = okHttpClient,
-        )
+    ): List<ApiResponse<MoveResult>> {
+        return batchOver(messagesUids) {
+            callApi(
+                url = ApiRoutes.moveMessages(mailboxUuid),
+                method = POST,
+                body = mapOf("uids" to it, "to" to destinationId),
+                okHttpClient = okHttpClient,
+            )
+        }
     }
 
     fun deleteDraft(mailboxUuid: String, remoteDraftUuid: String): ApiResponse<Unit> {
@@ -234,12 +243,16 @@ object ApiRepository : ApiRepositoryCore() {
 
     fun getDraft(messageDraftResource: String): ApiResponse<Draft> = callApi(ApiRoutes.resource(messageDraftResource), GET)
 
-    fun addToFavorites(mailboxUuid: String, messagesUids: List<String>): ApiResponse<Unit> {
-        return callApi(ApiRoutes.starMessages(mailboxUuid), POST, mapOf("uids" to messagesUids))
+    fun addToFavorites(mailboxUuid: String, messagesUids: List<String>): List<ApiResponse<Unit>> {
+        return batchOver(messagesUids) {
+            callApi(ApiRoutes.starMessages(mailboxUuid), POST, mapOf("uids" to it))
+        }
     }
 
-    fun removeFromFavorites(mailboxUuid: String, messagesUids: List<String>): ApiResponse<Unit> {
-        return callApi(ApiRoutes.unstarMessages(mailboxUuid), POST, mapOf("uids" to messagesUids))
+    fun removeFromFavorites(mailboxUuid: String, messagesUids: List<String>): List<ApiResponse<Unit>> {
+        return batchOver(messagesUids) {
+            callApi(ApiRoutes.unstarMessages(mailboxUuid), POST, mapOf("uids" to it))
+        }
     }
 
     fun getMessagesUids(
@@ -422,6 +435,22 @@ object ApiRepository : ApiRepositoryCore() {
 
     fun getShareLink(mailboxUuid: String, folderId: String, mailId: Int): ApiResponse<ShareThread> {
         return callApi(url = ApiRoutes.shareLink(mailboxUuid, folderId, mailId), method = POST)
+    }
+
+    /**
+     * Create batches of the given values to perform the given request
+     * - Parameters:
+     *   - values: Data to batch
+     *   - limit: Chunk size
+     *   - perform: Request to perform
+     * - Returns: Array of the perform return type
+     */
+    private fun <T, R> batchOver(
+        values: List<T>,
+        limit: Int = Utils.MESSAGES_UIDS_SIZE,
+        perform: (List<T>) -> ApiResponse<R>,
+    ): List<ApiResponse<R>> {
+        return values.chunked(limit).map(perform)
     }
 
     /**

--- a/app/src/main/java/com/infomaniak/mail/receivers/NotificationActionsReceiver.kt
+++ b/app/src/main/java/com/infomaniak/mail/receivers/NotificationActionsReceiver.kt
@@ -43,6 +43,7 @@ import com.infomaniak.mail.utils.NotificationPayload.NotificationBehavior
 import com.infomaniak.mail.utils.NotificationPayload.NotificationBehavior.NotificationType
 import com.infomaniak.mail.utils.NotificationUtils
 import com.infomaniak.mail.utils.SharedUtils
+import com.infomaniak.mail.utils.extensions.atLeastOneSucceeded
 import com.infomaniak.mail.utils.extensions.getApiException
 import com.infomaniak.mail.utils.extensions.getUids
 import dagger.hilt.android.AndroidEntryPoint
@@ -161,7 +162,7 @@ class NotificationActionsReceiver : BroadcastReceiver() {
             context.trackNotificationActionEvent(matomoValue)
 
             with(ApiRepository.moveMessages(mailbox.uuid, messages.getUids(), destinationFolder.id, okHttpClient)) {
-                if (isSuccess()) {
+                if (atLeastOneSucceeded()) {
                     dismissNotification(context, mailbox, notificationId)
                     updateFolders(folders = listOf(message.folder, destinationFolder), mailbox, realm)
                 } else {
@@ -169,7 +170,7 @@ class NotificationActionsReceiver : BroadcastReceiver() {
                     Sentry.withScope { scope ->
                         scope.setTag("reason", "Notif action fail because of API call")
                         scope.setExtra("destination folder role", folderRole.name)
-                        Sentry.captureException(getApiException())
+                        Sentry.captureException(first().getApiException())
                     }
                 }
             }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/SnackbarManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/SnackbarManager.kt
@@ -90,7 +90,7 @@ class SnackbarManager @Inject constructor() {
     )
 
     data class UndoData(
-        val resource: String,
+        val resources: List<String>,
         val foldersIds: List<String>,
         val destinationFolderId: String?,
     )

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -38,6 +38,7 @@ import com.infomaniak.mail.ui.main.thread.ThreadAdapter.SuperCollapsedBlock
 import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.extensions.MergedContactDictionary
 import com.infomaniak.mail.utils.extensions.appContext
+import com.infomaniak.mail.utils.extensions.atLeastOneSucceeded
 import com.infomaniak.mail.utils.extensions.getUids
 import com.infomaniak.mail.utils.extensions.indexOfFirstOrNull
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -335,8 +336,10 @@ class ThreadViewModel @Inject constructor(
         val realm = mailboxContentRealm()
         val thread = threadLive.value ?: return@launch
         val messages = messageController.getMessageAndDuplicates(thread, message)
-        val isSuccess = ApiRepository.deleteMessages(mailbox.uuid, messages.getUids()).isSuccess()
-        if (isSuccess) {
+
+        val apiResponses = ApiRepository.deleteMessages(mailbox.uuid, messages.getUids())
+
+        if (apiResponses.atLeastOneSucceeded()) {
             refreshController.refreshThreads(
                 refreshMode = RefreshMode.REFRESH_FOLDER_WITH_ROLE,
                 mailbox = mailbox,

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -34,6 +34,7 @@ import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.ui.main.settings.SettingRadioGroupView
 import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
+import com.infomaniak.mail.utils.extensions.atLeastOneSucceeded
 import com.infomaniak.mail.utils.extensions.getApiException
 import com.infomaniak.mail.utils.extensions.getFoldersIds
 import com.infomaniak.mail.utils.extensions.getUids
@@ -76,9 +77,9 @@ class SharedUtils @Inject constructor(
             else -> messageController.getMessageAndDuplicates(threads.first(), message)
         }
 
-        val isSuccess = ApiRepository.markMessagesAsSeen(mailbox.uuid, messages.getUids()).isSuccess()
+        val apiResponses = ApiRepository.markMessagesAsSeen(mailbox.uuid, messages.getUids())
 
-        if (isSuccess && shouldRefreshThreads) {
+        if (apiResponses.atLeastOneSucceeded() && shouldRefreshThreads) {
             refreshFolders(
                 mailbox = mailbox,
                 messagesFoldersIds = messages.getFoldersIds(),

--- a/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
@@ -43,6 +43,7 @@ object Utils {
 
     const val NUMBER_OF_OLD_MESSAGES_TO_FETCH = 500 // Number of Messages we want to fetch when 1st opening a Folder.
     const val PAGE_SIZE = 50 // Beware: the API refuses a PAGE_SIZE bigger than 200.
+    const val MESSAGES_UIDS_SIZE = 1_000 // Beware: the API refuses a MESSAGES_UIDS_SIZE bigger than 1000.
     const val DELAY_BEFORE_FETCHING_ACTIVITIES_AGAIN = 500L
 
     const val TAG_SEPARATOR = " "

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -280,6 +280,10 @@ inline fun <reified T> ApiResponse<T>.getApiException(): Exception {
     return error?.exception ?: ApiErrorException(ApiController.json.encodeToString(this))
 }
 
+fun List<ApiResponse<*>>.atLeastOneSucceeded(): Boolean = any { it.isSuccess() }
+
+fun List<ApiResponse<*>>.allFailed(): Boolean = none { it.isSuccess() }
+
 fun String.toLongUid(folderId: String) = "${this}@${folderId}"
 
 fun String.toShortUid(): Int = substringBefore('@').toInt()


### PR DESCRIPTION
Depends on #2005

We can't send more than 1000 UIDs to the API, they will be refused.
So we batch them.