### PR TITLE
feat: Add APP_EMAIL and DEFAULT category to the main activity in the manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -94,7 +94,10 @@
             android:theme="@style/AppThemeLauncher">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.APP_EMAIL" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
             <meta-data


### PR DESCRIPTION
This is useful to be detectable when another apps want to find all emails app on the phone without using a mailto: protocol or sending any other kind of data to the app