### PR TITLE
chore: Better align expeditor name, schedule date, and icons

### DIFF
--- a/app/src/main/res/drawable/ic_scheduled_messages_small.xml
+++ b/app/src/main/res/drawable/ic_scheduled_messages_small.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Infomaniak Mail - Android
+  ~ Copyright (C) 2025 Infomaniak Network SA
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:width="12dp"
+        android:height="12dp"
+        android:drawable="@drawable/ic_scheduled_messages" />
+</layer-list>

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -53,68 +53,88 @@
                     app:layout_constraintTop_toTopOf="parent"
                     tools:src="@tools:sample/avatars" />
 
-                <TextView
-                    android:id="@+id/expeditorName"
-                    style="@style/BodyMedium"
-                    android:layout_width="wrap_content"
+                <LinearLayout
+                    android:id="@+id/expeditorLayout"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/marginStandardMedium"
-                    android:ellipsize="end"
-                    android:lines="1"
-                    app:layout_constrainedWidth="true"
-                    app:layout_constraintEnd_toStartOf="@id/certifiedIcon"
-                    app:layout_constraintHorizontal_bias="0"
-                    app:layout_constraintHorizontal_chainStyle="packed"
-                    app:layout_constraintStart_toEndOf="@id/userAvatar"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:text="@tools:sample/full_names" />
-
-                <ImageView
-                    android:id="@+id/certifiedIcon"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/marginStandardVerySmall"
-                    android:src="@drawable/ic_certified"
-                    app:layout_constraintBottom_toBottomOf="@id/expeditorName"
-                    app:layout_constraintEnd_toStartOf="@id/iconsSpace"
-                    app:layout_constraintStart_toEndOf="@id/expeditorName"
-                    app:layout_constraintTop_toTopOf="@id/expeditorName"
-                    tools:ignore="ContentDescription" />
-
-                <Space
-                    android:id="@+id/iconsSpace"
-                    android:layout_width="@dimen/marginStandardSmall"
-                    android:layout_height="0dp"
-                    app:layout_constraintBottom_toBottomOf="@id/certifiedIcon"
-                    app:layout_constraintEnd_toStartOf="@id/scheduleSendIcon"
-                    app:layout_constraintStart_toEndOf="@id/certifiedIcon"
-                    app:layout_constraintTop_toTopOf="@id/certifiedIcon" />
-
-                <ImageView
-                    android:id="@+id/scheduleSendIcon"
-                    android:layout_width="@dimen/smallIconSize"
-                    android:layout_height="@dimen/smallIconSize"
-                    android:layout_marginEnd="@dimen/marginStandardVerySmall"
-                    android:contentDescription="@string/contentDescriptionScheduleSend"
-                    android:src="@drawable/ic_scheduled_messages"
-                    android:visibility="gone"
-                    app:layout_constraintBottom_toBottomOf="@id/shortMessageDate"
-                    app:layout_constraintEnd_toStartOf="@id/shortMessageDate"
-                    app:layout_constraintStart_toEndOf="@id/iconsSpace"
-                    app:layout_constraintTop_toTopOf="@id/shortMessageDate"
-                    app:tint="@color/scheduledIconColor"
-                    tools:visibility="visible" />
-
-                <TextView
-                    android:id="@+id/shortMessageDate"
-                    style="@style/Label.Secondary"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/marginStandardSmall"
-                    app:layout_constraintBaseline_toBaselineOf="@id/expeditorName"
+                    android:orientation="horizontal"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/scheduleSendIcon"
-                    tools:text="9 déc 2021 à 11:00" />
+                    app:layout_constraintStart_toEndOf="@id/userAvatar"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="horizontal"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <TextView
+                            android:id="@+id/expeditorName"
+                            style="@style/BodyMedium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/marginStandardMedium"
+                            android:ellipsize="end"
+                            android:lines="1"
+                            app:layout_constrainedWidth="true"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/iconCertified"
+                            app:layout_constraintHorizontal_bias="0"
+                            app:layout_constraintHorizontal_chainStyle="packed"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            tools:text="@tools:sample/full_names" />
+
+                        <ImageView
+                            android:id="@+id/iconCertified"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/marginStandardVerySmall"
+                            android:src="@drawable/ic_certified"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/iconsSpace"
+                            app:layout_constraintStart_toEndOf="@id/expeditorName"
+                            app:layout_constraintTop_toTopOf="parent"
+                            tools:ignore="ContentDescription" />
+
+                        <Space
+                            android:id="@+id/iconsSpace"
+                            android:layout_width="@dimen/marginStandardVerySmall"
+                            android:layout_height="0dp"
+                            app:layout_constraintBottom_toBottomOf="@id/iconCertified"
+                            app:layout_constraintEnd_toStartOf="@id/scheduleSendIcon"
+                            app:layout_constraintStart_toEndOf="@id/iconCertified"
+                            app:layout_constraintTop_toTopOf="@id/iconCertified" />
+
+                        <ImageView
+                            android:id="@+id/scheduleSendIcon"
+                            android:layout_width="@dimen/smallIconSize"
+                            android:layout_height="@dimen/smallIconSize"
+                            android:layout_marginHorizontal="@dimen/marginStandardVerySmall"
+                            android:contentDescription="@string/contentDescriptionScheduleSend"
+                            android:src="@drawable/ic_scheduled_messages"
+                            android:visibility="gone"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/shortMessageDate"
+                            app:layout_constraintStart_toEndOf="@id/iconsSpace"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:tint="@color/scheduledIconColor"
+                            tools:visibility="visible" />
+
+                        <TextView
+                            android:id="@+id/shortMessageDate"
+                            style="@style/Label.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="@dimen/marginStandardSmall"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toEndOf="@id/scheduleSendIcon"
+                            app:layout_constraintTop_toTopOf="parent"
+                            tools:text="9 déc 2021 à 11:00" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </LinearLayout>
 
                 <LinearLayout
                     android:id="@+id/recipientLayout"
