### PR TITLE
fix: Select date time dialog wrong values and wrong error messages

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.ui.alertDialogs
 
 import android.content.Context
+import android.text.format.DateFormat
 import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import com.google.android.material.datepicker.*
@@ -136,7 +137,7 @@ open class SelectDateAndTimeForScheduledDraftDialog @Inject constructor(
     private fun showTimePicker(dateToDisplay: Date, onDateSelected: (Int, Int) -> Unit) {
         val timePicker = MaterialTimePicker.Builder()
             .setInputMode(MaterialTimePicker.INPUT_MODE_CLOCK)
-            .setTimeFormat(TimeFormat.CLOCK_24H)
+            .setTimeFormat(if (DateFormat.is24HourFormat(activityContext)) TimeFormat.CLOCK_24H else TimeFormat.CLOCK_12H)
             .setHour(dateToDisplay.hours())
             .setMinute(dateToDisplay.minutes())
             .setTitleText(binding.context.getString(R.string.selectTimeDialogTitle))

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
@@ -32,6 +32,7 @@ import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
 import java.util.Calendar
 import java.util.Date
+import java.util.TimeZone
 import javax.inject.Inject
 import com.infomaniak.lib.core.R as RCore
 
@@ -153,9 +154,12 @@ open class SelectDateAndTimeForScheduledDraftDialog @Inject constructor(
         )
         val constraintsBuilder = CalendarConstraints.Builder().setValidator(CompositeDateValidator.allOf(dateValidators))
 
+        // MaterialDatePicker expects the `setSelection()` time to be defined as UTC time and not local time
+        val utcTime = dateToDisplay.time + TimeZone.getDefault().getOffset(dateToDisplay.time)
+
         val datePicker = MaterialDatePicker.Builder.datePicker()
             .setTitleText(binding.context.getString(R.string.selectDateDialogTitle))
-            .setSelection(dateToDisplay.time)
+            .setSelection(utcTime)
             .setCalendarConstraints(constraintsBuilder.build())
             .build()
 

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
@@ -29,6 +29,7 @@ import com.infomaniak.lib.core.utils.*
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.databinding.DialogSelectDateAndTimeForScheduledDraftBinding
+import com.infomaniak.mail.utils.date.DateFormatUtils.formatTime
 import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
 import java.util.Calendar
@@ -112,7 +113,7 @@ open class SelectDateAndTimeForScheduledDraftDialog @Inject constructor(
         selectedDate = date
         with(binding) {
             dateField.setText(date.format(FORMAT_DATE_DAY_MONTH_YEAR))
-            timeField.setText(date.format(FORMAT_DATE_HOUR_MINUTE))
+            timeField.setText(context.formatTime(date))
         }
     }
 

--- a/app/src/main/res/layout/dialog_select_date_and_time_for_scheduled_draft.xml
+++ b/app/src/main/res/layout/dialog_select_date_and_time_for_scheduled_draft.xml
@@ -20,9 +20,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:divider="@drawable/spacer_standard_medium"
     android:orientation="vertical"
     android:paddingHorizontal="@dimen/marginStandard"
-    android:paddingVertical="@dimen/marginStandardSmall">
+    android:paddingVertical="@dimen/marginStandardSmall"
+    android:showDividers="middle">
 
     <TextView
         android:id="@+id/dialogTitle"
@@ -32,48 +34,44 @@
         android:layout_marginTop="@dimen/marginStandard"
         tools:text="@string/datePickerTitle" />
 
-    <LinearLayout
+    <com.infomaniak.lib.core.views.EndIconTextInputLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginVertical="@dimen/marginStandard"
-        android:baselineAligned="false">
+        android:layout_height="wrap_content"
+        app:endIconDrawable="@drawable/ic_chevron_down"
+        app:endIconMode="custom"
+        app:hintEnabled="false">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/marginStandard"
-            android:layout_weight="1"
-            app:hintEnabled="false">
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/dateField"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:cursorVisible="false"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:inputType="date"
+            tools:text="mer. 27 nov. 2024" />
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/dateField"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:cursorVisible="false"
-                android:focusable="false"
-                android:focusableInTouchMode="false"
-                android:inputType="date"
-                tools:text="mer. 27 nov. 2024" />
+    </com.infomaniak.lib.core.views.EndIconTextInputLayout>
 
-        </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:hintEnabled="false">
+    <com.infomaniak.lib.core.views.EndIconTextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:endIconDrawable="@drawable/ic_chevron_down"
+        app:endIconMode="custom"
+        app:hintEnabled="false">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/timeField"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:cursorVisible="false"
-                android:focusable="false"
-                android:focusableInTouchMode="false"
-                android:inputType="date"
-                tools:text="08:00" />
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/timeField"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:cursorVisible="false"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:inputType="date"
+            tools:text="08:00" />
 
-        </com.google.android.material.textfield.TextInputLayout>
-    </LinearLayout>
+    </com.infomaniak.lib.core.views.EndIconTextInputLayout>
 
     <TextView
         android:id="@+id/scheduleDateError"


### PR DESCRIPTION
The error message sometimes not block the user when it should've or it would would block the user when it should not have. The values inside the time picker would also sometime be wrong and have a different one than the one displayed inside the dialog