### PR TITLE
Fix animated toolbar crash

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/login/IntroFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/login/IntroFragment.kt
@@ -40,7 +40,7 @@ import com.infomaniak.mail.data.LocalSettings.AccentColor
 import com.infomaniak.mail.databinding.FragmentIntroBinding
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.ui.login.IlluColors.changeIllustrationColors
-import com.infomaniak.mail.utils.UiUtils
+import com.infomaniak.mail.utils.UiUtils.animateColorChange
 import com.infomaniak.mail.utils.extensions.enumValueFrom
 import com.infomaniak.mail.utils.extensions.repeatFrame
 import dagger.hilt.android.AndroidEntryPoint
@@ -170,7 +170,7 @@ class IntroFragment : Fragment() {
         val newColor = newAccentColor.getOnboardingSecondaryBackground(context)
         val oldColor = oldAccentColor.getOnboardingSecondaryBackground(context)
 
-        colorAnimator = UiUtils.animateColorChange(oldColor, newColor) { color ->
+        colorAnimator = animateColorChange(oldColor, newColor) { color ->
             waveBackground.imageTintList = ColorStateList.valueOf(color)
         }
     }
@@ -183,7 +183,7 @@ class IntroFragment : Fragment() {
         val newPrimary = newAccentColor.getPrimary(context)
         val oldPrimary = oldAccentColor.getPrimary(context)
 
-        UiUtils.animateColorChange(oldPrimary, newPrimary) { color ->
+        animateColorChange(oldPrimary, newPrimary) { color ->
             pinkBlueTabLayout.setSelectedTabIndicatorColor(color)
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/login/LoginFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/login/LoginFragment.kt
@@ -38,7 +38,7 @@ import com.infomaniak.mail.databinding.FragmentLoginBinding
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.di.MainDispatcher
 import com.infomaniak.mail.utils.LoginUtils
-import com.infomaniak.mail.utils.UiUtils
+import com.infomaniak.mail.utils.UiUtils.animateColorChange
 import com.infomaniak.mail.utils.extensions.removeOverScrollForApiBelow31
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineDispatcher
@@ -152,7 +152,7 @@ class LoginFragment : Fragment() {
         val oldPrimary = oldAccentColor.getPrimary(context)
         val ripple = newAccentColor.getRipple(context)
 
-        UiUtils.animateColorChange(oldPrimary, newPrimary) { color ->
+        animateColorChange(oldPrimary, newPrimary) { color ->
             dotsIndicator.selectedDotColor = color
             connectButton.setBackgroundColor(color)
             nextButton.backgroundTintList = ColorStateList.valueOf(color)
@@ -165,7 +165,7 @@ class LoginFragment : Fragment() {
         val newOnPrimary = newAccentColor.getOnPrimary(context)
         val oldOnPrimary = oldAccentColor.getOnPrimary(context)
 
-        UiUtils.animateColorChange(oldOnPrimary, newOnPrimary) { color ->
+        animateColorChange(oldOnPrimary, newOnPrimary) { color ->
             connectButton.setTextColor(color)
             nextButton.imageTintList = ColorStateList.valueOf(color)
         }
@@ -175,7 +175,7 @@ class LoginFragment : Fragment() {
         val newSecondaryBackground = newAccentColor.getOnboardingSecondaryBackground(requireContext())
         val oldSecondaryBackground = oldAccentColor.getOnboardingSecondaryBackground(requireContext())
 
-        UiUtils.animateColorChange(oldSecondaryBackground, newSecondaryBackground) { color ->
+        animateColorChange(oldSecondaryBackground, newSecondaryBackground) { color ->
             requireActivity().window.statusBarColor = color
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/utils/UiUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/UiUtils.kt
@@ -33,12 +33,16 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.toColor
 import androidx.core.graphics.toColorInt
 import androidx.core.view.isGone
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.correspondent.Correspondent
 import com.infomaniak.mail.utils.extensions.updateNavigationBarColor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 object UiUtils {
 
@@ -143,7 +147,7 @@ object UiUtils {
         return isSingleField
     }
 
-    fun animateColorChange(
+    fun Fragment.animateColorChange(
         @ColorInt oldColor: Int,
         @ColorInt newColor: Int,
         duration: Long = 150L,
@@ -153,7 +157,9 @@ object UiUtils {
         return if (animate) {
             ValueAnimator.ofObject(ArgbEvaluator(), oldColor, newColor).apply {
                 setDuration(duration)
-                addUpdateListener { animator -> applyColor(animator.animatedValue as Int) }
+                addUpdateListener { animator ->
+                    lifecycleScope.launch(Dispatchers.Main) { applyColor(animator.animatedValue as Int) }
+                }
                 start()
             }
         } else {

--- a/app/src/main/java/com/infomaniak/mail/utils/UiUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/UiUtils.kt
@@ -158,7 +158,7 @@ object UiUtils {
             ValueAnimator.ofObject(ArgbEvaluator(), oldColor, newColor).apply {
                 setDuration(duration)
                 addUpdateListener { animator ->
-                    lifecycleScope.launch(Dispatchers.Main) { applyColor(animator.animatedValue as Int) }
+                    viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) { applyColor(animator.animatedValue as Int) }
                 }
                 start()
             }

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -97,6 +97,7 @@ import com.infomaniak.mail.ui.main.thread.ThreadFragment.HeaderState
 import com.infomaniak.mail.ui.newMessage.NewMessageViewModel.UiRecipients
 import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
+import com.infomaniak.mail.utils.UiUtils.animateColorChange
 import com.infomaniak.mail.utils.Utils
 import com.infomaniak.mail.utils.Utils.TAG_SEPARATOR
 import com.infomaniak.mail.utils.Utils.isPermanentDeleteFolder
@@ -488,7 +489,7 @@ fun Fragment.changeToolbarColorOnScroll(
         if (newColor == oldColor) return@setOnScrollChangeListener
 
         valueAnimator?.cancel()
-        valueAnimator = UiUtils.animateColorChange(oldColor, newColor, animate = true) { color ->
+        valueAnimator = animateColorChange(oldColor, newColor, animate = true) { color ->
             oldColor = color
             toolbar.setBackgroundColor(color)
             if (shouldUpdateStatusBar()) requireActivity().window.statusBarColor = color

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -95,13 +95,15 @@ import com.infomaniak.mail.ui.main.thread.SubjectFormatter.EllipsizeConfiguratio
 import com.infomaniak.mail.ui.main.thread.SubjectFormatter.TagColor
 import com.infomaniak.mail.ui.main.thread.ThreadFragment.HeaderState
 import com.infomaniak.mail.ui.newMessage.NewMessageViewModel.UiRecipients
-import com.infomaniak.mail.utils.*
+import com.infomaniak.mail.utils.AccountUtils
+import com.infomaniak.mail.utils.ApiErrorException
 import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
 import com.infomaniak.mail.utils.UiUtils.animateColorChange
 import com.infomaniak.mail.utils.Utils
 import com.infomaniak.mail.utils.Utils.TAG_SEPARATOR
 import com.infomaniak.mail.utils.Utils.isPermanentDeleteFolder
 import com.infomaniak.mail.utils.Utils.kSyncAccountUri
+import com.infomaniak.mail.utils.WebViewUtils
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
 import io.realm.kotlin.UpdatePolicy
@@ -472,11 +474,7 @@ fun Fragment.changeToolbarColorOnScroll(
     var headerColorState = HeaderState.LOWERED
 
     viewLifecycleOwner.lifecycle.addObserver(
-        object : LifecycleEventObserver {
-            override fun onStateChanged(source: LifecycleOwner, event: Event) {
-                if (event == Event.ON_DESTROY) valueAnimator?.cancel()
-            }
-        },
+        LifecycleEventObserver { _, event -> if (event == Event.ON_DESTROY) valueAnimator?.cancel() },
     )
 
     nestedScrollView.setOnScrollChangeListener { view, _, _, _, _ ->


### PR DESCRIPTION
addUpdateListener being java code sometimes makes it so the thread of the callback is not the main thread anymore which prevents us from modifying the UI and crashes the app. This makes sure we are on the main thread when calling the callback that will apply the colors and handle UI in general