### PR TITLE
feat: Filter snooze in folders

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -20,6 +20,8 @@ package com.infomaniak.mail.data.cache.mailboxContent
 import com.infomaniak.mail.data.models.thread.Thread
 import io.realm.kotlin.TypedRealm
 
+val defaultRefreshStrategy = object : DefaultRefreshStrategy {}
+
 val inboxRefreshStrategy = object : DefaultRefreshStrategy {
     override fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread> {
         return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = false, realm = realm)

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -17,7 +17,9 @@
  */
 package com.infomaniak.mail.data.cache.mailboxContent
 
+import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
+import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.TypedRealm
 
 val defaultRefreshStrategy = object : DefaultRefreshStrategy {}
@@ -33,5 +35,11 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
         return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = true, realm = realm)
     }
 
-    override fun shouldForceUpdateMessagesWhenAdded(): Boolean = true
+    override fun updateExistingMessageWhenAdded(remoteMessage: Message, realm: MutableRealm) {
+        MessageController.updateMessage(remoteMessage.uid, realm = realm) { localMessage ->
+            localMessage?.snoozeState = remoteMessage.snoozeState
+            localMessage?.snoozeEndDate = remoteMessage.snoozeEndDate
+            localMessage?.snoozeAction = remoteMessage.snoozeAction
+        }
+    }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -1,0 +1,33 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.cache.mailboxContent
+
+import com.infomaniak.mail.data.models.thread.Thread
+import io.realm.kotlin.TypedRealm
+
+val inboxRefreshStrategy = object : DefaultRefreshStrategy {
+    override fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread> {
+        return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = false, realm = realm)
+    }
+}
+
+val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
+    override fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread> {
+        return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = true, realm = realm)
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -30,4 +30,6 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
     override fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread> {
         return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = true, realm = realm)
     }
+
+    override fun shouldForceUpdateMessagesWhenAdded(): Boolean = true
 }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -545,11 +545,6 @@ class RefreshController @Inject constructor(
         return impactedThreadsUnmanaged
     }
 
