### PR TITLE
feat: Custom folder sorting can be parametrized easily for any folder role

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -24,6 +24,7 @@ import com.infomaniak.mail.data.api.ApiRepository
 import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
+import com.infomaniak.mail.data.models.Folder.FolderSort
 import com.infomaniak.mail.data.models.SnoozeState
 import com.infomaniak.mail.data.models.SwissTransferContainer
 import com.infomaniak.mail.data.models.message.Message
@@ -59,8 +60,8 @@ class ThreadController @Inject constructor(
 ) {
 
     //region Get data
-    fun getThreadsAsync(folder: Folder, filter: ThreadFilter = ThreadFilter.ALL, sortOrder: Sort): Flow<ResultsChange<Thread>> {
-        return getThreadsByMessageIdsQuery(folder, filter, sortOrder).asFlow()
+    fun getThreadsAsync(folder: Folder, filter: ThreadFilter = ThreadFilter.ALL): Flow<ResultsChange<Thread>> {
+        return getThreadsByMessageIdsQuery(folder, filter).asFlow()
     }
 
     fun getSearchThreadsAsync(): Flow<ResultsChange<Thread>> {
@@ -216,12 +217,14 @@ class ThreadController @Inject constructor(
         private fun getThreadsByMessageIdsQuery(
             folder: Folder,
             filter: ThreadFilter = ThreadFilter.ALL,
-            sortOrder: Sort,
         ): RealmQuery<Thread> {
 
             val notFromSearch = "${Thread::isFromSearch.name} == false"
             val notLocallyMovedOut = " AND ${Thread::isLocallyMovedOut.name} == false"
-            val realmQuery = folder.threads.query(notFromSearch + notLocallyMovedOut).sort(Thread::internalDate.name, sortOrder)
+            val folderSort = folder.role?.folderSort ?: FolderSort.Default
+            val realmQuery = folder.threads
+                .query(notFromSearch + notLocallyMovedOut)
+                .sort(folderSort.sortBy, folderSort.sortOrder)
 
             return if (filter == ThreadFilter.ALL) {
                 realmQuery

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -34,6 +34,7 @@ import com.infomaniak.mail.utils.Utils
 import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.ext.backlinks
 import io.realm.kotlin.ext.realmListOf
+import io.realm.kotlin.query.Sort
 import io.realm.kotlin.serializers.RealmListKSerializer
 import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmList
@@ -43,6 +44,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.UseSerializers
+import kotlin.reflect.KProperty1
 
 @Serializable
 class Folder : RealmObject, Cloneable {
@@ -170,17 +172,33 @@ class Folder : RealmObject, Cloneable {
         @DrawableRes val folderIconRes: Int,
         val order: Int,
         val matomoValue: String,
+        val folderSort: FolderSort = FolderSort.Default,
     ) {
         INBOX(R.string.inboxFolder, R.drawable.ic_drawer_inbox, 10, "inboxFolder"),
         COMMERCIAL(R.string.commercialFolder, R.drawable.ic_promotions, 9, "commercialFolder"),
         SOCIALNETWORKS(R.string.socialNetworksFolder, R.drawable.ic_social_media, 8, "socialNetworksFolder"),
         SENT(R.string.sentFolder, R.drawable.ic_send, 7, "sentFolder"),
-        SNOOZED(R.string.snoozedFolder, R.drawable.ic_alarm_clock, 6, "snoozedFolder"),
-        SCHEDULED_DRAFTS(R.string.scheduledMessagesFolder, R.drawable.ic_schedule_send, 5, "scheduledDraftsFolder"),
+        SNOOZED(R.string.snoozedFolder, R.drawable.ic_alarm_clock, 6, "snoozedFolder", FolderSort.Snooze),
+        SCHEDULED_DRAFTS(
+            R.string.scheduledMessagesFolder, R.drawable.ic_schedule_send, 5, "scheduledDraftsFolder", FolderSort.Scheduled
+        ),
         DRAFT(R.string.draftFolder, R.drawable.ic_draft, 4, "draftFolder"),
         SPAM(R.string.spamFolder, R.drawable.ic_spam, 3, "spamFolder"),
         TRASH(R.string.trashFolder, R.drawable.ic_bin, 2, "trashFolder"),
         ARCHIVE(R.string.archiveFolder, R.drawable.ic_archive_folder, 1, "archiveFolder"),
+    }
+
+    class FolderSort private constructor(
+        val sortOrder: Sort = Sort.DESCENDING,
+        sortBy: KProperty1<*, *> = Thread::internalDate,
+    ) {
+        val sortBy = sortBy.name
+
+        companion object {
+            val Default = FolderSort()
+            val Snooze = FolderSort(Sort.ASCENDING, Thread::snoozeEndDate)
+            val Scheduled = FolderSort(Sort.ASCENDING)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -68,7 +68,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.kotlin.Realm
 import io.realm.kotlin.ext.toRealmList
 import io.realm.kotlin.notifications.ResultsChange
-import io.realm.kotlin.query.Sort
 import io.sentry.Attachment
 import io.sentry.Sentry
 import io.sentry.SentryLevel
@@ -220,10 +219,7 @@ class MainViewModel @Inject constructor(
         currentThreadsLiveJob = viewModelScope.launch(ioCoroutineContext) {
             observeFolderAndFilter()
                 .flatMapLatest { (folder, filter) ->
-                    folder?.let {
-                        val sortOrder = if (folder.role == FolderRole.SCHEDULED_DRAFTS) Sort.ASCENDING else Sort.DESCENDING
-                        threadController.getThreadsAsync(it, filter, sortOrder)
-                    } ?: emptyFlow()
+                    folder?.let { threadController.getThreadsAsync(it, filter) } ?: emptyFlow()
                 }
                 .collect(currentThreadsLive::postValue)
         }


### PR DESCRIPTION
The snooze folder needs a new order for its threads, I took this opportunity to centralize and make it easily parametrisable.

For the snooze folder, not only did I need to change the order from the default descending order to an ascending order, but I also needed to sort by another property of the Thread model.

The goal is to have the Threads that will first be unsnoozed at the top of the screen

Depends on #2239