### PR TITLE
refactor: Hide schedule time picker cursor and remove unused hint space

### DIFF
--- a/app/src/main/res/layout/dialog_select_date_and_time_for_scheduled_draft.xml
+++ b/app/src/main/res/layout/dialog_select_date_and_time_for_scheduled_draft.xml
@@ -16,6 +16,7 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -41,12 +42,14 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/marginStandard"
-            android:layout_weight="1">
+            android:layout_weight="1"
+            app:hintEnabled="false">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/dateField"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:cursorVisible="false"
                 android:focusable="false"
                 android:focusableInTouchMode="false"
                 android:inputType="date"
@@ -56,12 +59,14 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            app:hintEnabled="false">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/timeField"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
+                android:cursorVisible="false"
                 android:focusable="false"
                 android:focusableInTouchMode="false"
                 android:inputType="date"


### PR DESCRIPTION
This goes in its own PR because the changes would be lost if they go inside the whole dialog refactor