### PR TITLE
feat: Add missing schedule date format in ThreadListFragment

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -19,11 +19,12 @@
 
 package com.infomaniak.mail.data.models.thread
 
-import android.content.Context
 import android.os.Build
-import com.infomaniak.lib.core.utils.*
+import com.infomaniak.lib.core.utils.FORMAT_DATE_CLEAR_MONTH_DAY_ONE_CHAR
+import com.infomaniak.lib.core.utils.FormatData
+import com.infomaniak.lib.core.utils.format
+import com.infomaniak.lib.core.utils.formatWithLocal
 import com.infomaniak.mail.MatomoMail.SEARCH_FOLDER_FILTER_NAME
-import com.infomaniak.mail.R
 import com.infomaniak.mail.data.api.RealmInstantSerializer
 import com.infomaniak.mail.data.cache.mailboxContent.FolderController
 import com.infomaniak.mail.data.models.Bimi
@@ -32,8 +33,6 @@ import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.utils.AccountUtils
-import com.infomaniak.mail.utils.extensions.isSmallerThanDays
-import com.infomaniak.mail.utils.extensions.toDate
 import com.infomaniak.mail.utils.extensions.toRealmInstant
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
@@ -219,25 +218,6 @@ class Thread : RealmObject {
 
         date = messages.last { it.folderId == folderId }.date
         subject = messages.first().subject
-    }
-
-    fun formatDate(context: Context): String = with(date.toDate()) {
-        when {
-            isInTheFuture() -> formatNumericalDayMonthYear()
-            isToday() -> format(FORMAT_DATE_HOUR_MINUTE)
-            isYesterday() -> context.getString(R.string.messageDetailsYesterday)
-            isSmallerThanDays(6) -> format(FORMAT_DAY_OF_THE_WEEK)
-            isThisYear() -> format(FORMAT_DATE_SHORT_DAY_ONE_CHAR)
-            else -> formatNumericalDayMonthYear()
-        }
-    }
-
-    private fun Date.formatNumericalDayMonthYear(): String {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            formatWithLocal(FormatData.DATE, FormatStyle.SHORT)
-        } else {
-            format(FORMAT_DATE_CLEAR_MONTH_DAY_ONE_CHAR) // Fallback on unambiguous date format for any local
-        }
     }
 
     fun computeAvatarRecipient(): Pair<Recipient?, Bimi?> = runCatching {

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -19,11 +19,6 @@
 
 package com.infomaniak.mail.data.models.thread
 
-import android.os.Build
-import com.infomaniak.lib.core.utils.FORMAT_DATE_CLEAR_MONTH_DAY_ONE_CHAR
-import com.infomaniak.lib.core.utils.FormatData
-import com.infomaniak.lib.core.utils.format
-import com.infomaniak.lib.core.utils.formatWithLocal
 import com.infomaniak.mail.MatomoMail.SEARCH_FOLDER_FILTER_NAME
 import com.infomaniak.mail.data.api.RealmInstantSerializer
 import com.infomaniak.mail.data.cache.mailboxContent.FolderController
@@ -50,7 +45,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.UseSerializers
-import java.time.format.FormatStyle
 import java.util.Date
 
 @Serializable

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
@@ -33,15 +33,15 @@ import java.util.Date
 enum class DateDisplay(@DrawableRes val icon: Int?, val formatDate: Context.(RealmInstant) -> String) {
     Default(
         icon = null,
-        formatDate = { date -> formatPastDate(date) }
+        formatDate = { date -> defaultFormatting(date) }
     ),
     Scheduled(
         icon = R.drawable.ic_scheduled_messages,
-        formatDate = { date -> formatRelativeFutureDate(date) }
+        formatDate = { date -> relativeFormatting(date) }
     ),
 }
 
-private fun Context.formatRelativeFutureDate(date: RealmInstant) = DateUtils.getRelativeDateTimeString(
+private fun Context.relativeFormatting(date: RealmInstant) = DateUtils.getRelativeDateTimeString(
     this,
     date.epochSeconds * 1000,
     DateUtils.DAY_IN_MILLIS,
@@ -49,7 +49,7 @@ private fun Context.formatRelativeFutureDate(date: RealmInstant) = DateUtils.get
     DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_ABBREV_MONTH,
 )?.toString() ?: ""
 
-private fun Context.formatPastDate(date: RealmInstant) = with(date.toDate()) {
+private fun Context.defaultFormatting(date: RealmInstant) = with(date.toDate()) {
     when {
         isInTheFuture() -> formatNumericalDayMonthYear()
         isToday() -> format(FORMAT_DATE_HOUR_MINUTE)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
@@ -47,7 +47,7 @@ private fun Context.formatRelativeFutureDate(date: RealmInstant) = DateUtils.get
     DateUtils.DAY_IN_MILLIS,
     DateUtils.WEEK_IN_MILLIS,
     DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_ABBREV_MONTH,
-)!!.toString()
+)?.toString() ?: ""
 
 private fun Context.formatPastDate(date: RealmInstant) = with(date.toDate()) {
     when {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
@@ -1,0 +1,70 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.ui.main.folder
+
+import android.content.Context
+import android.os.Build
+import android.text.format.DateUtils
+import androidx.annotation.DrawableRes
+import com.infomaniak.lib.core.utils.*
+import com.infomaniak.mail.R
+import com.infomaniak.mail.utils.extensions.isSmallerThanDays
+import com.infomaniak.mail.utils.extensions.toDate
+import io.realm.kotlin.types.RealmInstant
+import java.time.format.FormatStyle
+import java.util.Date
+
+sealed interface DateDisplay {
+    @get:DrawableRes
+    val icon: Int?
+
+    fun formatDate(date: RealmInstant, context: Context): String
+
+    data object Default : DateDisplay {
+        override val icon: Int? = null
+        override fun formatDate(date: RealmInstant, context: Context): String = with(date.toDate()) {
+            when {
+                isInTheFuture() -> formatNumericalDayMonthYear()
+                isToday() -> format(FORMAT_DATE_HOUR_MINUTE)
+                isYesterday() -> context.getString(com.infomaniak.mail.R.string.messageDetailsYesterday)
+                isSmallerThanDays(6) -> format(com.infomaniak.mail.data.models.thread.Thread.FORMAT_DAY_OF_THE_WEEK)
+                isThisYear() -> format(FORMAT_DATE_SHORT_DAY_ONE_CHAR)
+                else -> formatNumericalDayMonthYear()
+            }
+        }
+
+        private fun Date.formatNumericalDayMonthYear(): String {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                formatWithLocal(FormatData.DATE, FormatStyle.SHORT)
+            } else {
+                format(FORMAT_DATE_CLEAR_MONTH_DAY_ONE_CHAR) // Fallback on unambiguous date format for any local
+            }
+        }
+    }
+
+    data object Scheduled : DateDisplay {
+        override val icon: Int = R.drawable.ic_scheduled_messages
+        override fun formatDate(date: RealmInstant, context: Context): String = DateUtils.getRelativeDateTimeString(
+            context,
+            date.epochSeconds * 1000,
+            DateUtils.DAY_IN_MILLIS,
+            DateUtils.WEEK_IN_MILLIS,
+            DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_ABBREV_MONTH,
+        )!!.toString()
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
@@ -46,7 +46,7 @@ private fun Context.relativeFormatting(date: RealmInstant) = DateUtils.getRelati
     date.epochSeconds * 1000,
     DateUtils.DAY_IN_MILLIS,
     DateUtils.WEEK_IN_MILLIS,
-    DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_ABBREV_MONTH,
+    0,
 )?.toString() ?: ""
 
 private fun Context.defaultFormatting(date: RealmInstant) = with(date.toDate()) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
@@ -59,12 +59,14 @@ sealed interface DateDisplay {
 
     data object Scheduled : DateDisplay {
         override val icon: Int = R.drawable.ic_scheduled_messages
-        override fun formatDate(date: RealmInstant, context: Context): String = DateUtils.getRelativeDateTimeString(
-            context,
-            date.epochSeconds * 1000,
-            DateUtils.DAY_IN_MILLIS,
-            DateUtils.WEEK_IN_MILLIS,
-            DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_ABBREV_MONTH,
-        )!!.toString()
+        override fun formatDate(date: RealmInstant, context: Context): String = relativeFutureDate(context, date)
     }
 }
+
+private fun relativeFutureDate(context: Context, date: RealmInstant) = DateUtils.getRelativeDateTimeString(
+    context,
+    date.epochSeconds * 1000,
+    DateUtils.DAY_IN_MILLIS,
+    DateUtils.WEEK_IN_MILLIS,
+    DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_ABBREV_MONTH,
+)!!.toString()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/DateDisplay.kt
@@ -30,36 +30,30 @@ import io.realm.kotlin.types.RealmInstant
 import java.time.format.FormatStyle
 import java.util.Date
 
-sealed interface DateDisplay {
-    @get:DrawableRes
-    val icon: Int?
-
-    fun formatDate(date: RealmInstant, context: Context): String
-
-    data object Default : DateDisplay {
-        override val icon: Int? = null
-        override fun formatDate(date: RealmInstant, context: Context): String = formatPastDate(context, date)
-    }
-
-    data object Scheduled : DateDisplay {
-        override val icon: Int = R.drawable.ic_scheduled_messages
-        override fun formatDate(date: RealmInstant, context: Context): String = formatRelativeFutureDate(context, date)
-    }
+enum class DateDisplay(@DrawableRes val icon: Int?, val formatDate: Context.(RealmInstant) -> String) {
+    Default(
+        icon = null,
+        formatDate = { date -> formatPastDate(date) }
+    ),
+    Scheduled(
+        icon = R.drawable.ic_scheduled_messages,
+        formatDate = { date -> formatRelativeFutureDate(date) }
+    ),
 }
 
-private fun formatRelativeFutureDate(context: Context, date: RealmInstant) = DateUtils.getRelativeDateTimeString(
-    context,
+private fun Context.formatRelativeFutureDate(date: RealmInstant) = DateUtils.getRelativeDateTimeString(
+    this,
     date.epochSeconds * 1000,
     DateUtils.DAY_IN_MILLIS,
     DateUtils.WEEK_IN_MILLIS,
     DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_ABBREV_MONTH,
 )!!.toString()
 
-private fun formatPastDate(context: Context, date: RealmInstant) = with(date.toDate()) {
+private fun Context.formatPastDate(date: RealmInstant) = with(date.toDate()) {
     when {
         isInTheFuture() -> formatNumericalDayMonthYear()
         isToday() -> format(FORMAT_DATE_HOUR_MINUTE)
-        isYesterday() -> context.getString(R.string.messageDetailsYesterday)
+        isYesterday() -> getString(R.string.messageDetailsYesterday)
         isSmallerThanDays(6) -> format(FORMAT_DAY_OF_THE_WEEK)
         isThisYear() -> format(FORMAT_DATE_SHORT_DAY_ONE_CHAR)
         else -> formatNumericalDayMonthYear()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -231,9 +231,13 @@ class ThreadListAdapter @Inject constructor(
             expeditor.text = formatRecipientNames(computeDisplayedRecipients())
             mailSubject.text = context.formatSubject(subject)
             mailBodyPreview.text = computePreview().ifBlank { context.getString(R.string.noBodyTitle) }
-            mailDate.text = formatDate(context)
 
-            scheduleSendIcon.isVisible = numberOfScheduledDrafts > 0 && folderRole == FolderRole.SCHEDULED_DRAFTS
+            val dateDisplay = computeDateDisplay()
+            mailDate.text = dateDisplay.formatDate(date, context)
+            mailDateIcon.apply {
+                isVisible = dateDisplay.icon != null
+                dateDisplay.icon?.let { setImageResource(it) }
+            }
             draftPrefix.isVisible = hasDrafts
 
             val (isIconReplyVisible, isIconForwardVisible) = computeReplyAndForwardIcon(thread.isAnswered, thread.isForwarded)
@@ -482,6 +486,11 @@ class ThreadListAdapter @Inject constructor(
             1 -> recipients.single().displayedName(context)
             else -> everyone()
         }
+    }
+
+    private fun Thread.computeDateDisplay() = when {
+        numberOfScheduledDrafts > 0 && folderRole == FolderRole.SCHEDULED_DRAFTS -> DateDisplay.Scheduled
+        else -> DateDisplay.Default
     }
 
     private fun CardviewThreadItemBinding.setThreadUiRead() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -233,7 +233,7 @@ class ThreadListAdapter @Inject constructor(
             mailBodyPreview.text = computePreview().ifBlank { context.getString(R.string.noBodyTitle) }
 
             val dateDisplay = computeDateDisplay()
-            mailDate.text = dateDisplay.formatDate(date, context)
+            mailDate.text = dateDisplay.formatDate(context, date)
             mailDateIcon.apply {
                 isVisible = dateDisplay.icon != null
                 dateDisplay.icon?.let { setImageResource(it) }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -489,8 +489,8 @@ class ThreadListAdapter @Inject constructor(
     }
 
     private fun Thread.computeDateDisplay() = when {
-        numberOfScheduledDrafts > 0 && folderRole == FolderRole.SCHEDULED_DRAFTS -> DateDisplay.Scheduled
-        else -> DateDisplay.Default
+        numberOfScheduledDrafts > 0 && folderRole == FolderRole.SCHEDULED_DRAFTS -> ThreadListDateDisplay.Scheduled
+        else -> ThreadListDateDisplay.Default
     }
 
     private fun CardviewThreadItemBinding.setThreadUiRead() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListDateDisplay.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListDateDisplay.kt
@@ -30,7 +30,7 @@ import io.realm.kotlin.types.RealmInstant
 import java.time.format.FormatStyle
 import java.util.Date
 
-enum class DateDisplay(@DrawableRes val icon: Int?, val formatDate: Context.(RealmInstant) -> String) {
+enum class ThreadListDateDisplay(@DrawableRes val icon: Int?, val formatDate: Context.(RealmInstant) -> String) {
     Default(
         icon = null,
         formatDate = { date -> defaultFormatting(date) }

--- a/app/src/main/res/layout/cardview_thread_item.xml
+++ b/app/src/main/res/layout/cardview_thread_item.xml
@@ -199,7 +199,7 @@
                     app:cardBackgroundColor="@color/backgroundColor"
                     app:cardCornerRadius="2dp"
                     app:layout_constraintBottom_toBottomOf="@id/expeditor"
-                    app:layout_constraintEnd_toStartOf="@id/scheduleSendIcon"
+                    app:layout_constraintEnd_toStartOf="@id/mailDateIcon"
                     app:layout_constraintStart_toEndOf="@id/expeditor"
                     app:layout_constraintTop_toTopOf="@id/expeditor"
                     app:strokeColor="@color/progressbarTrackColor"
@@ -217,17 +217,17 @@
                 </com.google.android.material.card.MaterialCardView>
 
                 <ImageView
-                    android:id="@+id/scheduleSendIcon"
+                    android:id="@+id/mailDateIcon"
                     android:layout_width="@dimen/smallIconSize"
                     android:layout_height="@dimen/smallIconSize"
                     android:layout_marginHorizontal="@dimen/marginStandardVerySmall"
                     android:contentDescription="@string/contentDescriptionScheduleSend"
-                    android:src="@drawable/ic_scheduled_messages"
                     android:visibility="gone"
                     app:layout_constraintBottom_toBottomOf="@id/mailDate"
                     app:layout_constraintEnd_toStartOf="@id/mailDate"
                     app:layout_constraintTop_toTopOf="@id/mailDate"
                     app:tint="@color/scheduledIconColor"
+                    tools:src="@drawable/ic_scheduled_messages"
                     tools:visibility="visible" />
 
                 <TextView


### PR DESCRIPTION
The scheduled threads need to have a new relative formatting of the date which was missing in the original scheduled message feature. This PR adds the missing formatting and lays the groundwork for the snooze as well.

The existing default case logic for formatting dates has simply been moved to the new DateDisplay class without modifications. The name of the XML ImageView holding the "scheduled" icon has been renamed with a more neutral name to easily be reused for snooze