@@ -128,7 +148,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0"
                     app:layout_constraintStart_toEndOf="@id/userAvatar"
-                    app:layout_constraintTop_toBottomOf="@id/expeditorName"
+                    app:layout_constraintTop_toBottomOf="@id/expeditorLayout"
                     tools:ignore="UseCompoundDrawables">
 
                     <TextView

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -53,88 +53,66 @@
                     app:layout_constraintTop_toTopOf="parent"
                     tools:src="@tools:sample/avatars" />
 
-                <LinearLayout
-                    android:id="@+id/expeditorLayout"
-                    android:layout_width="0dp"
+                <TextView
+                    android:id="@+id/expeditorName"
+                    style="@style/BodyMedium"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    android:layout_marginStart="@dimen/marginStandardMedium"
+                    android:ellipsize="end"
+                    android:lines="1"
+                    app:layout_constrainedWidth="true"
+                    app:layout_constraintEnd_toStartOf="@id/certifiedIcon"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constraintHorizontal_chainStyle="packed"
                     app:layout_constraintStart_toEndOf="@id/userAvatar"
-                    app:layout_constraintTop_toTopOf="parent">
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="@tools:sample/full_names" />
 
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:orientation="horizontal"
-                        app:layout_constraintTop_toTopOf="parent">
+                <TextView
+                    android:id="@+id/certifiedIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/marginStandardVerySmall"
+                    app:drawableStartCompat="@drawable/ic_certified"
+                    app:layout_constraintBaseline_toBaselineOf="@id/expeditorName"
+                    app:layout_constraintEnd_toStartOf="@id/iconsSpace"
+                    app:layout_constraintStart_toEndOf="@id/expeditorName"
+                    tools:ignore="ContentDescription" />
 
-                        <TextView
-                            android:id="@+id/expeditorName"
-                            style="@style/BodyMedium"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/marginStandardMedium"
-                            android:ellipsize="end"
-                            android:lines="1"
-                            app:layout_constrainedWidth="true"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toStartOf="@id/iconCertified"
-                            app:layout_constraintHorizontal_bias="0"
-                            app:layout_constraintHorizontal_chainStyle="packed"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
-                            tools:text="@tools:sample/full_names" />
+                <Space
+                    android:id="@+id/iconsSpace"
+                    android:layout_width="@dimen/marginStandardSmall"
+                    android:layout_height="0dp"
+                    app:layout_constraintBottom_toBottomOf="@id/certifiedIcon"
+                    app:layout_constraintEnd_toStartOf="@id/scheduleSendIcon"
+                    app:layout_constraintStart_toEndOf="@id/certifiedIcon"
+                    app:layout_constraintTop_toTopOf="@id/certifiedIcon" />
 
