### PR TITLE
Delete draft that cannot ever be sent because of corrupted attachments

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/DraftController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/DraftController.kt
@@ -65,6 +65,12 @@ class DraftController @Inject constructor(
         val block: (MutableRealm) -> Unit = { getDraft(localUuid, realm = it)?.let(onUpdate) }
         realm?.let(block) ?: mailboxContentRealm().writeBlocking(block)
     }
+
+    fun deleteDraft(draft: Draft) {
+        mailboxContentRealm().writeBlocking {
+            delete(getDraftQuery(Draft::localUuid.name, draft.localUuid, realm = this))
+        }
+    }
     //endregion
 
     //region Open Draft

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -293,6 +293,10 @@ class DraftsActionsWorker @AssistedInject constructor(
                 SentryLevel.ERROR,
             )
 
+            // Remove the draft if it's corrupted instead of sending a sentry every time the worker starts again
+            draftController.deleteDraft(draft)
+            SentryLog.i("CorruptedAttachment", "Remove draft from realm due to corrupted attachment")
+
             return DraftActionResult(
                 realmActionOnDraft = null,
                 scheduledDate = null,

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -293,7 +293,7 @@ class DraftsActionsWorker @AssistedInject constructor(
                 SentryLevel.ERROR,
             )
 
-            // Remove the draft if it's corrupted instead of sending a sentry every time the worker starts again
+            // Remove the Draft if it's corrupted instead of sending a Sentry every time the worker starts again
             draftController.deleteDraft(draft)
             SentryLog.i("CorruptedAttachment", "Remove draft from realm due to corrupted attachment")
 


### PR DESCRIPTION
Most of the sentry issues we receive regarding corrupted attachments come from drafts stored in DB that are retried everytime the worker is started. This bug was caused by the UploadStatus crash inside addDraftBreadcrumbs() for certain. I suspect that there might remain other reasons for the corrupted attachment bug because even with the UploadStatus' runCatching() I did reproduce the corrupted attachement bug once. Also the issue did exist before the addDraftBreadcrumbs() addition and hasn't yet been fixed.

The plan of this PR is to remove the drafts that will never be processed so they stop spamming Sentry. Once this goes live we can see the errors where the attachement is corrupted for another reason than UploadStatus and fix this as well