### PR TITLE
Fix using backspace to delete recipient on API 34+

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/BackspaceAwareChip.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/BackspaceAwareChip.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.ui.newMessage
 
 import android.content.Context
+import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.KeyEvent
 import com.google.android.material.chip.Chip
@@ -31,6 +32,15 @@ class BackspaceAwareChip @JvmOverloads constructor(
 
     init {
         isFocusableInTouchMode = true
+    }
+
+    override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
+        if (isInTouchMode && focused) {
+            performClick()
+            clearFocus()
+            return
+        }
+        super.onFocusChanged(focused, direction, previouslyFocusedRect)
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/BackspaceAwareChip.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/BackspaceAwareChip.kt
@@ -29,6 +29,10 @@ class BackspaceAwareChip @JvmOverloads constructor(
 
     private var onBackspace: () -> Unit = {}
 
+    init {
+        isFocusableInTouchMode = true
+    }
+
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
         if (keyCode == KeyEvent.KEYCODE_DEL) onBackspace()
         return super.onKeyDown(keyCode, event)

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/BackspaceAwareChip.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/BackspaceAwareChip.kt
@@ -30,10 +30,6 @@ class BackspaceAwareChip @JvmOverloads constructor(
 
     private var onBackspace: () -> Unit = {}
 
-    init {
-        isFocusableInTouchMode = true
-    }
-
     override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
         if (isInTouchMode && focused) {
             performClick()

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/BackspaceAwareChip.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/BackspaceAwareChip.kt
@@ -34,9 +34,9 @@ class BackspaceAwareChip @JvmOverloads constructor(
         if (isInTouchMode && focused) {
             performClick()
             clearFocus()
-            return
+        } else {
+            super.onFocusChanged(focused, direction, previouslyFocusedRect)
         }
-        super.onFocusChanged(focused, direction, previouslyFocusedRect)
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {

--- a/app/src/main/res/layout/chip_contact.xml
+++ b/app/src/main/res/layout/chip_contact.xml
@@ -23,5 +23,6 @@
     android:layout_height="wrap_content"
     android:layout_marginHorizontal="2dp"
     android:ellipsize="end"
+    android:focusableInTouchMode="true"
     app:chipMinTouchTargetSize="44dp"
     tools:text="@tools:sample/full_names" />


### PR DESCRIPTION
Delete recipient backspace wasn't working anymore from API 34, this PR fix it.