### PR TITLE
feat: Hide empty snooze folder

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/CustomRefreshStrategies.kt
@@ -41,12 +41,17 @@ val inboxRefreshStrategy = object : DefaultRefreshStrategy {
     }
 }
 
+val scheduledDraftRefreshStrategy = object : DefaultRefreshStrategy {
+    override fun shouldHideEmptyFolder(): Boolean = true
+}
+
 val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
     override fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread> {
         return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = true, realm = realm)
     }
 
     override fun otherFolderRolesToQueryThreads(): List<Folder.FolderRole> = listOf(Folder.FolderRole.INBOX)
+    override fun shouldHideEmptyFolder(): Boolean = true
 
     override fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message? {
         val inboxId = FolderController.getFolder(Folder.FolderRole.INBOX, realm)?.id ?: return null

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshStrategies.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.ensureActive
 interface RefreshStrategy {
     fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread>
     fun otherFolderRolesToQueryThreads(): List<Folder.FolderRole>
+    fun shouldHideEmptyFolder(): Boolean
 
     fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message?
 
@@ -72,6 +73,7 @@ interface DefaultRefreshStrategy : RefreshStrategy {
     }
 
     override fun otherFolderRolesToQueryThreads(): List<Folder.FolderRole> = emptyList()
+    override fun shouldHideEmptyFolder(): Boolean = false
 
     override fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message? {
         return MessageController.getMessage(shortUid.toLongUid(folderId), realm)

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -151,6 +151,7 @@ class Folder : RealmObject, Cloneable {
     fun refreshStrategy(): RefreshStrategy = when (role) {
         FolderRole.INBOX -> inboxRefreshStrategy
         FolderRole.SNOOZED -> snoozeRefreshStrategy
+        FolderRole.SCHEDULED_DRAFTS -> scheduledDraftRefreshStrategy
         else -> defaultRefreshStrategy
     }
 


### PR DESCRIPTION
Now that the snooze folder is correctly fetched and updated, we can hide the folder when there's no message inside it, as intended.

Depends on #2225 