### PR TITLE
Optimize `getThreads()` query when executing action on Threads/Messages

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -69,6 +69,10 @@ class ThreadController @Inject constructor(
         return getSearchThreadsQuery(mailboxContentRealm()).count().find()
     }
 
+    fun getThreads(threadsUids: List<String>): RealmResults<Thread> {
+        return getThreadsByUids(threadsUids, mailboxContentRealm())
+    }
+
     fun getThread(uid: String): Thread? {
         return getThread(uid, mailboxContentRealm())
     }
@@ -181,6 +185,10 @@ class ThreadController @Inject constructor(
     companion object {
 
         //region Queries
+        private fun getThreadsByUidsQuery(threadsUids: List<String>, realm: TypedRealm): RealmQuery<Thread> {
+            return realm.query("${Thread::uid.name} IN $0", threadsUids)
+        }
+
         private fun getThreadsQuery(messageIds: Set<String>, realm: TypedRealm): RealmQuery<Thread> {
             return realm.query("ANY ${Thread::messagesIds.name} IN $0", messageIds)
         }
@@ -236,6 +244,10 @@ class ThreadController @Inject constructor(
         //region Get data
         fun getThread(uid: String, realm: TypedRealm): Thread? {
             return getThreadQuery(uid, realm).find()
+        }
+
+        private fun getThreadsByUids(threadsUids: List<String>, realm: TypedRealm): RealmResults<Thread> {
+            return getThreadsByUidsQuery(threadsUids, realm).find()
         }
 
         fun getThreads(messageIds: Set<String>, realm: TypedRealm): RealmResults<Thread> {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -474,7 +474,7 @@ class MainViewModel @Inject constructor(
     ) = viewModelScope.launch(ioCoroutineContext) {
 
         val mailbox = currentMailbox.value!!
-        val threads = getActionThreads(threadsUids).ifEmpty { return@launch }
+        val threads = threadController.getThreads(threadsUids).ifEmpty { return@launch }
         var trashId: String? = null
         var undoResource: String? = null
         val shouldPermanentlyDelete = isPermanentDeleteFolder(getActionFolderRole(threads, message))
@@ -581,7 +581,7 @@ class MainViewModel @Inject constructor(
     ) = viewModelScope.launch(ioCoroutineContext) {
         val mailbox = currentMailbox.value!!
         val destinationFolder = folderController.getFolder(destinationFolderId)!!
-        val threads = getActionThreads(threadsUids).ifEmpty { return@launch }
+        val threads = threadController.getThreads(threadsUids).ifEmpty { return@launch }
         val message = messageUid?.let { messageController.getMessage(it)!! }
 
         val messages = sharedUtils.getMessagesToMove(threads, message)
@@ -643,7 +643,7 @@ class MainViewModel @Inject constructor(
         message: Message? = null,
     ) = viewModelScope.launch(ioCoroutineContext) {
         val mailbox = currentMailbox.value!!
-        val threads = getActionThreads(threadsUids).ifEmpty { return@launch }
+        val threads = threadController.getThreads(threadsUids).ifEmpty { return@launch }
 
         val role = getActionFolderRole(threads, message)
         val isFromArchive = role == FolderRole.ARCHIVE
@@ -690,7 +690,7 @@ class MainViewModel @Inject constructor(
         shouldRead: Boolean = true,
     ) = viewModelScope.launch(ioCoroutineContext) {
         val mailbox = currentMailbox.value!!
-        val threads = getActionThreads(threadsUids).ifEmpty { return@launch }
+        val threads = threadController.getThreads(threadsUids).ifEmpty { return@launch }
 
         val isSeen = when {
             message != null -> message.isSeen
@@ -752,7 +752,7 @@ class MainViewModel @Inject constructor(
         shouldFavorite: Boolean = true,
     ) = viewModelScope.launch(ioCoroutineContext) {
         val mailbox = currentMailbox.value!!
-        val threads = getActionThreads(threadsUids).ifEmpty { return@launch }
+        val threads = threadController.getThreads(threadsUids).ifEmpty { return@launch }
 
         val isFavorite = when {
             message != null -> message.isFavorite
@@ -812,7 +812,7 @@ class MainViewModel @Inject constructor(
         displaySnackbar: Boolean = true,
     ) = viewModelScope.launch(ioCoroutineContext) {
         val mailbox = currentMailbox.value!!
-        val threads = getActionThreads(threadsUids).ifEmpty { return@launch }
+        val threads = threadController.getThreads(threadsUids).ifEmpty { return@launch }
 
         val destinationFolderRole = if (getActionFolderRole(threads, message) == FolderRole.SPAM) {
             FolderRole.INBOX
@@ -944,8 +944,6 @@ class MainViewModel @Inject constructor(
     private fun onDownloadStop() {
         isDownloadingChanges.postValue(false)
     }
-
-    private fun getActionThreads(threadsUids: List<String>): List<Thread> = threadsUids.mapNotNull(threadController::getThread)
 
     fun getActionFolderRole(thread: Thread?): FolderRole? {
         return getActionFolderRole(thread?.let(::listOf))


### PR DESCRIPTION
We were looping in Kotlin instead of doing a simple Realm query.