### PR TITLE
feat: Also recompute duplicated threads when snooze message is added/updated/deleted

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/DefaultRefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/DefaultRefreshStrategy.kt
@@ -43,6 +43,8 @@ interface DefaultRefreshStrategy : RefreshStrategy {
 
     override fun shouldHideEmptyFolder(): Boolean = false
 
+    override fun alsoRecomputeDuplicatedThreads(): Boolean = false
+
     override fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message? {
         return MessageController.getMessage(shortUid.toLongUid(folderId), realm)
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/RefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/RefreshStrategy.kt
@@ -34,6 +34,12 @@ interface RefreshStrategy {
 
     fun shouldHideEmptyFolder(): Boolean
 
+    /**
+     * When a [Message] is added, updated or deleted, we recompute threads that are impacted by this change. If this method
+     * returns true, the impacted threads will also consider threads where the processed [Message] appears as a duplicate.
+     */
+    fun alsoRecomputeDuplicatedThreads(): Boolean
+
     fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message?
 
     fun processDeletedMessage(

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/SnoozeRefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/SnoozeRefreshStrategy.kt
@@ -39,6 +39,8 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
 
     override fun shouldHideEmptyFolder(): Boolean = true
 
+    override fun alsoRecomputeDuplicatedThreads(): Boolean = true
+
     override fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message? {
         val inboxId = FolderController.getFolder(FolderRole.INBOX, realm)?.id ?: return null
         return super.getMessageFromShortUid(shortUid, inboxId, realm)

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -188,7 +188,7 @@ class Message : RealmObject {
 
     val threads by backlinks(Thread::messages)
 
-    private val threadsDuplicatedIn by backlinks(Thread::duplicates)
+    val threadsDuplicatedIn by backlinks(Thread::duplicates)
 
     // TODO: Remove this `runCatching / getOrElse` when the issue is fixed
     inline val folder

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -24,6 +24,7 @@ import com.infomaniak.mail.MatomoMail.SEARCH_FOLDER_FILTER_NAME
 import com.infomaniak.mail.data.api.RealmInstantSerializer
 import com.infomaniak.mail.data.cache.mailboxContent.FolderController
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
+import com.infomaniak.mail.data.cache.mailboxContent.refreshStrategies.RefreshStrategy
 import com.infomaniak.mail.data.models.Bimi
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
@@ -242,6 +243,10 @@ class Thread : RealmObject {
             updateSnoozeStatesBasedOn(message)
         }
 
+        /**
+         * Only needed for snooze because they rely on duplicates to compute the correct state of every thread. Tightly linked
+         * with [RefreshStrategy.alsoRecomputeDuplicatedThreads].
+         */
         duplicates.forEach(::updateSnoozeStatesBasedOn)
 
         val lastMessage = messages.last { it.folderId == folderId }


### PR DESCRIPTION
Receiving, updating or deleting a thread from Snooze can impact threads where the processed message is only refrenced as  a duplicate. So we need to recompute theses threads as well in this case

Depends on #2243 