### PR TITLE
Add api response code to api call sentry breadcrumb

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -61,12 +61,13 @@ object SentryDebug {
         previousDestinationName = newDestinationName
     }
 
-    fun addUrlBreadcrumb(url: String, requestContextId: String) {
+    fun addUrlBreadcrumb(url: String, requestContextId: String, responseCode: Int?) {
         addInfoBreadcrumb(
             category = "API",
             data = mapOf(
                 "url" to url,
                 "requestContextId" to requestContextId,
+                "responseCode" to responseCode.toString(),
             ),
         )
     }


### PR DESCRIPTION
Add the http response code to the Sentry breadcrumb that logs every api call so we can better understand what happened when an error arises. 

Also make sure that even if the code crashes inside one of the other interceptors, the breadcrumb will still be added