### PR TITLE
Set avatar background color to white so transparent BIMIs are displayed correctly

### DIFF
--- a/app/src/main/res/layout/view_avatar.xml
+++ b/app/src/main/res/layout/view_avatar.xml
@@ -30,7 +30,7 @@
         android:id="@+id/avatarImage"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="?android:attr/colorPrimary"
+        android:background="@color/white"
         android:contentDescription="@string/contentDescriptionUserAvatar"
         android:src="@drawable/placeholder"
         app:shapeAppearance="@style/CircleImageView"


### PR DESCRIPTION
This issue occurs with BIMIs avatar that use transparencey. Previously the background of the avatar was set to colorPriamary which clashed with some avatars' colors that where too close to the priamryColor. Setting it to white seems to be the way to go, how BIMIs where thought out