### PR TITLE
feat: Add the new snooze api field to the Message model

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,6 +83,7 @@ android {
 }
 
 dependencies {
+    implementation project(':Core')
     implementation project(path: ':Core:Legacy')
     implementation project(path: ':Core:Legacy:AppLock')
     implementation project(path: ':Core:Legacy:BugTracker')

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -161,7 +161,7 @@ object RealmDatabase {
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 2L
         const val MAILBOX_INFO_SCHEMA_VERSION = 8L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 20L
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 21L
         //endregion
 
         //region Configurations names

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,6 +19,8 @@
 
 package com.infomaniak.mail.data.models.message
 
+import com.infomaniak.core.ApiEnum
+import com.infomaniak.core.apiEnumValueOfOrNull
 import com.infomaniak.lib.core.utils.Utils.enumValueOfOrNull
 import com.infomaniak.mail.data.api.RealmInstantSerializer
 import com.infomaniak.mail.data.api.UnwrappingJsonListSerializer
@@ -106,6 +108,12 @@ class Message : RealmObject {
     var bimi: Bimi? = null
     @SerialName("schedule_action")
     var unscheduleDraftUrl: String? = null
+    @SerialName("snooze_state")
+    private var _snoozeState: String? = null
+    @SerialName("snooze_end_date")
+    var snoozeEndDate: RealmInstant? = null
+    @SerialName("snooze_action")
+    var snoozeAction: String? = null
 
     // TODO: Those are unused for now, but if we ever want to use them, we need to save them in `Message.keepHeavyData()`.
     //  If we don't do it now, we'll probably forget to do it in the future.
@@ -218,6 +226,14 @@ class Message : RealmObject {
         NONE,
         PENDING,
         ACKNOWLEDGED,
+    }
+
+    val snoozeState: SnoozeState? get() = apiEnumValueOfOrNull<SnoozeState>(_snoozeState)
+
+    enum class SnoozeState(override val apiValue: String): ApiEnum {
+        Snoozed(apiValue = "snoozed"),
+        Unsnoozed(apiValue = "unsnoozed"),
+        WasSnoozed(apiValue = "was_snoozed"),
     }
 
     fun initLocalValues(


### PR DESCRIPTION
We can already add these fields on master even if we don't use them yet. And it especially helps split the ApiEnum logic in its own PR. Also avoid having to carry a bump of realm schema version in a feature branch which will constantly need to be updated.

Depends on https://github.com/Infomaniak/android-core/pull/283