-                        <ImageView
-                            android:id="@+id/iconCertified"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/marginStandardVerySmall"
-                            android:src="@drawable/ic_certified"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toStartOf="@id/iconsSpace"
-                            app:layout_constraintStart_toEndOf="@id/expeditorName"
-                            app:layout_constraintTop_toTopOf="parent"
-                            tools:ignore="ContentDescription" />
+                <TextView
+                    android:id="@+id/scheduleSendIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/marginStandardVerySmall"
+                    android:contentDescription="@string/contentDescriptionScheduleSend"
+                    android:visibility="gone"
+                    app:drawableStartCompat="@drawable/ic_scheduled_messages_small"
+                    app:drawableTint="@color/scheduledIconColor"
+                    app:layout_constraintBaseline_toBaselineOf="@id/expeditorName"
+                    app:layout_constraintEnd_toStartOf="@id/shortMessageDate"
+                    app:layout_constraintStart_toEndOf="@id/iconsSpace"
+                    tools:visibility="visible" />
 
-                        <Space
-                            android:id="@+id/iconsSpace"
-                            android:layout_width="@dimen/marginStandardVerySmall"
-                            android:layout_height="0dp"
-                            app:layout_constraintBottom_toBottomOf="@id/iconCertified"
-                            app:layout_constraintEnd_toStartOf="@id/scheduleSendIcon"
-                            app:layout_constraintStart_toEndOf="@id/iconCertified"
-                            app:layout_constraintTop_toTopOf="@id/iconCertified" />
-
-                        <ImageView
-                            android:id="@+id/scheduleSendIcon"
-                            android:layout_width="@dimen/smallIconSize"
-                            android:layout_height="@dimen/smallIconSize"
-                            android:layout_marginHorizontal="@dimen/marginStandardVerySmall"
-                            android:contentDescription="@string/contentDescriptionScheduleSend"
-                            android:src="@drawable/ic_scheduled_messages"
-                            android:visibility="gone"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toStartOf="@id/shortMessageDate"
-                            app:layout_constraintStart_toEndOf="@id/iconsSpace"
-                            app:layout_constraintTop_toTopOf="parent"
-                            app:tint="@color/scheduledIconColor"
-                            tools:visibility="visible" />
-
-                        <TextView
-                            android:id="@+id/shortMessageDate"
-                            style="@style/Label.Secondary"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginEnd="@dimen/marginStandardSmall"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintStart_toEndOf="@id/scheduleSendIcon"
-                            app:layout_constraintTop_toTopOf="parent"
-                            tools:text="9 déc 2021 à 11:00" />
-
-                    </androidx.constraintlayout.widget.ConstraintLayout>
-                </LinearLayout>
+                <TextView
+                    android:id="@+id/shortMessageDate"
+                    style="@style/Label.Secondary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/marginStandardSmall"
+                    app:layout_constraintBaseline_toBaselineOf="@id/expeditorName"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/scheduleSendIcon"
+                    tools:text="9 déc 2021 à 11:00" />
 
                 <LinearLayout
                     android:id="@+id/recipientLayout"
@@ -148,7 +126,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0"
                     app:layout_constraintStart_toEndOf="@id/userAvatar"
-                    app:layout_constraintTop_toBottomOf="@id/expeditorLayout"
+                    app:layout_constraintTop_toBottomOf="@id/expeditorName"
                     tools:ignore="UseCompoundDrawables">
 
                     <TextView


### PR DESCRIPTION
Before:
<img width="180" alt="Before" src="https://github.com/user-attachments/assets/6edf9f33-85a5-4bb5-a65e-cece048bcbaa" />

After:
<img width="179" alt="After" src="https://github.com/user-attachments/assets/b4db2de4-2a5f-420b-acd7-477a6d2e23ce" />

Depends on #2183