### PR TITLE
Add some sentry to better understand message display improvements that still leave some overscroll

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/MessageWebViewClient.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/MessageWebViewClient.kt
@@ -32,6 +32,7 @@ import com.infomaniak.mail.data.models.Attachment
 import com.infomaniak.mail.utils.LocalStorageUtils
 import com.infomaniak.mail.utils.Utils
 import com.infomaniak.mail.utils.Utils.runCatchingRealm
+import com.infomaniak.mail.utils.WebViewVersionUtils.getWebViewVersionData
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import java.io.ByteArrayInputStream
@@ -105,12 +106,18 @@ class MessageWebViewClient(
         runCatchingRealm {
             val widthInDp = webView.width.toDp()
             if (widthInDp <= 0) {
+                val versionData = getWebViewVersionData(context)
+
                 Sentry.withScope { scope ->
                     scope.level = SentryLevel.WARNING
                     scope.setExtra("width", webView.width.toString())
                     scope.setExtra("measuredWidth", webView.measuredWidth.toString())
                     scope.setExtra("height", webView.height.toString())
                     scope.setExtra("measuredHeight", webView.measuredHeight.toString())
+                    scope.setTag(
+                        "webview version",
+                        "${versionData?.webViewPackageName}: ${versionData?.versionName} - ${versionData?.majorVersion}"
+                    )
                     scope.setTag("visibility", webView.visibility.toString())
                     scope.setTag("messageUid", messageUid)
                     scope.setTag("shouldLoadDistantResources", shouldLoadDistantResources.toString())

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -325,13 +325,13 @@ object SentryDebug {
         }
     }
 
-    fun sendWebViewVersionName(webViewPackageName: String?, webViewVersionName: String?, majorVersion: Int) {
+    fun sendWebViewVersionName(versionData: WebViewVersionUtils.WebViewVersionData?) {
         Sentry.captureMessage(
             "WebView version name might be null on some devices. Checking that the version name is ok.",
         ) { scope ->
-            scope.setTag("webViewPackageName", "$webViewPackageName")
-            scope.setTag("webViewVersionName", "$webViewVersionName")
-            scope.setTag("majorVersion", "$majorVersion")
+            scope.setTag("webViewPackageName", versionData?.webViewPackageName.toString())
+            scope.setTag("webViewVersionName", versionData?.versionName.toString())
+            scope.setTag("majorVersion", versionData?.majorVersion.toString())
         }
     }
     //endregion

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -284,6 +284,7 @@ object SentryDebug {
     fun sendOverScrolledMessage(clientWidth: Int, scrollWidth: Int, messageUid: String) {
         Sentry.captureMessage("When resizing the mail with js, after zooming, it can still scroll.", SentryLevel.ERROR) { scope ->
             scope.setTag("messageUid", messageUid)
+            scope.setTag("isClientWidthEmpty", (clientWidth <= 0).toString())
             scope.setExtra("clientWidth", "$clientWidth")
             scope.setExtra("scrollWidth", "$scrollWidth")
         }

--- a/app/src/main/java/com/infomaniak/mail/utils/WebViewVersionUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/WebViewVersionUtils.kt
@@ -1,0 +1,48 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.utils
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import androidx.webkit.WebViewCompat
+
+object WebViewVersionUtils {
+    private const val DEFAULT_WEBVIEW_VERSION = 0
+
+    fun getWebViewVersionData(context: Context): WebViewVersionData? {
+        val webViewPackage = WebViewCompat.getCurrentWebViewPackage(context) ?: return null
+        val webViewPackageName = webViewPackage.packageName
+        val (versionName, majorVersion) = webViewPackage.getWebViewVersions()
+
+        return WebViewVersionData(versionName, majorVersion, webViewPackageName)
+    }
+
+    private fun PackageInfo.getWebViewVersions(): Pair<String, Int> {
+        val majorVersion = runCatching {
+            versionName.substringBefore('.').toInt()
+        }.getOrDefault(defaultValue = DEFAULT_WEBVIEW_VERSION)
+
+        return versionName to majorVersion
+    }
+
+    data class WebViewVersionData(
+        val versionName: String,
+        val majorVersion: Int,
+        val webViewPackageName: String,
+    )
+}


### PR DESCRIPTION
When resizing the mail with js, after zooming, it can still scroll. Sometimes, the issue is caused because the target width in which we want to the fit all of the html is 0. In this case, no amount of processing will ever let us fit the content in a width of 0 obviously.

This PR adds a new clarifying sentry captureMessage to try and understand how we could possibly end up with a target width of 0 in the first place. This PR also adds a tag to the already existing captureMessage to understand in what proportion the issue is caused by zero-width webviews