### PR TITLE
Remove Messages from Folders in MenuDrawer

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -24,7 +24,7 @@ import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.utils.extensions.copyListToRealm
-import com.infomaniak.mail.utils.extensions.flattenFolderChildren
+import com.infomaniak.mail.utils.extensions.flattenFolderChildrenAndRemoveMessages
 import com.infomaniak.mail.utils.extensions.sortFolders
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
@@ -80,7 +80,7 @@ class FolderController @Inject constructor(
 
     //region Edit data
     fun update(mailbox: Mailbox, remoteFolders: List<Folder>, realm: Realm) {
-        val remoteFoldersWithChildren = remoteFolders.flattenFolderChildren()
+        val remoteFoldersWithChildren = remoteFolders.flattenFolderChildrenAndRemoveMessages()
 
         realm.writeBlocking {
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -701,7 +701,7 @@ class RefreshController @Inject constructor(
             scope.ensureActive()
 
             it.recomputeThread(realm = this)
-            impactedThreadsUnmanaged.add(it.copyFromRealm(1u))
+            impactedThreadsUnmanaged.add(it.copyFromRealm(0u))
         }
 
         return impactedThreadsUnmanaged

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -69,7 +69,7 @@ import com.infomaniak.mail.utils.Utils.runCatchingRealm
 import com.infomaniak.mail.utils.coroutineContext
 import com.infomaniak.mail.utils.extensions.MergedContactDictionary
 import com.infomaniak.mail.utils.extensions.appContext
-import com.infomaniak.mail.utils.extensions.flattenFolderChildren
+import com.infomaniak.mail.utils.extensions.flattenFolderChildrenAndRemoveMessages
 import com.infomaniak.mail.utils.extensions.getFoldersIds
 import com.infomaniak.mail.utils.extensions.getUids
 import com.infomaniak.mail.utils.extensions.launchNoValidMailboxesActivity
@@ -158,11 +158,11 @@ class MainViewModel @Inject constructor(
     }.asLiveData(ioCoroutineContext)
 
     val defaultFoldersLive = _currentMailboxObjectId.filterNotNull().flatMapLatest {
-        folderController.getMenuDrawerDefaultFoldersAsync().map { it.list.flattenFolderChildren(dismissHiddenChildren = true) }
+        folderController.getMenuDrawerDefaultFoldersAsync().map { it.list.flattenFolderChildrenAndRemoveMessages(dismissHiddenChildren = true) }
     }.asLiveData(ioCoroutineContext)
 
     val customFoldersLive = _currentMailboxObjectId.filterNotNull().flatMapLatest {
-        folderController.getMenuDrawerCustomFoldersAsync().map { it.list.flattenFolderChildren(dismissHiddenChildren = true) }
+        folderController.getMenuDrawerCustomFoldersAsync().map { it.list.flattenFolderChildrenAndRemoveMessages(dismissHiddenChildren = true) }
     }.asLiveData(ioCoroutineContext)
 
     val currentQuotasLive = _currentMailboxObjectId.flatMapLatest {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/move/MoveViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/move/MoveViewModel.kt
@@ -30,7 +30,7 @@ import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.utils.coroutineContext
 import com.infomaniak.mail.utils.extensions.addDividerBeforeFirstCustomFolder
 import com.infomaniak.mail.utils.extensions.appContext
-import com.infomaniak.mail.utils.extensions.flattenFolderChildren
+import com.infomaniak.mail.utils.extensions.flattenFolderChildrenAndRemoveMessages
 import com.infomaniak.mail.utils.extensions.standardize
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -71,7 +71,7 @@ class MoveViewModel @Inject constructor(
             sourceFolderIdLiveData.postValue(sourceFolderId)
 
             allFolders = folderController.getMoveFolders()
-                .flattenFolderChildren()
+                .flattenFolderChildrenAndRemoveMessages()
                 .addDividerBeforeFirstCustomFolder(dividerType = Unit)
                 .also(filterResults::postValue)
         }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -42,7 +42,7 @@ import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.SearchUtils
 import com.infomaniak.mail.utils.coroutineContext
 import com.infomaniak.mail.utils.extensions.appContext
-import com.infomaniak.mail.utils.extensions.flattenFolderChildren
+import com.infomaniak.mail.utils.extensions.flattenFolderChildrenAndRemoveMessages
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.sentry.Sentry
 import kotlinx.coroutines.CoroutineDispatcher
@@ -80,7 +80,7 @@ class SearchViewModel @Inject constructor(
         private set
 
     val foldersLive = folderController.getSearchFoldersAsync()
-        .map { it.list.flattenFolderChildren() }
+        .map { it.list.flattenFolderChildrenAndRemoveMessages() }
         .asLiveData(ioCoroutineContext)
 
     private var currentFilters = mutableSetOf<ThreadFilter>()

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -323,7 +323,7 @@ fun LiveData<UiRecipients>.valueOrEmpty(): List<Recipient> = value?.recipients ?
 //endregion
 
 //region Folders
-fun List<Folder>.flattenFolderChildren(dismissHiddenChildren: Boolean = false): List<Folder> {
+fun List<Folder>.flattenFolderChildrenAndRemoveMessages(dismissHiddenChildren: Boolean = false): List<Folder> {
 
     if (isEmpty()) return this
 

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -335,7 +335,8 @@ fun List<Folder>.flattenFolderChildren(dismissHiddenChildren: Boolean = false): 
         val folder = inputList.removeFirst()
 
         val children = if (folder.isManaged()) {
-            outputList.add(folder.copyFromRealm(1u))
+            // We remove the Messages because we don't need them here. And it can be a pretty big list.
+            outputList.add(folder.copyFromRealm(1u).apply { messages.clear() })
             with(folder.children) {
                 (if (dismissHiddenChildren) query("${Folder::isHidden.name} == false") else query())
                     .sortFolders()


### PR DESCRIPTION
We don't need the Messages when displaying Folders in the MenuDrawer, so we remove them, because it can be a pretty big list causing OOMs.