### PR TITLE
feat: Display the number of threads in snooze instead of its unread c…

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FolderViewHolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/items/FolderViewHolder.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -66,7 +66,7 @@ class FolderViewHolder(
         }
 
         val unread = when (folder.role) {
-            FolderRole.DRAFT, FolderRole.SCHEDULED_DRAFTS -> UnreadDisplay(count = folder.threads.count())
+            FolderRole.DRAFT, FolderRole.SCHEDULED_DRAFTS, FolderRole.SNOOZED -> UnreadDisplay(count = folder.threads.count())
             FolderRole.SENT, FolderRole.TRASH -> UnreadDisplay(count = 0)
             else -> folder.unreadCountDisplay
         }


### PR DESCRIPTION
The snooze folder needs to show the number of threads present in the folder, not the number of unread threads in it.

Depends on #2224 