### PR TITLE
Change minimum length of search query

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -253,7 +253,7 @@ class SearchViewModel @Inject constructor(
 
     companion object {
         private val TAG: String = SearchViewModel::class.java.simpleName
-        private const val MIN_SEARCH_QUERY = 3 // The minimum value allowed for a search query
+        private const val MIN_SEARCH_QUERY = 2 // The minimum value allowed for a search query
         private const val SEARCH_DEBOUNCE_DURATION = 500L
     }
 }


### PR DESCRIPTION
On Web and iOS it's 2 so we have the same behavior. 