### PR TITLE
Revert "Prioritize api contacts avatar over phone contacts avatar"

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/ContactUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ContactUtils.kt
@@ -89,8 +89,8 @@ object ContactUtils {
                 val key = Recipient().initLocalValues(email, apiContact.name)
                 val contactAvatar = apiContact.avatar?.let { avatar -> ApiRoutes.resource(avatar) }
                 if (phoneMergedContacts.contains(key)) { // If we have already encountered this user
-                    if (contactAvatar != null) { // Only replace the avatar if we have an api avatar to replace it with
-                        phoneMergedContacts[key]?.avatar = contactAvatar // Give priority to the api avatar
+                    if (phoneMergedContacts[key]?.avatar == null) { // Only replace the avatar if we didn't have any before
+                        phoneMergedContacts[key]?.avatar = contactAvatar
                     }
                 } else { // If we haven't yet encountered this user, add him
                     phoneMergedContacts[key] = MergedContact().initLocalValues(email, apiContact.name, contactAvatar)


### PR DESCRIPTION
This reverts commit 6af361f05efaf8973a80b23dad2ce3923b1a0576.

The task wasn't to do this but to change the order in which contacts are ordered when searching for contacts when writing an email