### PR TITLE
Execute actions right away instead of waiting for API call result

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -161,7 +161,7 @@ object RealmDatabase {
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 1L
         const val MAILBOX_INFO_SCHEMA_VERSION = 6L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 17L
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 18L
         //endregion
 
         //region Configurations names

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
@@ -149,23 +149,21 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
     //endregion
 
     //region Edit
-
-    fun updateIsFavoriteStatus(messageUids: List<String>, isFavorite: Boolean) = with(mailboxContentRealm()) {
-        writeBlocking {
-            getMessagesByUids(messageUids, this).forEach {
+    fun updateIsFavoriteStatus(messageUids: List<String>, isFavorite: Boolean) {
+        mailboxContentRealm().writeBlocking {
+            getMessagesByUids(messageUids, realm = this).forEach {
                 it.isFavorite = isFavorite
             }
         }
     }
 
-    fun updateReadStatus(messageUids: List<String>, isSeen: Boolean) = with(mailboxContentRealm()) {
-        writeBlocking {
-            getMessagesByUids(messageUids, this).forEach {
+    fun updateReadStatus(messageUids: List<String>, isSeen: Boolean) {
+        mailboxContentRealm().writeBlocking {
+            getMessagesByUids(messageUids, realm = this).forEach {
                 it.isSeen = isSeen
             }
         }
     }
-
     //endregion
 
     companion object {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
@@ -148,6 +148,26 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
     }
     //endregion
 
+    //region Edit
+
+    fun updateIsFavoriteStatus(messageUids: List<String>, isFavorite: Boolean) = with(mailboxContentRealm()) {
+        writeBlocking {
+            getMessagesByUids(messageUids, this).forEach {
+                it.isFavorite = isFavorite
+            }
+        }
+    }
+
+    fun updateReadStatus(messageUids: List<String>, isSeen: Boolean) = with(mailboxContentRealm()) {
+        writeBlocking {
+            getMessagesByUids(messageUids, this).forEach {
+                it.isSeen = isSeen
+            }
+        }
+    }
+
+    //endregion
+
     companion object {
         private val isNotDraft = "${Message::isDraft.name} == false"
         private val isNotScheduled = "${Message::isScheduled.name} == false"

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
@@ -148,24 +148,6 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
     }
     //endregion
 
-    //region Edit
-    fun updateIsFavoriteStatus(messageUids: List<String>, isFavorite: Boolean) {
-        mailboxContentRealm().writeBlocking {
-            getMessagesByUids(messageUids, realm = this).forEach {
-                it.isFavorite = isFavorite
-            }
-        }
-    }
-
-    fun updateReadStatus(messageUids: List<String>, isSeen: Boolean) {
-        mailboxContentRealm().writeBlocking {
-            getMessagesByUids(messageUids, realm = this).forEach {
-                it.isSeen = isSeen
-            }
-        }
-    }
-    //endregion
-
     companion object {
         private val isNotDraft = "${Message::isDraft.name} == false"
         private val isNotScheduled = "${Message::isScheduled.name} == false"
@@ -232,6 +214,18 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
 
         fun deleteSearchMessages(realm: MutableRealm) = with(realm) {
             delete(query<Message>("${Message::isFromSearch.name} == true").find())
+        }
+
+        fun updateFavoriteStatus(messageUids: List<String>, isFavorite: Boolean, realm: MutableRealm) {
+            getMessagesByUids(messageUids, realm).forEach {
+                it.isFavorite = isFavorite
+            }
+        }
+
+        fun updateSeenStatus(messageUids: List<String>, isSeen: Boolean, realm: MutableRealm) {
+            getMessagesByUids(messageUids, realm).forEach {
+                it.isSeen = isSeen
+            }
         }
         //endregion
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -74,7 +74,7 @@ class RefreshController @Inject constructor(
     private lateinit var realm: Realm
     private var okHttpClient: OkHttpClient? = null
     private var onStart: (() -> Unit)? = null
-    private var onStop: (() -> Unit)? = null
+    private var onStop: ((List<String>) -> Unit)? = null
     private var endOfMessagesReached: Boolean = false
 
     //region Fetch Messages
@@ -110,7 +110,7 @@ class RefreshController @Inject constructor(
             ThreadController.deleteEmptyThreadsInFolder(folder.id, realm)
 
             if (threads != null) {
-                onStop?.invoke()
+                onStop?.invoke(emptyList())
                 SentryLog.d("API", "End of refreshing threads with mode: $refreshMode | (${folder.displayForSentry()})")
             }
         }
@@ -169,7 +169,7 @@ class RefreshController @Inject constructor(
             REFRESH_FOLDER_WITH_ROLE -> refreshWithRoleConsideration(scope)
             REFRESH_FOLDER -> {
                 refresh(scope, initialFolder).also {
-                    onStop?.invoke()
+                    onStop?.invoke(emptyList())
                     clearCallbacks()
                 }
             }
@@ -183,7 +183,7 @@ class RefreshController @Inject constructor(
     private suspend fun Realm.refreshWithRoleConsideration(scope: CoroutineScope): Set<Thread> {
 
         val impactedThreads = refresh(scope, initialFolder)
-        onStop?.invoke()
+        onStop?.invoke(emptyList())
         clearCallbacks()
 
         when (initialFolder.role) {
@@ -710,7 +710,7 @@ class RefreshController @Inject constructor(
         if (throwable is ApiErrorException) throwable.handleOtherApiErrors()
 
         // This is the end. The `onStop` callback should be called before we are gone.
-        onStop?.invoke()
+        onStop?.invoke(emptyList())
         clearCallbacks()
     }
 
@@ -800,7 +800,7 @@ class RefreshController @Inject constructor(
 
     data class RefreshCallbacks(
         val onStart: (() -> Unit),
-        val onStop: (() -> Unit),
+        val onStop: ((List<String>) -> Unit),
     )
 
     companion object {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -130,10 +130,10 @@ class RefreshController @Inject constructor(
         this.realm = realm
         this.okHttpClient = okHttpClient
         callbacks?.let {
-            onStart = it.onStart
-            onStop = it.onStop
+            this.onStart = it.onStart
+            this.onStop = it.onStop
         }
-        endOfMessagesReached = false
+        this.endOfMessagesReached = false
     }
 
     private suspend fun refreshWithRunCatching(job: Job): Pair<Set<Thread>?, Throwable?> = runCatching {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -182,12 +182,10 @@ class ThreadController @Inject constructor(
         }
     }
 
-    fun updateIsMovedOutLocally(threadUids: List<String>, hasBeenMovedOut: Boolean) {
+    fun updateIsLocallyMovedOutStatus(threadUids: List<String>, hasBeenMovedOut: Boolean) {
         mailboxContentRealm().writeBlocking {
             threadUids.forEach {
-                getThread(it, this)?.apply {
-                    this.isMovedOutLocally = hasBeenMovedOut
-                }
+                getThread(it, realm = this)?.isLocallyMovedOut = hasBeenMovedOut
             }
         }
     }
@@ -224,8 +222,8 @@ class ThreadController @Inject constructor(
         private fun getThreadsQuery(folder: Folder, filter: ThreadFilter = ThreadFilter.ALL): RealmQuery<Thread> {
 
             val notFromSearch = "${Thread::isFromSearch.name} == false"
-            val isMovedOutLocally = " AND ${Thread::isMovedOutLocally.name} == false"
-            val realmQuery = folder.threads.query(notFromSearch + isMovedOutLocally).sort(Thread::date.name, Sort.DESCENDING)
+            val notLocallyMovedOut = " AND ${Thread::isLocallyMovedOut.name} == false"
+            val realmQuery = folder.threads.query(notFromSearch + notLocallyMovedOut).sort(Thread::date.name, Sort.DESCENDING)
 
             return if (filter == ThreadFilter.ALL) {
                 realmQuery

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -181,26 +181,6 @@ class ThreadController @Inject constructor(
         }
     }
 
-    fun updateFavoriteStatus(threadUids: List<String>, isFavorite: Boolean) {
-        mailboxContentRealm().writeBlocking {
-            threadUids.forEach {
-                getThread(it, this)?.apply {
-                    this.isFavorite = isFavorite
-                }
-            }
-        }
-    }
-
-    fun updateReadStatus(threadUids: List<String>) {
-        mailboxContentRealm().writeBlocking {
-            threadUids.forEach {
-                getThread(it, this)?.apply {
-                    this.unseenMessagesCount = messages.count { message -> !message.isSeen }
-                }
-            }
-        }
-    }
-
     fun updateIsMovedOutLocally(threadUids: List<String>, hasBeenMovedOut: Boolean) {
         mailboxContentRealm().writeBlocking {
             threadUids.forEach {
@@ -438,6 +418,18 @@ class ThreadController @Inject constructor(
                         it?.hasAttachable = hasAttachableInThread
                     }
                 }
+            }
+        }
+
+        fun updateFavoriteStatus(threadUids: List<String>, isFavorite: Boolean, realm: MutableRealm) {
+            threadUids.forEach {
+                getThread(it, realm)?.isFavorite = isFavorite
+            }
+        }
+
+        fun updateSeenStatus(threadUids: List<String>, isSeen: Boolean, realm: MutableRealm) {
+            threadUids.forEach {
+                getThread(it, realm)?.unseenMessagesCount = if (isSeen) 0 else 1
             }
         }
         //endregion

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -91,6 +91,9 @@ class Thread : RealmObject {
     var isFromSearch: Boolean = false
     @Transient
     var hasAttachable: Boolean = false
+    //Has been  moved (deleted, moved) but API called has not been done yet. Used to filter locally the list of threads
+    @Transient
+    var isMovedOutLocally: Boolean = false
     //endregion
 
     private val _folders by backlinks(Folder::threads)

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -91,7 +91,7 @@ class Thread : RealmObject {
     var isFromSearch: Boolean = false
     @Transient
     var hasAttachable: Boolean = false
-    //Has been  moved (deleted, moved) but API called has not been done yet. Used to filter locally the list of threads
+    // Has been moved (archived, spammed, deleted, moved) but API call hasn't been done yet. Used to filter locally the Threads' list.
     @Transient
     var isMovedOutLocally: Boolean = false
     //endregion

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -93,7 +93,7 @@ class Thread : RealmObject {
     var hasAttachable: Boolean = false
     // Has been moved (archived, spammed, deleted, moved) but API call hasn't been done yet. Used to filter locally the Threads' list.
     @Transient
-    var isMovedOutLocally: Boolean = false
+    var isLocallyMovedOut: Boolean = false
     //endregion
 
     private val _folders by backlinks(Folder::threads)

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -91,7 +91,8 @@ class Thread : RealmObject {
     var isFromSearch: Boolean = false
     @Transient
     var hasAttachable: Boolean = false
-    // Has been moved (archived, spammed, deleted, moved) but API call hasn't been done yet. Used to filter locally the Threads' list.
+    // Has been moved (archived, spammed, deleted, moved) but API call hasn't been done yet.
+    // It's only used to filter locally the Threads' list.
     @Transient
     var isLocallyMovedOut: Boolean = false
     //endregion

--- a/app/src/main/java/com/infomaniak/mail/receivers/NotificationActionsReceiver.kt
+++ b/app/src/main/java/com/infomaniak/mail/receivers/NotificationActionsReceiver.kt
@@ -112,7 +112,7 @@ class NotificationActionsReceiver : BroadcastReceiver() {
             else -> null
         } ?: return
 
-        return executeAction(context, folderRole, undoNotificationTitle, matomoValue, payload)
+        executeAction(context, folderRole, undoNotificationTitle, matomoValue, payload)
     }
 
     private fun executeUndoAction(payload: NotificationPayload) {

--- a/app/src/main/java/com/infomaniak/mail/receivers/NotificationActionsReceiver.kt
+++ b/app/src/main/java/com/infomaniak/mail/receivers/NotificationActionsReceiver.kt
@@ -91,8 +91,7 @@ class NotificationActionsReceiver : BroadcastReceiver() {
         }
     }
 
-    private fun handleNotificationIntent(context: Context, payload: NotificationPayload, action: String) = with(payload) {
-
+    private fun handleNotificationIntent(context: Context, payload: NotificationPayload, action: String) {
         // Undo action
         if (action == UNDO_ACTION) {
             context.trackNotificationActionEvent("cancelClicked")
@@ -113,7 +112,7 @@ class NotificationActionsReceiver : BroadcastReceiver() {
             else -> null
         } ?: return
 
-        executeAction(context, folderRole, undoNotificationTitle, matomoValue, payload)
+        return executeAction(context, folderRole, undoNotificationTitle, matomoValue, payload)
     }
 
     private fun executeUndoAction(payload: NotificationPayload) {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -691,7 +691,7 @@ class MainViewModel @Inject constructor(
                 mailbox = mailbox,
                 messagesFoldersIds = messagesFoldersIds,
                 destinationFolderId = destinationFolder.id,
-                callbacks = RefreshCallbacks(::onDownloadStart, ::onDownloadStop),
+                callbacks = RefreshCallbacks(onStart = ::onDownloadStart, onStop = { onDownloadStop(threadsUids) }),
             )
         }
 
@@ -887,7 +887,7 @@ class MainViewModel @Inject constructor(
                 mailbox = mailbox,
                 messagesFoldersIds = messages.getFoldersIds(exception = destinationFolder.id),
                 destinationFolderId = destinationFolder.id,
-                callbacks = RefreshCallbacks(::onDownloadStart, ::onDownloadStop),
+                callbacks = RefreshCallbacks(onStart = ::onDownloadStart, onStop = { onDownloadStop(threadsUids) }),
             )
         } else {
             threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = false)

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -503,20 +503,24 @@ class MainViewModel @Inject constructor(
 
         deleteThreadOrMessageTrigger.postValue(Unit)
 
-        if (apiResponses.atLeastOneSucceeded()) {
-            if (shouldAutoAdvance(message, threadsUids)) autoAdvanceThreadsUids.postValue(threadsUids)
+        when {
+            apiResponses.atLeastOneSucceeded() -> {
+                if (shouldAutoAdvance(message, threadsUids)) autoAdvanceThreadsUids.postValue(threadsUids)
 
-            refreshFoldersAsync(
-                mailbox = mailbox,
-                messagesFoldersIds = messages.getFoldersIds(exception = trashId),
-                destinationFolderId = trashId,
-                callbacks = RefreshCallbacks(::onDownloadStart, ::onDownloadStop),
-            )
-        } else if (!apiResponses.atLeastOneSucceeded()) {
-            threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = false)
-        } else if (isSwipe) {
-            // We need to make the swiped Thread come back, so we reassign the LiveData with Realm values
-            reassignCurrentThreadsLive()
+                refreshFoldersAsync(
+                    mailbox = mailbox,
+                    messagesFoldersIds = messages.getFoldersIds(exception = trashId),
+                    destinationFolderId = trashId,
+                    callbacks = RefreshCallbacks(::onDownloadStart, ::onDownloadStop),
+                )
+            }
+            !apiResponses.atLeastOneSucceeded() -> {
+                threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = false)
+            }
+            isSwipe -> {
+                // We need to make the swiped Thread come back, so we reassign the LiveData with Realm values
+                reassignCurrentThreadsLive()
+            }
         }
 
         val undoDestinationId = message?.folderId ?: threads.first().folderId

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -510,7 +510,7 @@ class MainViewModel @Inject constructor(
                 mailbox = mailbox,
                 messagesFoldersIds = messages.getFoldersIds(exception = trashId),
                 destinationFolderId = trashId,
-                callbacks = RefreshCallbacks(onStart = { onDownloadStart() }, onStop = { onDownloadStop(threadsUids) }),
+                callbacks = RefreshCallbacks(onStart = ::onDownloadStart, onStop = { onDownloadStop(threadsUids) }),
             )
         } else if (isSwipe) {
             // We need to make the swiped Thread come back, so we reassign the LiveData with Realm values
@@ -612,7 +612,7 @@ class MainViewModel @Inject constructor(
                 mailbox = mailbox,
                 messagesFoldersIds = messages.getFoldersIds(exception = destinationFolder.id),
                 destinationFolderId = destinationFolder.id,
-                callbacks = RefreshCallbacks(onStart = { onDownloadStart() }, onStop = { onDownloadStop(threadsUids) }),
+                callbacks = RefreshCallbacks(onStart = ::onDownloadStart, onStop = { onDownloadStop(threadsUids) }),
             )
         }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -810,11 +810,9 @@ class MainViewModel @Inject constructor(
         }
         val uids = messages.getUids()
 
-        /*threadController.updateFavoriteStatus(threadsUids, !isFavorite)
+        threadController.updateFavoriteStatus(threadsUids, !isFavorite)
         messageController.updateIsFavoriteStatus(uids, !isFavorite)
 
-        val isSuccess = if (isFavorite) {
-            ApiRepository.removeFromFavorites(mailbox.uuid, uids).isSuccess()*/
         val apiResponses = if (isFavorite) {
             ApiRepository.removeFromFavorites(mailbox.uuid, uids)
         } else {
@@ -874,6 +872,8 @@ class MainViewModel @Inject constructor(
 
         val messages = getMessagesToSpamOrHam(threads, message)
 
+        threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = true)
+
         val apiResponses = ApiRepository.moveMessages(mailbox.uuid, messages.getUids(), destinationFolder.id)
 
         if (apiResponses.atLeastOneSucceeded()) {
@@ -883,6 +883,8 @@ class MainViewModel @Inject constructor(
                 destinationFolderId = destinationFolder.id,
                 callbacks = RefreshCallbacks(::onDownloadStart, ::onDownloadStop),
             )
+        } else {
+            threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = false)
         }
 
         if (displaySnackbar) showMoveSnackbar(threads, message, messages, apiResponses, destinationFolder)

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -490,7 +490,7 @@ class MainViewModel @Inject constructor(
         val messages = getMessagesToDelete(threads, message)
         val uids = messages.getUids()
 
-        threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = true)
+        threadController.updateIsLocallyMovedOutStatus(threadsUids, hasBeenMovedOut = true)
 
         val apiResponses = if (shouldPermanentlyDelete) {
             ApiRepository.deleteMessages(mailbox.uuid, uids)
@@ -517,7 +517,7 @@ class MainViewModel @Inject constructor(
             reassignCurrentThreadsLive()
         }
 
-        threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = false)
+        threadController.updateIsLocallyMovedOutStatus(threadsUids, hasBeenMovedOut = false)
 
         val undoDestinationId = message?.folderId ?: threads.first().folderId
         val undoFoldersIds = (messages.getFoldersIds(exception = undoDestinationId) + trashId).filterNotNull()
@@ -601,7 +601,7 @@ class MainViewModel @Inject constructor(
 
         val messages = sharedUtils.getMessagesToMove(threads, message)
 
-        threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = true)
+        threadController.updateIsLocallyMovedOutStatus(threadsUids, hasBeenMovedOut = true)
 
         val apiResponses = ApiRepository.moveMessages(mailbox.uuid, messages.getUids(), destinationFolder.id)
 
@@ -616,7 +616,7 @@ class MainViewModel @Inject constructor(
             )
         }
 
-        threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = false)
+        threadController.updateIsLocallyMovedOutStatus(threadsUids, hasBeenMovedOut = false)
 
         showMoveSnackbar(threads, message, messages, apiResponses, destinationFolder)
     }
@@ -746,8 +746,8 @@ class MainViewModel @Inject constructor(
     ) = viewModelScope.launch(ioCoroutineContext) {
 
         val messages = getMessagesToMarkAsUnseen(threads, message)
-        val messagesUids = messages.map { it.uid }
         val threadsUids = threads.map { it.uid }
+        val messagesUids = messages.map { it.uid }
 
         updateSeenStatus(threadsUids, messagesUids, isSeen = false)
 
@@ -878,7 +878,7 @@ class MainViewModel @Inject constructor(
 
         val messages = getMessagesToSpamOrHam(threads, message)
 
-        threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = true)
+        threadController.updateIsLocallyMovedOutStatus(threadsUids, hasBeenMovedOut = true)
 
         val apiResponses = ApiRepository.moveMessages(mailbox.uuid, messages.getUids(), destinationFolder.id)
 
@@ -890,7 +890,7 @@ class MainViewModel @Inject constructor(
                 callbacks = RefreshCallbacks(onStart = ::onDownloadStart, onStop = { onDownloadStop(threadsUids) }),
             )
         } else {
-            threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = false)
+            threadController.updateIsLocallyMovedOutStatus(threadsUids, hasBeenMovedOut = false)
         }
 
         if (displaySnackbar) showMoveSnackbar(threads, message, messages, apiResponses, destinationFolder)
@@ -1044,7 +1044,7 @@ class MainViewModel @Inject constructor(
     }
 
     private fun onDownloadStop(threadsUids: List<String>) {
-        threadController.updateIsMovedOutLocally(threadsUids, hasBeenMovedOut = false)
+        threadController.updateIsLocallyMovedOutStatus(threadsUids, hasBeenMovedOut = false)
         isDownloadingChanges.postValue(false)
     }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -77,8 +77,8 @@ class SharedUtils @Inject constructor(
             else -> messageController.getMessageAndDuplicates(threads.first(), message)
         }
 
-        val messagesUids = messages.map { it.uid }
         val threadsUids = threads.map { it.uid }
+        val messagesUids = messages.map { it.uid }
 
         updateSeenStatus(threadsUids, messagesUids, isSeen = true)
 


### PR DESCRIPTION
- Marked as read/unread/favorite/unfavorite
  - Update locally immediately
  - Make WS call
  - If there's an error, reset to previous value
- Move/Delete
  - Create a local variable in Realm (isMovedOutLocally) and if it is being moved, set this value to true without waiting for the API to return. When displaying the ThreadList, filter on isMovedOutLocally == false
  - If there's an error, return as before