### PR TITLE
When expanding a long Thread, display Messages by batches so it doesn't freeze the UI anymore

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -596,7 +596,7 @@ class RefreshController @Inject constructor(
         // Add Sentry log and leave if the Message already exists
         if (existingMessage != null && !existingMessage.isOrphan()) {
             SentryLog.i(
-                TAG,
+                "Realm",
                 "Already existing message in folder ${folder.displayForSentry()} | threadMode = ${localSettings.threadMode}",
             )
             return true
@@ -817,8 +817,4 @@ class RefreshController @Inject constructor(
         val onStart: (() -> Unit),
         val onStop: (() -> Unit),
     )
-
-    companion object {
-        private val TAG = RefreshController::class.java.simpleName
-    }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -147,6 +147,7 @@ class ThreadFragment : Fragment() {
         observeLightThemeToggle()
         observeThreadLive()
         observeMessagesLive()
+        observeBatchedMessages()
         observeFailedMessages()
         observeQuickActionBarClicks()
         observeSubjectUpdateTriggers()
@@ -428,11 +429,20 @@ class ThreadFragment : Fragment() {
                 return@observe
             }
 
-            threadAdapter.submitList(items)
+            if (items.count() > ThreadViewModel.SUPER_COLLAPSED_BLOCK_MINIMUM_MESSAGES_LIMIT) {
+                displayBatchedMessages(items)
+            } else {
+                threadAdapter.submitList(items)
+            }
+
             if (messagesToFetch.isNotEmpty()) fetchMessagesHeavyData(messagesToFetch)
 
             fetchCalendarEvents(items)
         }
+    }
+
+    private fun observeBatchedMessages() {
+        threadViewModel.batchedMessages.observe(viewLifecycleOwner, threadAdapter::submitList)
     }
 
     private fun observeFailedMessages() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -429,7 +429,7 @@ class ThreadFragment : Fragment() {
                 return@observe
             }
 
-            if (items.count() > ThreadViewModel.SUPER_COLLAPSED_BLOCK_MINIMUM_MESSAGES_LIMIT) {
+            if (threadState.hasSuperCollapsedBlockBeenClicked) {
                 displayBatchedMessages(items)
             } else {
                 threadAdapter.submitList(items)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -259,7 +259,7 @@ class ThreadViewModel @Inject constructor(
             batchedMessages.postValue(ArrayList(output))
 
             if (batch.size < batchSize) return
-            delay(50L)
+            delay(DELAY_BETWEEN_EACH_BATCHED_MESSAGES)
             sendBatchesRecursively(input.subList(batchSize, input.size), output)
         }
 
@@ -471,5 +471,6 @@ class ThreadViewModel @Inject constructor(
     companion object {
         private const val SUPER_COLLAPSED_BLOCK_MINIMUM_MESSAGES_LIMIT = 5
         private const val SUPER_COLLAPSED_BLOCK_FIRST_INDEX_LIMIT = 3
+        private const val DELAY_BETWEEN_EACH_BATCHED_MESSAGES = 50L
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -469,7 +469,7 @@ class ThreadViewModel @Inject constructor(
     }
 
     companion object {
-        const val SUPER_COLLAPSED_BLOCK_MINIMUM_MESSAGES_LIMIT = 5
+        private const val SUPER_COLLAPSED_BLOCK_MINIMUM_MESSAGES_LIMIT = 5
         private const val SUPER_COLLAPSED_BLOCK_FIRST_INDEX_LIMIT = 3
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -253,11 +253,13 @@ class ThreadViewModel @Inject constructor(
 
             val batch = input.take(batchSize)
             output.addAll(batch)
-            batchedMessages.postValue(output.toMutableList())
+
+            // We need to post a different list each time, because the `submitList` function in AsyncListDiffer
+            // won't trigger if we send the same list object (https://stackoverflow.com/questions/49726385).
+            batchedMessages.postValue(ArrayList(output))
+
             if (batch.size < batchSize) return
-
             delay(50L)
-
             sendBatchesRecursively(input.subList(batchSize, input.size), output)
         }
 


### PR DESCRIPTION
In the situation of a Thread long enough so we display the SuperCollapsedBlock :
- When clicking on the SCB, we have to display all remaining Messages.
- Instead of displaying all of them in one go, we loop them and send them 1 by 1 every few milliseconds.