### PR TITLE
fix: Don't show the contact if the email is incorrect

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -192,7 +192,6 @@ class NewMessageViewModel @Inject constructor(
     fun arrivedFromExistingDraft() = arrivedFromExistingDraft
     fun draftLocalUuid() = draftLocalUuid
     fun draftMode() = draftMode
-    fun recipient() = recipient
     fun shouldLoadDistantResources() = shouldLoadDistantResources
 
     fun initDraftAndViewModel(intent: Intent): LiveData<Draft?> = liveData(ioCoroutineContext) {

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/RecipientFieldView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/RecipientFieldView.kt
@@ -132,11 +132,7 @@ class RecipientFieldView @JvmOverloads constructor(
                 onContactClicked = { addRecipient(it.email, it.name) },
                 onAddUnrecognizedContact = {
                     val input = textInput.text.toString()
-                    if (input.isEmail()) {
-                        addRecipient(email = input, name = input)
-                    } else {
-                        snackbarManager.setValue(context.getString(R.string.addUnknownRecipientInvalidEmail))
-                    }
+                    addRecipient(email = input, name = input)
                 },
                 snackbarManager = snackbarManager,
             )
@@ -311,6 +307,11 @@ class RecipientFieldView @JvmOverloads constructor(
     }
 
     private fun addRecipient(email: String, name: String) {
+
+        if (!email.isEmail()) {
+            snackbarManager.setValue(context.getString(R.string.addUnknownRecipientInvalidEmail))
+            return
+        }
 
         if (contactChipAdapter.itemCount > MAX_ALLOWED_RECIPIENT) {
             snackbarManager.setValue(context.getString(R.string.tooManyRecipients))


### PR DESCRIPTION
Do not allow the user to add a contact with an invalid email, and set only one entry as 'ContactChipAdapter' for easier management.