### PR TITLE
fix: Mark the ProcessMessageNotificationsWorker as expedited

### DIFF
--- a/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
+++ b/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
@@ -111,6 +111,7 @@ class ProcessMessageNotificationsWorker @AssistedInject constructor(
             val workRequest = OneTimeWorkRequestBuilder<ProcessMessageNotificationsWorker>()
                 .addTag(TAG)
                 .setInputData(workData)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
                 .build()
 


### PR DESCRIPTION
This will signal to the OS that we want it to run ASAP