### PR TITLE
fix: Refresh User & Mailboxes before fetching Notifications

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/NotificationUtils.kt
@@ -33,6 +33,7 @@ import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.lib.core.utils.clearStack
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
+import com.infomaniak.mail.data.api.ApiRepository
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
 import com.infomaniak.mail.data.models.draft.Draft.DraftAction
 import com.infomaniak.mail.data.models.draft.Draft.DraftMode
@@ -304,6 +305,17 @@ class NotificationUtils @Inject constructor(
         addAction(archiveAction)
         addAction(deleteAction)
         addAction(replyAction)
+    }
+
+    suspend fun updateUserAndMailboxes(mailboxController: MailboxController, tag: String) {
+        // Refresh User
+        AccountUtils.updateCurrentUser()
+
+        // Refresh Mailboxes
+        SentryLog.d(tag, "Refresh mailboxes from remote")
+        with(ApiRepository.getMailboxes()) {
+            if (isSuccess()) mailboxController.updateMailboxes(data!!)
+        }
     }
 
     companion object : NotificationUtilsCore() {

--- a/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
+++ b/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
@@ -76,8 +76,12 @@ class ProcessMessageNotificationsWorker @AssistedInject constructor(
         }
 
         val mailbox = mailboxController.getMailbox(userId, mailboxId) ?: run {
-            // If the Mailbox doesn't exist in Realm anymore, it means it's not attached to this User anymore.
-            // We can leave safely.
+            // If the Mailbox doesn't exist in Realm, it's either because :
+            // - The Mailbox isn't attached to this User anymore.
+            // - The user POSSIBLY recently added this new Mailbox on its account, via the Infomaniak
+            //   WebMail or somewhere else. We need to wait until the user opens the app again to
+            //   fetch this new Mailbox. Then, we'll be able to handle Notifications for this Mailbox.
+            // Either way, we can leave safely.
             return@withContext Result.success()
         }
 


### PR DESCRIPTION
When a Mailbox isn't attached to a User anymore, we need to update Realm to reflect this.
It's already done when starting the app, but it wasn't done when fetching Notifications in background.