### PR TITLE
fix: DownloadAttachmentProgressFragment lifecycle crash

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/DownloadAttachmentProgressDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/DownloadAttachmentProgressDialog.kt
@@ -67,7 +67,7 @@ class DownloadAttachmentProgressDialog : DialogFragment() {
     }
 
     private fun downloadAttachment() {
-        downloadAttachmentViewModel.downloadAttachment().observe(this) { cachedAttachment ->
+        downloadAttachmentViewModel.downloadAttachment().observe(viewLifecycleOwner) { cachedAttachment ->
             if (cachedAttachment == null) {
                 popBackStackWithError()
             } else {


### PR DESCRIPTION
fixes MAIL-ANDROID-F1P