### PR TITLE
Fix coral light color token

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -61,7 +61,7 @@
     <color name="mango_dark">#FFC166</color>
     <color name="orange_light">#FF8500</color>
     <color name="orange_dark">#FFAA4C</color>
-    <color name="coral_light">#EF5803</color>
+    <color name="coral_light">#FF540B</color>
     <color name="coral_dark">#FD9459</color>
     <color name="red_light">#F44336</color>
     <color name="red_dark">#FC8878</color>


### PR DESCRIPTION
The color token was based on a wrong spec. We just noticed the issue, so here is the update color token with the correct value