### PR TITLE
feat: Handles update uid for the snooze folder

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -46,6 +46,7 @@ import com.infomaniak.mail.data.models.draft.SaveDraftResult
 import com.infomaniak.mail.data.models.draft.ScheduleDraftResult
 import com.infomaniak.mail.data.models.draft.SendDraftResult
 import com.infomaniak.mail.data.models.getMessages.ActivitiesResult
+import com.infomaniak.mail.data.models.getMessages.CommonMessageFlags
 import com.infomaniak.mail.data.models.getMessages.GetMessagesByUidsResult
 import com.infomaniak.mail.data.models.getMessages.NewMessagesResult
 import com.infomaniak.mail.data.models.mailbox.Mailbox
@@ -283,12 +284,12 @@ object ApiRepository : ApiRepositoryCore() {
         )
     }
 
-    fun getMessagesUidsDelta(
+    inline fun <reified T: CommonMessageFlags> getMessagesUidsDelta(
         mailboxUuid: String,
         folderId: String,
         cursor: String,
         okHttpClient: OkHttpClient?,
-    ): ApiResponse<ActivitiesResult> {
+    ): ApiResponse<ActivitiesResult<T>> {
         return callApi(
             url = ApiRoutes.getMessagesUidsDelta(mailboxUuid, folderId, cursor),
             method = GET,

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -46,7 +46,7 @@ import com.infomaniak.mail.data.models.draft.SaveDraftResult
 import com.infomaniak.mail.data.models.draft.ScheduleDraftResult
 import com.infomaniak.mail.data.models.draft.SendDraftResult
 import com.infomaniak.mail.data.models.getMessages.ActivitiesResult
-import com.infomaniak.mail.data.models.getMessages.CommonMessageFlags
+import com.infomaniak.mail.data.models.getMessages.MessageFlags
 import com.infomaniak.mail.data.models.getMessages.GetMessagesByUidsResult
 import com.infomaniak.mail.data.models.getMessages.NewMessagesResult
 import com.infomaniak.mail.data.models.mailbox.Mailbox
@@ -284,7 +284,7 @@ object ApiRepository : ApiRepositoryCore() {
         )
     }
 
-    inline fun <reified T: CommonMessageFlags> getMessagesUidsDelta(
+    inline fun <reified T: MessageFlags> getMessagesUidsDelta(
         mailboxUuid: String,
         folderId: String,
         cursor: String,

--- a/app/src/main/java/com/infomaniak/mail/data/api/DateSerializer.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/DateSerializer.kt
@@ -1,0 +1,44 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2022-2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.api
+
+import com.infomaniak.core.utils.FORMAT_DATE_WITH_TIMEZONE
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object DateSerializer : KSerializer<Date> {
+
+    private val simpleDateFormat = SimpleDateFormat(FORMAT_DATE_WITH_TIMEZONE, Locale.ROOT)
+
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Date", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Date {
+        return simpleDateFormat.parse(decoder.decodeString()) ?: Date(Long.MAX_VALUE)
+    }
+
+    override fun serialize(encoder: Encoder, value: Date) {
+        value.let(simpleDateFormat::format).let(encoder::encodeString)
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -258,7 +258,7 @@ class RefreshController @Inject constructor(
     private suspend fun Realm.fetchActivities(scope: CoroutineScope, folder: Folder, previousCursor: String) {
         val activities = when (folder.role) {
             FolderRole.SNOOZED -> getMessagesUidsDelta<SnoozeMessageFlags>(folder.id, previousCursor)
-            else -> getMessagesUidsDelta<MessageFlags>(folder.id, previousCursor)
+            else -> getMessagesUidsDelta<DefaultMessageFlags>(folder.id, previousCursor)
         } ?: return
 
         scope.ensureActive()
@@ -478,7 +478,7 @@ class RefreshController @Inject constructor(
     //region Updated Messages
     private fun MutableRealm.handleUpdatedUids(
         scope: CoroutineScope,
-        messageFlags: List<CommonMessageFlags>,
+        messageFlags: List<MessageFlags>,
         folderId: String,
         refreshStrategy: RefreshStrategy,
     ): ImpactedFolders {
@@ -488,7 +488,7 @@ class RefreshController @Inject constructor(
 
             refreshStrategy.getMessageFromShortUid(flags.shortUid, folderId, realm = this)?.let { message ->
                 when (flags) {
-                    is MessageFlags -> message.updateFlags(flags)
+                    is DefaultMessageFlags -> message.updateFlags(flags)
                     is SnoozeMessageFlags -> message.updateSnoozeFlags(flags)
                 }
                 threads += message.threads
@@ -696,7 +696,7 @@ class RefreshController @Inject constructor(
         }
     }
 
-    private inline fun <reified T : CommonMessageFlags> getMessagesUidsDelta(folderId: String, previousCursor: String): ActivitiesResult<T>? {
+    private inline fun <reified T : MessageFlags> getMessagesUidsDelta(folderId: String, previousCursor: String): ActivitiesResult<T>? {
         return with(ApiRepository.getMessagesUidsDelta<T>(mailbox.uuid, folderId, previousCursor, okHttpClient)) {
             if (!isSuccess()) throwErrorAsException()
             return@with data
@@ -735,7 +735,7 @@ class RefreshController @Inject constructor(
         logMessage: String,
         email: String,
         folder: Folder,
-        activities: ActivitiesResult<out CommonMessageFlags>,
+        activities: ActivitiesResult<out MessageFlags>,
     ) {
         SentryDebug.addThreadsAlgoBreadcrumb(
             message = logMessage,

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -26,9 +26,7 @@ import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshMo
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
-import com.infomaniak.mail.data.models.getMessages.ActivitiesResult
-import com.infomaniak.mail.data.models.getMessages.ActivitiesResult.MessageFlags
-import com.infomaniak.mail.data.models.getMessages.NewMessagesResult
+import com.infomaniak.mail.data.models.getMessages.*
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.message.Message.MessageInitialState
@@ -258,8 +256,11 @@ class RefreshController @Inject constructor(
     }
 
     private suspend fun Realm.fetchActivities(scope: CoroutineScope, folder: Folder, previousCursor: String) {
+        val activities = when (folder.role) {
+            FolderRole.SNOOZED -> getMessagesUidsDelta<SnoozeMessageFlags>(folder.id, previousCursor)
+            else -> getMessagesUidsDelta<MessageFlags>(folder.id, previousCursor)
+        } ?: return
 
-        val activities = getMessagesUidsDelta(folder.id, previousCursor) ?: return
         scope.ensureActive()
 
         val logMessage = "Deleted: ${activities.deletedShortUids.count()} | " +
@@ -477,7 +478,7 @@ class RefreshController @Inject constructor(
     //region Updated Messages
     private fun MutableRealm.handleUpdatedUids(
         scope: CoroutineScope,
-        messageFlags: List<MessageFlags>,
+        messageFlags: List<CommonMessageFlags>,
         folderId: String,
         refreshStrategy: RefreshStrategy,
     ): ImpactedFolders {
@@ -486,7 +487,10 @@ class RefreshController @Inject constructor(
             scope.ensureActive()
 
             refreshStrategy.getMessageFromShortUid(flags.shortUid, folderId, realm = this)?.let { message ->
-                message.updateFlags(flags)
+                when (flags) {
+                    is MessageFlags -> message.updateFlags(flags)
+                    is SnoozeMessageFlags -> message.updateSnoozeFlags(flags)
+                }
                 threads += message.threads
             }
         }
@@ -692,8 +696,8 @@ class RefreshController @Inject constructor(
         }
     }
 
-    private fun getMessagesUidsDelta(folderId: String, previousCursor: String): ActivitiesResult? {
-        return with(ApiRepository.getMessagesUidsDelta(mailbox.uuid, folderId, previousCursor, okHttpClient)) {
+    private inline fun <reified T : CommonMessageFlags> getMessagesUidsDelta(folderId: String, previousCursor: String): ActivitiesResult<T>? {
+        return with(ApiRepository.getMessagesUidsDelta<T>(mailbox.uuid, folderId, previousCursor, okHttpClient)) {
             if (!isSuccess()) throwErrorAsException()
             return@with data
         }
@@ -731,7 +735,7 @@ class RefreshController @Inject constructor(
         logMessage: String,
         email: String,
         folder: Folder,
-        activities: ActivitiesResult,
+        activities: ActivitiesResult<out CommonMessageFlags>,
     ) {
         SentryDebug.addThreadsAlgoBreadcrumb(
             message = logMessage,

--- a/app/src/main/java/com/infomaniak/mail/data/models/getMessages/ActivitiesResult.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/getMessages/ActivitiesResult.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ActivitiesResult<T : CommonMessageFlags>(
+data class ActivitiesResult<T : MessageFlags>(
     @SerialName("deleted")
     val deletedShortUids: List<String>,
     @SerialName("updated")

--- a/app/src/main/java/com/infomaniak/mail/data/models/getMessages/CommonMessageFlags.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/getMessages/CommonMessageFlags.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2025 Infomaniak Network SA
+ * Copyright (C) 2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,19 +17,6 @@
  */
 package com.infomaniak.mail.data.models.getMessages
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class ActivitiesResult<T : CommonMessageFlags>(
-    @SerialName("deleted")
-    val deletedShortUids: List<String>,
-    @SerialName("updated")
-    val updatedMessages: List<T>,
-    @SerialName("added")
-    val addedShortUids: List<Int>,
-    @SerialName("unread_count")
-    val unreadCountRemote: Int,
-    @SerialName("signature")
-    val cursor: String,
-)
+sealed interface CommonMessageFlags {
+    val shortUid: String
+}

--- a/app/src/main/java/com/infomaniak/mail/data/models/getMessages/DefaultMessageFlags.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/getMessages/DefaultMessageFlags.kt
@@ -17,6 +17,21 @@
  */
 package com.infomaniak.mail.data.models.getMessages
 
-sealed interface CommonMessageFlags {
-    val shortUid: String
-}
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DefaultMessageFlags(
+    @SerialName("uid")
+    override val shortUid: String,
+    @SerialName("answered")
+    val isAnswered: Boolean,
+    @SerialName("flagged")
+    val isFavorite: Boolean,
+    @SerialName("forwarded")
+    val isForwarded: Boolean,
+    @SerialName("scheduled")
+    val isScheduledMessage: Boolean,
+    @SerialName("seen")
+    val isSeen: Boolean,
+) : MessageFlags

--- a/app/src/main/java/com/infomaniak/mail/data/models/getMessages/MessageFlags.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/getMessages/MessageFlags.kt
@@ -17,21 +17,6 @@
  */
 package com.infomaniak.mail.data.models.getMessages
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class MessageFlags(
-    @SerialName("uid")
-    override val shortUid: String,
-    @SerialName("answered")
-    val isAnswered: Boolean,
-    @SerialName("flagged")
-    val isFavorite: Boolean,
-    @SerialName("forwarded")
-    val isForwarded: Boolean,
-    @SerialName("scheduled")
-    val isScheduledMessage: Boolean,
-    @SerialName("seen")
-    val isSeen: Boolean,
-) : CommonMessageFlags
+sealed interface MessageFlags {
+    val shortUid: String
+}

--- a/app/src/main/java/com/infomaniak/mail/data/models/getMessages/MessageFlags.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/getMessages/MessageFlags.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2025 Infomaniak Network SA
+ * Copyright (C) 2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,15 +21,17 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ActivitiesResult<T : CommonMessageFlags>(
-    @SerialName("deleted")
-    val deletedShortUids: List<String>,
-    @SerialName("updated")
-    val updatedMessages: List<T>,
-    @SerialName("added")
-    val addedShortUids: List<Int>,
-    @SerialName("unread_count")
-    val unreadCountRemote: Int,
-    @SerialName("signature")
-    val cursor: String,
-)
+data class MessageFlags(
+    @SerialName("uid")
+    override val shortUid: String,
+    @SerialName("answered")
+    val isAnswered: Boolean,
+    @SerialName("flagged")
+    val isFavorite: Boolean,
+    @SerialName("forwarded")
+    val isForwarded: Boolean,
+    @SerialName("scheduled")
+    val isScheduledMessage: Boolean,
+    @SerialName("seen")
+    val isSeen: Boolean,
+) : CommonMessageFlags

--- a/app/src/main/java/com/infomaniak/mail/data/models/getMessages/SnoozeMessageFlags.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/getMessages/SnoozeMessageFlags.kt
@@ -47,4 +47,4 @@ data class SnoozeMessageFlags(
     override val shortUid: String,
     @SerialName("snooze_end_date")
     val snoozeEndDate: Date,
-): CommonMessageFlags
+): MessageFlags

--- a/app/src/main/java/com/infomaniak/mail/data/models/getMessages/SnoozeMessageFlags.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/getMessages/SnoozeMessageFlags.kt
@@ -1,0 +1,50 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+@file:UseSerializers(DateSerializer::class)
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.models.getMessages
+
+import com.infomaniak.mail.data.api.DateSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import java.util.Date
+
+@Serializable
+data class SnoozeMessageFlags(
+    @SerialName("uid")
+    override val shortUid: String,
+    @SerialName("snooze_end_date")
+    val snoozeEndDate: Date,
+): CommonMessageFlags

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -30,7 +30,7 @@ import com.infomaniak.mail.data.models.SnoozeState
 import com.infomaniak.mail.data.models.SwissTransferFile
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
 import com.infomaniak.mail.data.models.correspondent.Recipient
-import com.infomaniak.mail.data.models.getMessages.MessageFlags
+import com.infomaniak.mail.data.models.getMessages.DefaultMessageFlags
 import com.infomaniak.mail.data.models.getMessages.SnoozeMessageFlags
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.utils.AccountUtils
@@ -330,7 +330,7 @@ class Message : RealmObject {
         }
     }
 
-    fun updateFlags(flags: MessageFlags) {
+    fun updateFlags(flags: DefaultMessageFlags) {
         isSeen = flags.isSeen
         isFavorite = flags.isFavorite
         isAnswered = flags.isAnswered

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -30,7 +30,8 @@ import com.infomaniak.mail.data.models.SnoozeState
 import com.infomaniak.mail.data.models.SwissTransferFile
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
 import com.infomaniak.mail.data.models.correspondent.Recipient
-import com.infomaniak.mail.data.models.getMessages.ActivitiesResult.MessageFlags
+import com.infomaniak.mail.data.models.getMessages.MessageFlags
+import com.infomaniak.mail.data.models.getMessages.SnoozeMessageFlags
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.MessageBodyUtils.SplitBody
@@ -335,6 +336,10 @@ class Message : RealmObject {
         isAnswered = flags.isAnswered
         isForwarded = flags.isForwarded
         isScheduledMessage = flags.isScheduledMessage
+    }
+
+    fun updateSnoozeFlags(flags: SnoozeMessageFlags) {
+        snoozeEndDate = flags.snoozeEndDate.toRealmInstant()
     }
 
     fun shouldBeExpanded(index: Int, lastIndex: Int) = !isDraft && (!isSeen || index == lastIndex)


### PR DESCRIPTION
Introduces custom logic to handle the new returned MessageFlag returned by activities in the snooze folder.

The API sends a custom MessageFlag with other values than the one we're used to. This PR applies the new returned values to our messages when it encourers this snooze message flag.

Depends on #2223 