### PR TITLE
feat: Introduce custom logic to handle deleted uids in the case of the snooze folder

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -60,14 +60,12 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
         context: Context,
         mailbox: Mailbox,
         realm: MutableRealm,
-    ): Collection<Thread> {
+    ) {
         managedMessage.apply {
             snoozeState = null
             snoozeEndDate = null
             snoozeAction = null
         }
-
-        return managedMessage.threads
     }
 
     override fun addFolderToImpactedFolders(folderId: String, impactedFolders: ImpactedFolders) {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -40,6 +40,11 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
         return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = true, realm = realm)
     }
 
+    override fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message? {
+        val inboxId = FolderController.getFolder(Folder.FolderRole.INBOX, realm)?.id ?: return null
+        return super.getMessageFromShortUid(shortUid, inboxId, realm)
+    }
+
     override fun processDeletedMessage(
         scope: CoroutineScope,
         managedMessage: Message,

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -35,6 +35,11 @@ val inboxRefreshStrategy = object : DefaultRefreshStrategy {
     }
 
     override fun otherFolderRolesToQueryThreads(): List<Folder.FolderRole> = listOf(Folder.FolderRole.SNOOZED)
+
+    override fun addFolderToImpactedFolders(folderId: String, impactedFolders: ImpactedFolders) {
+        impactedFolders += folderId
+        impactedFolders += Folder.FolderRole.SNOOZED
+    }
 }
 
 val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
@@ -65,8 +70,9 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
         return managedMessage.threads
     }
 
