### PR TITLE
Fix infinite refresh loading of Threads when switching Account/Mailbox

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -81,7 +81,7 @@ class RefreshController @Inject constructor(
         refreshThreadsJob?.cancel(ForcedCancellationException())
     }
 
-    fun clearCallbacks() {
+    private fun clearCallbacks() {
         onStart = null
         onStop = null
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -207,9 +207,8 @@ class MainViewModel @Inject constructor(
     }.asFlow()
 
     override fun onCleared() {
-        refreshController.clearCallbacks()
-        super.onCleared()
         RealmDatabase.closeOldRealms()
+        super.onCleared()
     }
 
     /**


### PR DESCRIPTION
When switching account, we were cleaning RefreshController callbacks, and by doing so we are cleaning the `onStop` callback of the currently executed RefreshController, leading to the impossibility for the RefreshController to call its `onStop` callback.