### PR TITLE
chore(Sentry): Remove sentry of _uploadStatus that is useless

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/Attachment.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Attachment.kt
@@ -26,7 +26,6 @@ import com.infomaniak.mail.utils.AttachableMimeTypeUtils
 import com.infomaniak.mail.utils.LocalStorageUtils
 import com.infomaniak.mail.utils.SentryDebug
 import io.realm.kotlin.types.EmbeddedRealmObject
-import io.sentry.Sentry
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -63,12 +62,7 @@ class Attachment : EmbeddedRealmObject, Attachable {
     //endregion
 
     val uploadStatus: UploadStatus?
-        get() = runCatching {
-            enumValueOf<UploadStatus>(_uploadStatus)
-        }.getOrElse {
-            Sentry.captureException(it) { scope -> scope.setTag("_uploadStatus", _uploadStatus) }
-            null
-        }
+        get() = enumValueOfOrNull<UploadStatus>(_uploadStatus)
 
     val isCalendarEvent: Boolean get() = AttachableMimeTypeUtils.calendarMatches.contains(mimeType)
 


### PR DESCRIPTION
It spams sentry just to trigger because _uploadStatus is an empty string