### PR TITLE
fix(MyKSuite-09): Fix upgrade bottomsheet nav

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -37,6 +37,8 @@ import androidx.navigation.NavDestination
 import androidx.navigation.fragment.NavHostFragment
 import androidx.work.Data
 import com.airbnb.lottie.LottieAnimationView
+import com.infomaniak.core.myksuite.ui.screens.KSuiteApp
+import com.infomaniak.core.myksuite.ui.utils.MyKSuiteUiUtils.openMyKSuiteUpgradeBottomSheet
 import com.infomaniak.lib.core.MatomoCore.TrackerAction
 import com.infomaniak.lib.core.utils.*
 import com.infomaniak.lib.core.utils.Utils
@@ -282,7 +284,7 @@ class MainActivity : BaseActivity() {
 
             if (mainViewModel.currentMailbox.value?.isFreeMailbox == true && hasLimitBeenReached) {
                 snackbarManager.setValue(getString(errorRes), buttonTitle = R.string.buttonUpgrade) {
-                    MyKSuiteUiUtils.openMyKSuiteUpgradeBottomSheet(navController)
+                    navController.openMyKSuiteUpgradeBottomSheet(KSuiteApp.Mail)
                 }
             } else {
                 snackbarManager.setValue(getString(errorRes))

--- a/app/src/main/java/com/infomaniak/mail/ui/bottomSheetDialogs/ScheduleSendBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/bottomSheetDialogs/ScheduleSendBottomSheetDialog.kt
@@ -25,6 +25,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.view.children
 import androidx.core.view.isVisible
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.infomaniak.lib.core.utils.*
@@ -93,7 +94,7 @@ class ScheduleSendBottomSheetDialog @Inject constructor() : BottomSheetDialogFra
 
         setOnClickListener {
             if (navigationArgs.isCurrentMailboxFree) {
-                openMyKSuiteUpgradeBottomSheet(ScheduleSendBottomSheetDialog::class.java.name)
+                openMyKSuiteUpgradeBottomSheet(findNavController())
             } else {
                 setBackNavigationResult(OPEN_DATE_AND_TIME_SCHEDULE_DIALOG, true)
             }

--- a/app/src/main/java/com/infomaniak/mail/ui/bottomSheetDialogs/ScheduleSendBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/bottomSheetDialogs/ScheduleSendBottomSheetDialog.kt
@@ -28,6 +28,8 @@ import androidx.core.view.isVisible
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.infomaniak.core.myksuite.ui.screens.KSuiteApp
+import com.infomaniak.core.myksuite.ui.utils.MyKSuiteUiUtils.openMyKSuiteUpgradeBottomSheet
 import com.infomaniak.lib.core.utils.*
 import com.infomaniak.mail.MatomoMail.trackScheduleSendEvent
 import com.infomaniak.mail.R
@@ -35,7 +37,6 @@ import com.infomaniak.mail.databinding.BottomSheetScheduleSendBinding
 import com.infomaniak.mail.ui.alertDialogs.SelectDateAndTimeForScheduledDraftDialog.Companion.MIN_SCHEDULE_DELAY_MINUTES
 import com.infomaniak.mail.ui.main.thread.actions.ActionItemView
 import com.infomaniak.mail.ui.main.thread.actions.ActionItemView.TrailingContent
-import com.infomaniak.mail.utils.MyKSuiteUiUtils.openMyKSuiteUpgradeBottomSheet
 import com.infomaniak.mail.utils.date.DateFormatUtils.dayOfWeekDateWithoutYear
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Date
@@ -94,7 +95,7 @@ class ScheduleSendBottomSheetDialog @Inject constructor() : BottomSheetDialogFra
 
         setOnClickListener {
             if (navigationArgs.isCurrentMailboxFree) {
-                openMyKSuiteUpgradeBottomSheet(findNavController())
+                findNavController().openMyKSuiteUpgradeBottomSheet(KSuiteApp.Mail)
             } else {
                 setBackNavigationResult(OPEN_DATE_AND_TIME_SCHEDULE_DIALOG, true)
             }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/mailbox/SignatureSettingFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/mailbox/SignatureSettingFragment.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
 import com.infomaniak.lib.core.utils.UtilsUi.openUrl
 import com.infomaniak.lib.core.utils.safeBinding
@@ -85,7 +86,7 @@ class SignatureSettingFragment : Fragment() {
 
     private fun onSignatureClicked(signature: Signature, shouldBlockDummySignature: Boolean) = with(signatureSettingViewModel) {
         if (signature.isDummy && shouldBlockDummySignature) {
-            openMyKSuiteUpgradeBottomSheet()
+            openMyKSuiteUpgradeBottomSheet(findNavController())
             return@with
         }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/mailbox/SignatureSettingFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/mailbox/SignatureSettingFragment.kt
@@ -24,6 +24,8 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.infomaniak.core.myksuite.ui.screens.KSuiteApp
+import com.infomaniak.core.myksuite.ui.utils.MyKSuiteUiUtils.openMyKSuiteUpgradeBottomSheet
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
 import com.infomaniak.lib.core.utils.UtilsUi.openUrl
 import com.infomaniak.lib.core.utils.safeBinding
@@ -31,7 +33,6 @@ import com.infomaniak.mail.BuildConfig
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.signature.Signature
 import com.infomaniak.mail.databinding.FragmentSignatureSettingBinding
-import com.infomaniak.mail.utils.MyKSuiteUiUtils.openMyKSuiteUpgradeBottomSheet
 import com.infomaniak.mail.utils.extensions.setSystemBarsColors
 import dagger.hilt.android.AndroidEntryPoint
 import io.realm.kotlin.ext.copyFromRealm
@@ -86,7 +87,7 @@ class SignatureSettingFragment : Fragment() {
 
     private fun onSignatureClicked(signature: Signature, shouldBlockDummySignature: Boolean) = with(signatureSettingViewModel) {
         if (signature.isDummy && shouldBlockDummySignature) {
-            openMyKSuiteUpgradeBottomSheet(findNavController())
+            findNavController().openMyKSuiteUpgradeBottomSheet(KSuiteApp.Mail)
             return@with
         }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/LogoutUser.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/LogoutUser.kt
@@ -52,7 +52,7 @@ class LogoutUser @Inject constructor(
 
         user.logoutToken()
         AccountUtils.removeUser(user)
-        MyKSuiteDataUtils.deleteKSuiteData(user.id)
+        MyKSuiteDataUtils.deleteData(user.id)
         RealmDatabase.removeUserData(appContext, user.id)
         mailboxController.deleteUserMailboxes(user.id)
         localSettings.removeRegisteredFirebaseUser(userId = user.id)

--- a/app/src/main/java/com/infomaniak/mail/utils/MyKSuiteUiUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/MyKSuiteUiUtils.kt
@@ -18,28 +18,16 @@
 package com.infomaniak.mail.utils
 
 import android.content.Context
-import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
-import androidx.navigation.NavController
-import androidx.navigation.NavDeepLinkRequest
 import com.infomaniak.core.myksuite.ui.data.MyKSuiteData
-import com.infomaniak.core.myksuite.ui.screens.KSuiteApp
 import com.infomaniak.core.myksuite.ui.screens.MyKSuiteDashboardScreenData
 import com.infomaniak.core.myksuite.ui.screens.components.KSuiteProductsWithQuotas
 import com.infomaniak.core.myksuite.ui.views.MyKSuiteDashboardFragmentArgs
-import com.infomaniak.core.myksuite.ui.views.MyKSuiteUpgradeBottomSheetDialog
 import com.infomaniak.lib.core.utils.FormatterFileSize.formatShortFileSize
 import com.infomaniak.mail.R
 import com.infomaniak.mail.utils.extensions.animatedNavigation
 
 object MyKSuiteUiUtils {
-
-    fun openMyKSuiteUpgradeBottomSheet(navController: NavController) {
-        NavDeepLinkRequest.Builder
-            .fromUri(MyKSuiteUpgradeBottomSheetDialog.getDeeplink(KSuiteApp.Mail).toUri())
-            .build()
-            .also(navController::navigate)
-    }
 
     fun Fragment.openMyKSuiteDashboard(myKSuiteData: MyKSuiteData) {
         val args = MyKSuiteDashboardFragmentArgs(dashboardData = getDashboardData(requireContext(), myKSuiteData))

--- a/app/src/main/java/com/infomaniak/mail/utils/MyKSuiteUiUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/MyKSuiteUiUtils.kt
@@ -18,29 +18,27 @@
 package com.infomaniak.mail.utils
 
 import android.content.Context
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
+import androidx.navigation.NavDeepLinkRequest
 import com.infomaniak.core.myksuite.ui.data.MyKSuiteData
 import com.infomaniak.core.myksuite.ui.screens.KSuiteApp
 import com.infomaniak.core.myksuite.ui.screens.MyKSuiteDashboardScreenData
 import com.infomaniak.core.myksuite.ui.screens.components.KSuiteProductsWithQuotas
 import com.infomaniak.core.myksuite.ui.views.MyKSuiteDashboardFragmentArgs
-import com.infomaniak.core.myksuite.ui.views.MyKSuiteUpgradeBottomSheetDialogArgs
+import com.infomaniak.core.myksuite.ui.views.MyKSuiteUpgradeBottomSheetDialog
 import com.infomaniak.lib.core.utils.FormatterFileSize.formatShortFileSize
-import com.infomaniak.lib.core.utils.safeNavigate
 import com.infomaniak.mail.R
 import com.infomaniak.mail.utils.extensions.animatedNavigation
 
 object MyKSuiteUiUtils {
 
-    fun Fragment.openMyKSuiteUpgradeBottomSheet(currentClassName: String? = null) {
-        val args = MyKSuiteUpgradeBottomSheetDialogArgs(kSuiteApp = KSuiteApp.Mail)
-        safeNavigate(R.id.myKSuiteUpgradeBottomSheet, args.toBundle(), currentClassName = currentClassName)
-    }
-
     fun openMyKSuiteUpgradeBottomSheet(navController: NavController) {
-        val args = MyKSuiteUpgradeBottomSheetDialogArgs(kSuiteApp = KSuiteApp.Mail)
-        navController.navigate(R.id.myKSuiteUpgradeBottomSheet, args.toBundle())
+        NavDeepLinkRequest.Builder
+            .fromUri(MyKSuiteUpgradeBottomSheetDialog.getDeeplink(KSuiteApp.Mail).toUri())
+            .build()
+            .also(navController::navigate)
     }
 
     fun Fragment.openMyKSuiteDashboard(myKSuiteData: MyKSuiteData) {

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -21,6 +21,8 @@
     android:id="@+id/main_navigation"
     app:startDestination="@id/threadListFragment">
 
+    <include app:graph="@navigation/my_ksuite_navigation" />
+
     <fragment
         android:id="@+id/threadListFragment"
         android:name="com.infomaniak.mail.ui.main.folder.ThreadListFragment"
@@ -681,15 +683,6 @@
         android:name="com.infomaniak.mail.ui.bottomSheetDialogs.AccountBottomSheetDialog"
         android:label="AccountBottomSheetDialog"
         tools:layout="@layout/bottom_sheet_account" />
-
-    <dialog
-        android:id="@+id/myKSuiteUpgradeBottomSheet"
-        android:name="com.infomaniak.core.myksuite.ui.views.MyKSuiteUpgradeBottomSheetDialog"
-        android:label="MyKSuiteUpgradeBottomSheet">
-        <argument
-            android:name="kSuiteApp"
-            app:argType="com.infomaniak.core.myksuite.ui.screens.KSuiteApp" />
-    </dialog>
 
     <fragment
         android:id="@+id/myKSuiteDashboardFragment"

--- a/app/src/main/res/navigation/new_message_navigation.xml
+++ b/app/src/main/res/navigation/new_message_navigation.xml
@@ -21,6 +21,8 @@
     android:id="@+id/new_message_navigation"
     app:startDestination="@id/newMessageFragment">
 
+    <include app:graph="@navigation/my_ksuite_navigation" />
+
     <fragment
         android:id="@+id/newMessageFragment"
         android:name="com.infomaniak.mail.ui.newMessage.NewMessageFragment"
@@ -93,14 +95,5 @@
             android:name="isCurrentMailboxFree"
             android:defaultValue="true"
             app:argType="boolean" />
-    </dialog>
-
-    <dialog
-        android:id="@+id/myKSuiteUpgradeBottomSheet"
-        android:name="com.infomaniak.core.myksuite.ui.views.MyKSuiteUpgradeBottomSheetDialog"
-        android:label="MyKSuiteUpgradeBottomSheet">
-        <argument
-            android:name="kSuiteApp"
-            app:argType="com.infomaniak.core.myksuite.ui.screens.KSuiteApp" />
     </dialog>
 </navigation>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 androidGradlePlugin = "8.7.2"
 coilSvg = "2.7.0"
-compose = "1.7.6"
+compose = "1.7.8"
 dotsindicator = "5.1.0"
 dragdropswipeRecyclerview = "1.2.0"
 firebaseMessagingKtx = "24.1.0"


### PR DESCRIPTION
This fix the Release build compilation error by navigating by deeplink from the App to the module's view.
This is needed because in release, the generated args class will be generate 2 times so it will crash compilation. 
And we can't directly use ID navigation as the id of the module's view will not be available from the App.

Source: https://developer.android.com/guide/navigation/integrations/multi-module#across