-    override fun extraFolderIdsThatNeedToRefreshUnreadOnDeletedUid(realm: TypedRealm): List<String> {
-        return FolderController.getFolder(Folder.FolderRole.SNOOZED, realm)?.let { listOf(it.id) } ?: emptyList()
+    override fun addFolderToImpactedFolders(folderId: String, impactedFolders: ImpactedFolders) {
+        impactedFolders += folderId
+        impactedFolders += Folder.FolderRole.INBOX
     }
 
     override fun processDeletedThread(thread: Thread, realm: MutableRealm) = thread.recomputeThread()

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -42,27 +42,18 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
 
     override fun processDeletedMessage(
         scope: CoroutineScope,
-        message: Message,
+        managedMessage: Message,
         context: Context,
         mailbox: Mailbox,
         realm: MutableRealm,
     ): Collection<Thread> {
-        var successfullyUpdated = true
-
-        MessageController.updateMessage(message.uid, realm) {
-            if (it == null) {
-                successfullyUpdated = false
-                return@updateMessage
-            }
-
-            it.apply {
-                snoozeState = null
-                snoozeEndDate = null
-                snoozeAction = null
-            }
+        managedMessage.apply {
+            snoozeState = null
+            snoozeEndDate = null
+            snoozeAction = null
         }
 
-        return if (successfullyUpdated) message.threads else emptyList()
+        return managedMessage.threads
     }
 
     override fun extraFolderIdsThatNeedToRefreshUnreadOnDelete(realm: TypedRealm): List<String> {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -33,12 +33,16 @@ val inboxRefreshStrategy = object : DefaultRefreshStrategy {
     override fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread> {
         return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = false, realm = realm)
     }
+
+    override fun otherFolderRolesToQueryThreads(): List<Folder.FolderRole> = listOf(Folder.FolderRole.SNOOZED)
 }
 
 val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
     override fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread> {
         return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = true, realm = realm)
     }
+
+    override fun otherFolderRolesToQueryThreads(): List<Folder.FolderRole> = listOf(Folder.FolderRole.INBOX)
 
     override fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message? {
         val inboxId = FolderController.getFolder(Folder.FolderRole.INBOX, realm)?.id ?: return null

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -65,9 +65,8 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
         return FolderController.getFolder(Folder.FolderRole.SNOOZED, realm)?.let { listOf(it.id) } ?: emptyList()
     }
 
-    override fun processDeletedThread(thread: Thread, realm: MutableRealm) {
-        thread.recomputeThread()
-    }
+    override fun processDeletedThread(thread: Thread, realm: MutableRealm) = thread.recomputeThread()
+    override fun queryFolderThreadsOnDeletedUid(): Boolean = true
 
     /**
      * In the case of the Snooze refresh strategy, the Message could already exist (because it comes from the INBOX).

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -61,12 +61,12 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
         return managedMessage.threads
     }
 
-    override fun extraFolderIdsThatNeedToRefreshUnreadOnDelete(realm: TypedRealm): List<String> {
+    override fun extraFolderIdsThatNeedToRefreshUnreadOnDeletedUid(realm: TypedRealm): List<String> {
         return FolderController.getFolder(Folder.FolderRole.SNOOZED, realm)?.let { listOf(it.id) } ?: emptyList()
     }
 
     override fun processDeletedThread(thread: Thread, realm: MutableRealm) = thread.recomputeThread()
-    override fun queryFolderThreadsOnDeletedUid(): Boolean = true
+    override fun shouldQueryFolderThreadsOnDeletedUid(): Boolean = true
 
     /**
      * In the case of the Snooze refresh strategy, the Message could already exist (because it comes from the INBOX).

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -224,10 +224,6 @@ class FolderController @Inject constructor(
             realm.write { getFolder(id, realm = this)?.let { onUpdate(this, it) } }
         }
 
-        fun updateFolder(id: String, realm: MutableRealm, onUpdate: (Folder) -> Unit) {
-            getFolder(id, realm = realm)?.let { onUpdate(it) }
-        }
-
         suspend fun updateFolderAndChildren(id: String, realm: Realm, onUpdate: (Folder) -> Unit) {
 
             tailrec fun updateChildrenRecursively(inputList: MutableList<Folder>) {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2025 Infomaniak Network SA
+ * Copyright (C) 2022-2024 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -222,6 +222,10 @@ class FolderController @Inject constructor(
         //region Edit data
         suspend fun updateFolder(id: String, realm: Realm, onUpdate: (MutableRealm, Folder) -> Unit) {
             realm.write { getFolder(id, realm = this)?.let { onUpdate(this, it) } }
+        }
+
+        fun updateFolder(id: String, realm: MutableRealm, onUpdate: (Folder) -> Unit) {
+            getFolder(id, realm = realm)?.let { onUpdate(it) }
         }
 
         suspend fun updateFolderAndChildren(id: String, realm: Realm, onUpdate: (Folder) -> Unit) {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ImpactedFolders.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ImpactedFolders.kt
@@ -42,7 +42,7 @@ data class ImpactedFolders(
      */
     fun getFolderIds(realm: TypedRealm): Set<String> {
         folderRoles.forEach { folderRole ->
-            FolderController.getFolder(folderRole, realm)?.let { folderIds.add(it.id) }
+            FolderController.getFolder(folderRole, realm)?.id?.let(folderIds::add)
         }
 
         return folderIds

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ImpactedFolders.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ImpactedFolders.kt
@@ -1,0 +1,50 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.cache.mailboxContent
+
+import com.infomaniak.mail.data.models.Folder
+import io.realm.kotlin.TypedRealm
+
+data class ImpactedFolders(
+    private val folderIds: MutableSet<String> = mutableSetOf(),
+    private val folderRoles: MutableSet<Folder.FolderRole> = mutableSetOf(),
+) {
+    operator fun plusAssign(folderId: String) {
+        folderIds += folderId
+    }
+
+    operator fun plusAssign(folderRole: Folder.FolderRole) {
+        folderRoles += folderRole
+    }
+
+    operator fun plusAssign(otherTarget: ImpactedFolders) {
+        folderIds += otherTarget.folderIds
+        folderRoles += otherTarget.folderRoles
+    }
+
+    /**
+     * This method makes sure we have no duplicated folders by merging both lists into a single one
+     */
+    fun getFolderIds(realm: TypedRealm): Set<String> {
+        folderRoles.forEach { folderRole ->
+            FolderController.getFolder(folderRole, realm)?.let { folderIds.add(it.id) }
+        }
+
+        return folderIds
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -271,7 +271,7 @@ class RefreshController @Inject constructor(
         var inboxUnreadCount: Int? = null
         write {
             val impactedFoldersIds = mutableSetOf<String>().apply {
-                addAll(handleDeletedUids(scope, activities.deletedShortUids, folder.id))
+                addAll(handleDeletedUids(scope, activities.deletedShortUids, folder.id, folder.refreshStrategy()))
                 addAll(handleUpdatedUids(scope, activities.updatedMessages, folder.id))
             }
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -456,7 +456,7 @@ class RefreshController @Inject constructor(
         }
 
         val impactedFolders = mutableSetOf<String>()
-        impactedFolders += refreshStrategy.extraFolderIdsThatNeedToRefreshUnreadOnDelete(realm = this)
+        impactedFolders += refreshStrategy.extraFolderIdsThatNeedToRefreshUnreadOnDeletedUid(realm = this)
 
         threads.forEach { thread ->
             scope.ensureActive()
@@ -465,7 +465,7 @@ class RefreshController @Inject constructor(
             refreshStrategy.processDeletedThread(thread, realm = this)
         }
 
-        if (shortUids.isNotEmpty() && refreshStrategy.queryFolderThreadsOnDeletedUid()) {
+        if (shortUids.isNotEmpty() && refreshStrategy.shouldQueryFolderThreadsOnDeletedUid()) {
             FolderController.updateFolder(folderId, realm = this) {
                 val allCurrentFolderThreads = refreshStrategy.queryFolderThreads(folderId, realm = this)
                 it.threads.replaceContent(list = allCurrentFolderThreads)

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -465,6 +465,13 @@ class RefreshController @Inject constructor(
             refreshStrategy.processDeletedThread(thread, realm = this)
         }
 
+        if (shortUids.isNotEmpty() && refreshStrategy.queryFolderThreadsOnDeletedUid()) {
+            FolderController.updateFolder(folderId, realm = this) {
+                val allCurrentFolderThreads = refreshStrategy.queryFolderThreads(folderId, realm = this)
+                it.threads.replaceContent(list = allCurrentFolderThreads)
+            }
+        }
+
         return impactedFolders
     }
     //endregion

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -451,7 +451,9 @@ class RefreshController @Inject constructor(
             scope.ensureActive()
 
             val message = currentFolderRefreshStrategy.getMessageFromShortUid(shortUid, folderId, realm = this) ?: return@forEach
-            threads += currentFolderRefreshStrategy.processDeletedMessage(scope, message, appContext, mailbox, realm = this)
+            threads += message.threads
+
+            currentFolderRefreshStrategy.processDeletedMessage(scope, message, appContext, mailbox, realm = this)
         }
 
         val impactedFolders = ImpactedFolders()

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -269,9 +269,10 @@ class RefreshController @Inject constructor(
 
         var inboxUnreadCount: Int? = null
         write {
+            val refreshStrategy = folder.refreshStrategy()
             val impactedFoldersIds = mutableSetOf<String>().apply {
-                addAll(handleDeletedUids(scope, activities.deletedShortUids, folder.id, folder.refreshStrategy()))
-                addAll(handleUpdatedUids(scope, activities.updatedMessages, folder.id, folder.refreshStrategy()))
+                addAll(handleDeletedUids(scope, activities.deletedShortUids, folder.id, refreshStrategy))
+                addAll(handleUpdatedUids(scope, activities.updatedMessages, folder.id, refreshStrategy))
             }
 
             inboxUnreadCount = updateFoldersUnreadCount(impactedFoldersIds, realm = this)

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -36,14 +36,13 @@ interface RefreshStrategy {
      */
     fun processDeletedMessage(
         scope: CoroutineScope,
-        message: Message,
+        managedMessage: Message,
         context: Context,
         mailbox: Mailbox,
         realm: MutableRealm,
     ): Collection<Thread>
 
     fun extraFolderIdsThatNeedToRefreshUnreadOnDelete(realm: TypedRealm): List<String>
-
     fun processDeletedThread(thread: Thread, realm: MutableRealm)
 
     /**
@@ -68,7 +67,7 @@ interface DefaultRefreshStrategy : RefreshStrategy {
 
     override fun processDeletedMessage(
         scope: CoroutineScope,
-        message: Message,
+        managedMessage: Message,
         context: Context,
         mailbox: Mailbox,
         realm: MutableRealm,
@@ -78,14 +77,14 @@ interface DefaultRefreshStrategy : RefreshStrategy {
          * Doing so for managed Realm objects will lively update the list we're iterating through, making us skip the next item.
          * Looping in reverse enables us to not skip any item.
          */
-        message.threads.asReversed().forEach { thread ->
+        managedMessage.threads.asReversed().forEach { thread ->
             scope.ensureActive()
 
-            val isSuccess = thread.messages.remove(message)
+            val isSuccess = thread.messages.remove(managedMessage)
             if (isSuccess) add(thread)
         }
 
-        MessageController.deleteMessage(context, mailbox, message, realm)
+        MessageController.deleteMessage(context, mailbox, managedMessage, realm)
     }
 
     override fun extraFolderIdsThatNeedToRefreshUnreadOnDelete(realm: TypedRealm): List<String> = emptyList()

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -39,7 +39,7 @@ interface RefreshStrategy {
      * @return The list of impacted threads that have changed and need to be recomputed. The list of impacted threads will also be
      * used to determine what folders need to have their unread count updated. If an extra folder needs its unread count updated
      * but no thread has that extra folder as [Thread.folderId], you can define the extra folder you want inside
-     * [extraFolderIdsThatNeedToRefreshUnreadOnDeletedUid].
+     * [addFolderToImpactedFolders] as you they are inserted inside the list of impacted folders.
      */
     fun processDeletedMessage(
         scope: CoroutineScope,
@@ -49,7 +49,7 @@ interface RefreshStrategy {
         realm: MutableRealm,
     ): Collection<Thread>
 
-    fun extraFolderIdsThatNeedToRefreshUnreadOnDeletedUid(realm: TypedRealm): List<String>
+    fun addFolderToImpactedFolders(folderId: String, impactedFolders: ImpactedFolders)
     fun processDeletedThread(thread: Thread, realm: MutableRealm)
     fun shouldQueryFolderThreadsOnDeletedUid(): Boolean
 
@@ -101,7 +101,9 @@ interface DefaultRefreshStrategy : RefreshStrategy {
         MessageController.deleteMessage(context, mailbox, managedMessage, realm)
     }
 
-    override fun extraFolderIdsThatNeedToRefreshUnreadOnDeletedUid(realm: TypedRealm): List<String> = emptyList()
+    override fun addFolderToImpactedFolders(folderId: String, impactedFolders: ImpactedFolders) {
+        impactedFolders += folderId
+    }
 
     override fun processDeletedThread(thread: Thread, realm: MutableRealm) {
         if (thread.getNumberOfMessagesInFolder() == 0) {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.data.cache.mailboxContent
 
 import android.content.Context
+import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
@@ -30,6 +31,7 @@ import kotlinx.coroutines.ensureActive
 
 interface RefreshStrategy {
     fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread>
+    fun otherFolderRolesToQueryThreads(): List<Folder.FolderRole> // TODO: Couple it tighter with queryFolderThreads()?
 
     fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message?
 
@@ -70,6 +72,8 @@ interface DefaultRefreshStrategy : RefreshStrategy {
     override fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread> {
         return ThreadController.getThreadsByFolderId(folderId, realm)
     }
+
+    override fun otherFolderRolesToQueryThreads(): List<Folder.FolderRole> = emptyList()
 
     override fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message? {
         return MessageController.getMessage(shortUid.toLongUid(folderId), realm)

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -49,6 +49,7 @@ interface RefreshStrategy {
 
     fun extraFolderIdsThatNeedToRefreshUnreadOnDelete(realm: TypedRealm): List<String>
     fun processDeletedThread(thread: Thread, realm: MutableRealm)
+    fun queryFolderThreadsOnDeletedUid(): Boolean
 
     /**
      * About the [impactedThreadsManaged]:
@@ -105,6 +106,8 @@ interface DefaultRefreshStrategy : RefreshStrategy {
             thread.recomputeThread(realm)
         }
     }
+
+    override fun queryFolderThreadsOnDeletedUid(): Boolean = false
 
     private fun String.toLongUid(folderId: String) = "${this}@${folderId}"
     private fun Thread.getNumberOfMessagesInFolder() = messages.count { message -> message.folderId == folderId }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -34,7 +34,10 @@ interface RefreshStrategy {
     fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message?
 
     /**
-     * @return The list of impacted threads that have changed and need to be recomputed
+     * @return The list of impacted threads that have changed and need to be recomputed. The list of impacted threads will also be
+     * used to determine what folders need to have their unread count updated. If an extra folder needs its unread count updated
+     * but no thread has that extra folder as [Thread.folderId], you can define the extra folder you want inside
+     * [extraFolderIdsThatNeedToRefreshUnreadOnDelete].
      */
     fun processDeletedMessage(
         scope: CoroutineScope,

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.ensureActive
 interface RefreshStrategy {
     fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread>
 
+    fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message?
+
     /**
      * @return The list of impacted threads that have changed and need to be recomputed
      */
@@ -65,6 +67,10 @@ interface DefaultRefreshStrategy : RefreshStrategy {
         return ThreadController.getThreadsByFolderId(folderId, realm)
     }
 
+    override fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message? {
+        return MessageController.getMessage(shortUid.toLongUid(folderId), realm)
+    }
+
     override fun processDeletedMessage(
         scope: CoroutineScope,
         managedMessage: Message,
@@ -97,6 +103,7 @@ interface DefaultRefreshStrategy : RefreshStrategy {
         }
     }
 
+    private fun String.toLongUid(folderId: String) = "${this}@${folderId}"
     private fun Thread.getNumberOfMessagesInFolder() = messages.count { message -> message.folderId == folderId }
 
     override fun handleAddedMessages(

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.ensureActive
 
 interface RefreshStrategy {
     fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread>
-    fun otherFolderRolesToQueryThreads(): List<Folder.FolderRole> // TODO: Couple it tighter with queryFolderThreads()?
+    fun otherFolderRolesToQueryThreads(): List<Folder.FolderRole>
 
     fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message?
 
@@ -39,7 +39,7 @@ interface RefreshStrategy {
      * @return The list of impacted threads that have changed and need to be recomputed. The list of impacted threads will also be
      * used to determine what folders need to have their unread count updated. If an extra folder needs its unread count updated
      * but no thread has that extra folder as [Thread.folderId], you can define the extra folder you want inside
-     * [addFolderToImpactedFolders] as you they are inserted inside the list of impacted folders.
+     * [addFolderToImpactedFolders] as they will be inserted inside the list of impacted folders.
      */
     fun processDeletedMessage(
         scope: CoroutineScope,

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -37,7 +37,7 @@ interface RefreshStrategy {
      * @return The list of impacted threads that have changed and need to be recomputed. The list of impacted threads will also be
      * used to determine what folders need to have their unread count updated. If an extra folder needs its unread count updated
      * but no thread has that extra folder as [Thread.folderId], you can define the extra folder you want inside
-     * [extraFolderIdsThatNeedToRefreshUnreadOnDelete].
+     * [extraFolderIdsThatNeedToRefreshUnreadOnDeletedUid].
      */
     fun processDeletedMessage(
         scope: CoroutineScope,
@@ -47,9 +47,9 @@ interface RefreshStrategy {
         realm: MutableRealm,
     ): Collection<Thread>
 
-    fun extraFolderIdsThatNeedToRefreshUnreadOnDelete(realm: TypedRealm): List<String>
+    fun extraFolderIdsThatNeedToRefreshUnreadOnDeletedUid(realm: TypedRealm): List<String>
     fun processDeletedThread(thread: Thread, realm: MutableRealm)
-    fun queryFolderThreadsOnDeletedUid(): Boolean
+    fun shouldQueryFolderThreadsOnDeletedUid(): Boolean
 
     /**
      * About the [impactedThreadsManaged]:
@@ -97,7 +97,7 @@ interface DefaultRefreshStrategy : RefreshStrategy {
         MessageController.deleteMessage(context, mailbox, managedMessage, realm)
     }
 
-    override fun extraFolderIdsThatNeedToRefreshUnreadOnDelete(realm: TypedRealm): List<String> = emptyList()
+    override fun extraFolderIdsThatNeedToRefreshUnreadOnDeletedUid(realm: TypedRealm): List<String> = emptyList()
 
     override fun processDeletedThread(thread: Thread, realm: MutableRealm) {
         if (thread.getNumberOfMessagesInFolder() == 0) {
@@ -107,7 +107,7 @@ interface DefaultRefreshStrategy : RefreshStrategy {
         }
     }
 
-    override fun queryFolderThreadsOnDeletedUid(): Boolean = false
+    override fun shouldQueryFolderThreadsOnDeletedUid(): Boolean = false
 
     private fun String.toLongUid(folderId: String) = "${this}@${folderId}"
     private fun Thread.getNumberOfMessagesInFolder() = messages.count { message -> message.folderId == folderId }

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -35,7 +35,6 @@ import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.MessageBodyUtils.SplitBody
 import com.infomaniak.mail.utils.extensions.toRealmInstant
-import com.infomaniak.mail.utils.extensions.toShortUid
 import io.realm.kotlin.ext.*
 import io.realm.kotlin.serializers.RealmListKSerializer
 import io.realm.kotlin.types.*
@@ -349,6 +348,10 @@ class Message : RealmObject {
     }
 
     fun isOrphan(): Boolean = threads.isEmpty() && threadsDuplicatedIn.isEmpty()
+
+    // Be careful when using this method because some folders might contain messages from other folders than itself. This
+    // operation should only happen in very specific situations like computing the shortUid of a Message from its uid.
+    private fun String.toShortUid(): Int = substringBefore('@').toInt()
 
     override fun equals(other: Any?) = other === this || (other is Message && other.uid == uid)
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -171,7 +171,8 @@ class Thread : RealmObject {
 
     fun recomputeThread(realm: MutableRealm? = null) {
 
-        // Delete Thread if empty
+        // Delete Thread if empty. Do not rely on this deletion code being part of the method's logic, it's a temporary fix. If
+        // threads should be deleted, then they need to be deleted outside this method.
         if (messages.none { it.folderId == folderId }) {
             if (isManaged()) realm?.delete(this)
             return

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -299,10 +299,6 @@ inline fun <reified T> ApiResponse<T>.getApiException(): Exception {
 fun List<ApiResponse<*>>.atLeastOneSucceeded(): Boolean = any { it.isSuccess() }
 
 fun List<ApiResponse<*>>.allFailed(): Boolean = none { it.isSuccess() }
-
-fun String.toLongUid(folderId: String) = "${this}@${folderId}"
-
-fun String.toShortUid(): Int = substringBefore('@').toInt()
 //endregion
 
 //region Realm


### PR DESCRIPTION
Defines the custom logic to handle deleted uids for the snooze folder. It leverages the RefreshStrategy to define the custom logic.

Inside this PR there's an issue where the snooze folder is not refreshed after an action on a message. This is fixed in the very next PR.

Depends on #2234