### PR TITLE
refactor: Small `isMe()` optimization

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/correspondent/Correspondent.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/correspondent/Correspondent.kt
@@ -36,11 +36,11 @@ interface Correspondent : Parcelable {
         val correspondentEmail = email.lowercase()
 
         val isRealMe = userEmail == correspondentEmail
+        if (isRealMe) return true
 
         val (start, end) = userEmail.getStartAndEndOfPlusEmail()
         val isPlusMe = correspondentEmail.startsWith(start) && correspondentEmail.endsWith(end)
-
-        return isRealMe || isPlusMe
+        return isPlusMe
     }
 
     fun shouldDisplayUserAvatar(): Boolean = isMe() && email.lowercase() == AccountUtils.currentUser?.email?.lowercase()


### PR DESCRIPTION
If we are the real Me, directly return `true` without computing the plus Me.