### PR TITLE
refactor: Decouple impacted folder ids computation in thread algo deleted uids handling

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -467,8 +467,7 @@ class RefreshController @Inject constructor(
 
             impactedFolders.add(thread.folderId)
 
-            val numberOfMessagesInFolder = thread.messages.count { it.folderId == thread.folderId }
-            if (numberOfMessagesInFolder == 0) {
+            if (thread.getNumberOfMessagesInFolder() == 0) {
                 delete(thread)
             } else {
                 thread.recomputeThread(realm = this)
@@ -477,6 +476,8 @@ class RefreshController @Inject constructor(
 
         return impactedFolders
     }
+
+    private fun Thread.getNumberOfMessagesInFolder() = messages.count { message -> message.folderId == folderId }
     //endregion
 
     //region Updated Messages

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -452,7 +452,7 @@ class RefreshController @Inject constructor(
 
             val message = MessageController.getMessage(uid = shortUid.toLongUid(folderId), realm = this) ?: return@forEach
 
-            for (thread in message.threads.asReversed()) {
+            message.threads.forEach { thread ->
                 scope.ensureActive()
 
                 val isSuccess = thread.messages.remove(message)

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -456,30 +456,23 @@ class RefreshController @Inject constructor(
                 scope.ensureActive()
 
                 val isSuccess = thread.messages.remove(message)
-                val numberOfMessagesInFolder = thread.messages.count { it.folderId == thread.folderId }
-
-                // We need to save this value because the Thread could be deleted before we use this `folderId`.
-                val threadFolderId = thread.folderId
-
-                if (numberOfMessagesInFolder == 0) {
-                    threads.removeIf { it.uid == thread.uid }
-                    delete(thread)
-                } else if (isSuccess) {
-                    threads += thread
-                } else {
-                    continue
-                }
-
-                impactedFolders.add(threadFolderId)
+                if (isSuccess) threads += thread
             }
 
             MessageController.deleteMessage(appContext, mailbox, message, realm = this)
         }
 
-        threads.forEach {
+        threads.forEach { thread ->
             scope.ensureActive()
 
-            it.recomputeThread(realm = this)
+            impactedFolders.add(thread.folderId)
+
+            val numberOfMessagesInFolder = thread.messages.count { it.folderId == thread.folderId }
+            if (numberOfMessagesInFolder == 0) {
+                delete(thread)
+            } else {
+                thread.recomputeThread(realm = this)
+            }
         }
 
         return impactedFolders


### PR DESCRIPTION
This will be useful when abstracting logic for the snooze feature