-    private fun MutableRealm.updateExistingMessage(remoteMessage: Message) {
-        val isMessageAlreadyInRealm = MessageController.getMessage(remoteMessage.uid, realm = this) != null
-        if (isMessageAlreadyInRealm) MessageController.upsertMessage(remoteMessage, realm = this)
-    }
-
     private fun initMessageLocalValues(remoteMessage: Message, folder: Folder) {
         remoteMessage.initLocalValues(
             MessageInitialState(
@@ -772,8 +767,8 @@ class RefreshController @Inject constructor(
     }
     //endregion
 
-    // SCHEDULED_DRAFTS and SNOOZED need to be refreshed often because the folders only appear in the menu folder when there is at
-    // least one email in it.
+    // SCHEDULED_DRAFTS and SNOOZED need to be refreshed often because these folders
+    // only appear in the MenuDrawer when there is at least 1 email in it.
     private val FOLDER_ROLES_TO_REFRESH_TOGETHER = setOf(
         FolderRole.INBOX,
         FolderRole.SENT,

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -764,11 +764,14 @@ class RefreshController @Inject constructor(
     }
     //endregion
 
+    // SCHEDULED_DRAFTS and SNOOZED need to be refreshed often because the folders only appear in the menu folder when there is at
+    // least one email in it.
     private val FOLDER_ROLES_TO_REFRESH_TOGETHER = setOf(
         FolderRole.INBOX,
         FolderRole.SENT,
         FolderRole.DRAFT,
         FolderRole.SCHEDULED_DRAFTS,
+        FolderRole.SNOOZED,
     )
 
     enum class RefreshMode {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -329,7 +329,11 @@ class RefreshController @Inject constructor(
         var inboxUnreadCount: Int? = null
         FolderController.updateFolder(folder.id, realm = this) { mutableRealm, it ->
 
-            val allCurrentFolderThreads = ThreadController.getThreadsByFolderId(it.id, realm = mutableRealm)
+            val allCurrentFolderThreads = when (folder.role) {
+                FolderRole.INBOX -> ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = false, realm = mutableRealm)
+                FolderRole.SNOOZED -> ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = true, realm = mutableRealm)
+                else -> ThreadController.getThreadsByFolderId(it.id, realm = mutableRealm)
+            }
             it.threads.replaceContent(list = allCurrentFolderThreads)
 
             inboxUnreadCount = updateFoldersUnreadCount(

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -329,11 +329,7 @@ class RefreshController @Inject constructor(
         var inboxUnreadCount: Int? = null
         FolderController.updateFolder(folder.id, realm = this) { mutableRealm, it ->
 
-            val allCurrentFolderThreads = when (folder.role) {
-                FolderRole.INBOX -> ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = false, realm = mutableRealm)
-                FolderRole.SNOOZED -> ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = true, realm = mutableRealm)
-                else -> ThreadController.getThreadsByFolderId(it.id, realm = mutableRealm)
-            }
+            val allCurrentFolderThreads = folder.threadQueryStrategy(folder.role, folder.id).applyStrategy(mutableRealm)
             it.threads.replaceContent(list = allCurrentFolderThreads)
 
             inboxUnreadCount = updateFoldersUnreadCount(

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -512,7 +512,7 @@ class RefreshController @Inject constructor(
 
         val impactedThreadsManaged = mutableSetOf<Thread>()
         val addedMessagesUids = mutableListOf<Int>()
-        val shouldForceUpdateMessages = folder.refreshStrategy().shouldForceUpdateMessagesWhenAdded()
+        val refreshStrategy = folder.refreshStrategy()
 
         remoteMessages.forEach { remoteMessage ->
             scope.ensureActive()
@@ -521,7 +521,7 @@ class RefreshController @Inject constructor(
 
             addedMessagesUids.add(remoteMessage.shortUid)
 
-            if (shouldForceUpdateMessages) updateExistingMessage(remoteMessage)
+            refreshStrategy.updateExistingMessageWhenAdded(remoteMessage, realm = this)
 
             val newThread = if (isConversationMode) {
                 handleAddedMessage(scope, remoteMessage, impactedThreadsManaged)

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -329,7 +329,7 @@ class RefreshController @Inject constructor(
         var inboxUnreadCount: Int? = null
         FolderController.updateFolder(folder.id, realm = this) { mutableRealm, it ->
 
-            val allCurrentFolderThreads = folder.threadQueryStrategy(folder.role, folder.id).applyStrategy(mutableRealm)
+            val allCurrentFolderThreads = folder.refreshStrategy().queryFolderThreads(folder.id, mutableRealm)
             it.threads.replaceContent(list = allCurrentFolderThreads)
 
             inboxUnreadCount = updateFoldersUnreadCount(

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -1,0 +1,32 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.cache.mailboxContent
+
+import com.infomaniak.mail.data.models.thread.Thread
+import io.realm.kotlin.TypedRealm
+
+interface RefreshStrategy {
+    fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread>
+    fun shouldForceUpdateMessagesWhenAdded(): Boolean
+}
+
+interface DefaultRefreshStrategy : RefreshStrategy {
+    override fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread> {
+        return ThreadController.getThreadsByFolderId(folderId, realm)
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -17,12 +17,14 @@
  */
 package com.infomaniak.mail.data.cache.mailboxContent
 
+import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
+import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.TypedRealm
 
 interface RefreshStrategy {
     fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread>
-    fun shouldForceUpdateMessagesWhenAdded(): Boolean
+    fun updateExistingMessageWhenAdded(remoteMessage: Message, realm: MutableRealm)
 }
 
 interface DefaultRefreshStrategy : RefreshStrategy {
@@ -30,5 +32,5 @@ interface DefaultRefreshStrategy : RefreshStrategy {
         return ThreadController.getThreadsByFolderId(folderId, realm)
     }
 
-    override fun shouldForceUpdateMessagesWhenAdded(): Boolean = false
+    override fun updateExistingMessageWhenAdded(remoteMessage: Message, realm: MutableRealm) = Unit
 }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -29,4 +29,6 @@ interface DefaultRefreshStrategy : RefreshStrategy {
     override fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread> {
         return ThreadController.getThreadsByFolderId(folderId, realm)
     }
+
+    override fun shouldForceUpdateMessagesWhenAdded(): Boolean = false
 }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -248,8 +248,8 @@ class ThreadController @Inject constructor(
             withSnooze: Boolean,
             realm: TypedRealm,
         ): RealmQuery<Thread> {
-            // Checking for snoozeEndDate and snoozeAction on top of _snoozeState mimics the behavior on the web and helps avoid
-            // displaying threads that are in an incoherent state on the API
+            // Checking for snoozeEndDate and snoozeAction on top of _snoozeState mimics the webmail's behavior
+            // and helps to avoid displaying threads that are in an incoherent state on the API
             val isSnoozedState = "_snoozeState == $1 AND snoozeEndDate != null AND snoozeAction != null"
             val snoozeQuery = if (withSnooze) isSnoozedState else "NOT($isSnoozedState)"
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -248,14 +248,12 @@ class ThreadController @Inject constructor(
             withSnooze: Boolean,
             realm: TypedRealm,
         ): RealmQuery<Thread> {
-            val snoozeState = SnoozeState.Snoozed.apiValue
-
             // Checking for snoozeEndDate and snoozeAction on top of _snoozeState mimics the behavior on the web and helps avoid
             // displaying threads that are in an incoherent state on the API
             val isSnoozedState = "_snoozeState == $1 AND snoozeEndDate != null AND snoozeAction != null"
             val snoozeQuery = if (withSnooze) isSnoozedState else "NOT($isSnoozedState)"
 
-            return realm.query<Thread>("${Thread::folderId.name} == $0 AND $snoozeQuery", folderId, snoozeState)
+            return realm.query<Thread>("${Thread::folderId.name} == $0 AND $snoozeQuery", folderId, SnoozeState.Snoozed.apiValue)
         }
 
         private fun getThreadQuery(uid: String, realm: TypedRealm): RealmSingleQuery<Thread> {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -255,11 +255,7 @@ class ThreadController @Inject constructor(
             val isSnoozedState = "_snoozeState == $1 AND snoozeEndDate != null AND snoozeAction != null"
             val snoozeQuery = if (withSnooze) isSnoozedState else "NOT($isSnoozedState)"
 
-            return realm.query<Thread>(
-                "${Thread::folderId.name} == $0 AND $snoozeQuery",
-                folderId,
-                snoozeState,
-            )
+            return realm.query<Thread>("${Thread::folderId.name} == $0 AND $snoozeQuery", folderId, snoozeState)
         }
 
         private fun getThreadQuery(uid: String, realm: TypedRealm): RealmSingleQuery<Thread> {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -249,10 +249,18 @@ class ThreadController @Inject constructor(
             realm: TypedRealm,
         ): RealmQuery<Thread> {
             val snoozeState = SnoozeState.Snoozed.apiValue
+
             val collectionOperator = if (withSnooze) "ANY" else "NONE"
+            val nullOperator = if (withSnooze) "!=" else "=="
+
+            val isSnoozedState = "$collectionOperator messages._snoozeState == $1"
+
+            // TODO: Use the thread snooze state values instead of ANY/NONE on the messages
+            // This mimics the behavior on the web and help avoid displaying threads that are in an incoherent state on the API
+            val hasCorrectMetadata = "messages.snoozeEndDate $nullOperator null AND messages.snoozeAction $nullOperator null"
 
             return realm.query<Thread>(
-                "${Thread::folderId.name} == $0 AND $collectionOperator messages._snoozeState == $1",
+                "${Thread::folderId.name} == $0 AND $isSnoozedState AND $hasCorrectMetadata",
                 folderId,
                 snoozeState,
             )

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -250,17 +250,13 @@ class ThreadController @Inject constructor(
         ): RealmQuery<Thread> {
             val snoozeState = SnoozeState.Snoozed.apiValue
 
-            val collectionOperator = if (withSnooze) "ANY" else "NONE"
-            val nullOperator = if (withSnooze) "!=" else "=="
-
-            val isSnoozedState = "$collectionOperator messages._snoozeState == $1"
-
-            // TODO: Use the thread snooze state values instead of ANY/NONE on the messages
-            // This mimics the behavior on the web and help avoid displaying threads that are in an incoherent state on the API
-            val hasCorrectMetadata = "messages.snoozeEndDate $nullOperator null AND messages.snoozeAction $nullOperator null"
+            // Checking for snoozeEndDate and snoozeAction on top of _snoozeState mimics the behavior on the web and helps avoid
+            // displaying threads that are in an incoherent state on the API
+            val isSnoozedState = "_snoozeState == $1 AND snoozeEndDate != null AND snoozeAction != null"
+            val snoozeQuery = if (withSnooze) isSnoozedState else "NOT($isSnoozedState)"
 
             return realm.query<Thread>(
-                "${Thread::folderId.name} == $0 AND $isSnoozedState AND $hasCorrectMetadata",
+                "${Thread::folderId.name} == $0 AND $snoozeQuery",
                 folderId,
                 snoozeState,
             )

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -244,8 +244,8 @@ class ThreadController @Inject constructor(
         }
 
         private fun getThreadsWithSnoozeFilterQuery(
-            withSnooze: Boolean,
             folderId: String,
+            withSnooze: Boolean,
             realm: TypedRealm,
         ): RealmQuery<Thread> {
             val snoozeState = SnoozeState.Snoozed.apiValue
@@ -296,7 +296,7 @@ class ThreadController @Inject constructor(
 
         fun getInboxThreadsWithSnoozeFilter(withSnooze: Boolean, realm: TypedRealm): List<Thread> {
             val inboxId = FolderController.getFolder(FolderRole.INBOX, realm)?.id ?: return emptyList()
-            return getThreadsWithSnoozeFilterQuery(withSnooze, folderId = inboxId, realm).find()
+            return getThreadsWithSnoozeFilterQuery(inboxId, withSnooze, realm).find()
         }
         //endregion
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -149,7 +149,7 @@ class Folder : RealmObject, Cloneable {
     fun refreshStrategy(): RefreshStrategy = when (role) {
         FolderRole.INBOX -> inboxRefreshStrategy
         FolderRole.SNOOZED -> snoozeRefreshStrategy
-        else -> object : DefaultRefreshStrategy {}
+        else -> defaultRefreshStrategy
     }
 
     fun getLocalizedName(context: Context): String {

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -25,8 +25,7 @@ import androidx.annotation.StringRes
 import com.infomaniak.lib.core.utils.Utils.enumValueOfOrNull
 import com.infomaniak.lib.core.utils.removeAccents
 import com.infomaniak.mail.R
-import com.infomaniak.mail.data.cache.mailboxContent.MessageController
-import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
+import com.infomaniak.mail.data.cache.mailboxContent.*
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.utils.SentryDebug
@@ -147,14 +146,10 @@ class Folder : RealmObject, Cloneable {
 
     fun messages(realm: TypedRealm): List<Message> = MessageController.getMessagesByFolderId(id, realm)
 
-    fun threadQueryStrategy(folderRole: FolderRole?, folderId: String): ThreadQueryStrategy {
-        return ThreadQueryStrategy { realm ->
-            when (folderRole) {
-                FolderRole.INBOX -> ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = false, realm = realm)
-                FolderRole.SNOOZED -> ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = true, realm = realm)
-                else -> ThreadController.getThreadsByFolderId(folderId, realm = realm)
-            }
-        }
+    fun refreshStrategy(): RefreshStrategy = when (role) {
+        FolderRole.INBOX -> inboxRefreshStrategy
+        FolderRole.SNOOZED -> snoozeRefreshStrategy
+        else -> object : DefaultRefreshStrategy {}
     }
 
     fun getLocalizedName(context: Context): String {
@@ -186,10 +181,6 @@ class Folder : RealmObject, Cloneable {
         SPAM(R.string.spamFolder, R.drawable.ic_spam, 3, "spamFolder"),
         TRASH(R.string.trashFolder, R.drawable.ic_bin, 2, "trashFolder"),
         ARCHIVE(R.string.archiveFolder, R.drawable.ic_archive_folder, 1, "archiveFolder"),
-    }
-
-    class ThreadQueryStrategy(private val strategy: (TypedRealm) -> List<Thread>) {
-        fun applyStrategy(realm: TypedRealm): List<Thread> = strategy(realm)
     }
 
     companion object {


### PR DESCRIPTION
Queries different threads in realm to choose what threads will be part of the snooze folder and the inbox folder. To do so, I introduce a RefreshStrategy so multiple folders can define different logics for the same step of the refresh algorithm.

This will also help us easily keep track of what bit of logic is different for the snooze folder if the API ever sends us more normal data for the snooze folder

Depends on #2220 