### PR TITLE
fix: Remove onFocusChange in BackspaceAwareChip

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/BackspaceAwareChip.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/BackspaceAwareChip.kt
@@ -18,7 +18,6 @@
 package com.infomaniak.mail.ui.newMessage
 
 import android.content.Context
-import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.KeyEvent
 import com.google.android.material.chip.Chip
@@ -29,15 +28,6 @@ class BackspaceAwareChip @JvmOverloads constructor(
 ) : Chip(context, attrs) {
 
     private var onBackspace: () -> Unit = {}
-
-    override fun onFocusChanged(focused: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
-        if (isInTouchMode && focused) {
-            performClick()
-            clearFocus()
-        } else {
-            super.onFocusChanged(focused, direction, previouslyFocusedRect)
-        }
-    }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
         if (keyCode == KeyEvent.KEYCODE_DEL) onBackspace()


### PR DESCRIPTION
The issue was that we couldn't delete a recipient chip using the backspace key when composing an email on API 34 and above. To address this, we initially added the `onFocusChanged` method in `BackspaceAwareChip` and set `focusableInTouchMode=true` in the XML layout file for `BackspaceAwareChip`. While this resolved the issue, it caused an ANR on some devices in unknown condition. 

Ultimately, we found that setting only `focusableInTouchMode=true` in the XML was sufficient to fix the problem.