### PR TITLE
refactor: Move `goToPlayStore()` from Legacy to new Core

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/bottomSheetDialogs/UpdateAvailableBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/bottomSheetDialogs/UpdateAvailableBottomSheetDialog.kt
@@ -21,9 +21,9 @@ import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
+import com.infomaniak.core.extensions.goToPlayStore
 import com.infomaniak.lib.core.utils.context
 import com.infomaniak.lib.core.utils.getAppName
-import com.infomaniak.lib.core.utils.goToPlayStore
 import com.infomaniak.lib.stores.StoresSettingsRepository
 import com.infomaniak.lib.stores.StoresViewModel
 import com.infomaniak.mail.MatomoMail.DISCOVER_LATER

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -48,10 +48,14 @@ import com.ernestoyaquello.dragdropswiperecyclerview.listener.OnItemSwipeListene
 import com.ernestoyaquello.dragdropswiperecyclerview.listener.OnListScrollListener
 import com.ernestoyaquello.dragdropswiperecyclerview.listener.OnListScrollListener.ScrollDirection
 import com.ernestoyaquello.dragdropswiperecyclerview.listener.OnListScrollListener.ScrollState
+import com.infomaniak.core.extensions.goToPlayStore
 import com.infomaniak.core.utils.isToday
 import com.infomaniak.lib.core.MatomoCore.TrackerAction
-import com.infomaniak.lib.core.utils.*
+import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
+import com.infomaniak.lib.core.utils.context
+import com.infomaniak.lib.core.utils.safeNavigate
+import com.infomaniak.lib.core.utils.setPaddingRelative
 import com.infomaniak.lib.stores.updatemanagers.InAppUpdateManager
 import com.infomaniak.mail.MatomoMail.trackEvent
 import com.infomaniak.mail.MatomoMail.trackMenuDrawerEvent

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/DownloadMessagesProgressDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/DownloadMessagesProgressDialog.kt
@@ -24,7 +24,7 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.infomaniak.lib.core.utils.goToPlayStore
+import com.infomaniak.core.extensions.goToPlayStore
 import com.infomaniak.lib.core.utils.setBackNavigationResult
 import com.infomaniak.mail.utils.LocalStorageUtils.clearEmlCacheDir
 import com.infomaniak.mail.utils.SaveOnKDriveUtils.DRIVE_PACKAGE

--- a/app/src/main/java/com/infomaniak/mail/ui/sync/SyncConfigureFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/sync/SyncConfigureFragment.kt
@@ -28,9 +28,9 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import com.infomaniak.core.extensions.goToPlayStore
 import com.infomaniak.lib.core.MatomoCore.TrackerAction
 import com.infomaniak.lib.core.utils.context
-import com.infomaniak.lib.core.utils.goToPlayStore
 import com.infomaniak.lib.core.utils.safeBinding
 import com.infomaniak.mail.MatomoMail.trackSyncAutoConfigEvent
 import com.infomaniak.mail.R

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/AttachmentExtensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/AttachmentExtensions.kt
@@ -20,15 +20,14 @@ package com.infomaniak.mail.utils.extensions
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.os.Bundle
 import android.provider.MediaStore.Files.FileColumns
 import androidx.core.content.FileProvider
+import com.infomaniak.core.extensions.goToPlayStore
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.networking.HttpUtils
 import com.infomaniak.lib.core.utils.SentryLog
-import com.infomaniak.lib.core.utils.goToPlayStore
 import com.infomaniak.lib.core.utils.hasSupportedApplications
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.api.ApiRoutes
@@ -46,7 +45,6 @@ import com.infomaniak.mail.utils.WorkerUtils.UploadMissingLocalFileException
 import com.infomaniak.mail.utils.extensions.AttachmentExtensions.AttachmentIntentType.OPEN_WITH
 import com.infomaniak.mail.utils.extensions.AttachmentExtensions.AttachmentIntentType.SAVE_TO_DRIVE
 import io.realm.kotlin.Realm
-import io.sentry.Sentry
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.asRequestBody


### PR DESCRIPTION
Depends on https://github.com/Infomaniak/android-core/pull/302