### PR TITLE
refactor: Make property access coherent and go through Folder

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -24,7 +24,6 @@ import com.infomaniak.mail.data.api.ApiRepository
 import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
-import com.infomaniak.mail.data.models.Folder.FolderSort
 import com.infomaniak.mail.data.models.SnoozeState
 import com.infomaniak.mail.data.models.SwissTransferContainer
 import com.infomaniak.mail.data.models.message.Message
@@ -219,7 +218,7 @@ class ThreadController @Inject constructor(
 
             val notFromSearch = "${Thread::isFromSearch.name} == false"
             val notLocallyMovedOut = " AND ${Thread::isLocallyMovedOut.name} == false"
-            val folderSort = folder.role?.folderSort ?: FolderSort.Default
+            val folderSort = folder.getFolderSort()
             val realmQuery = folder.threads
                 .query(notFromSearch + notLocallyMovedOut)
                 .sort(folderSort.sortBy, folderSort.sortOrder)

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -149,12 +149,7 @@ class Folder : RealmObject, Cloneable {
 
     fun messages(realm: TypedRealm): List<Message> = MessageController.getMessagesByFolderId(id, realm)
 
-    fun refreshStrategy(): RefreshStrategy = when (role) {
-        FolderRole.INBOX -> inboxRefreshStrategy
-        FolderRole.SNOOZED -> snoozeRefreshStrategy
-        FolderRole.SCHEDULED_DRAFTS -> scheduledDraftRefreshStrategy
-        else -> defaultRefreshStrategy
-    }
+    fun refreshStrategy(): RefreshStrategy = role?.refreshStrategy ?: defaultRefreshStrategy
 
     fun getFolderSort() = role?.folderSort ?: FolderSort.Default
 
@@ -176,16 +171,31 @@ class Folder : RealmObject, Cloneable {
         @DrawableRes val folderIconRes: Int,
         val order: Int,
         val matomoValue: String,
+        val refreshStrategy: RefreshStrategy = defaultRefreshStrategy,
         val folderSort: FolderSort = FolderSort.Default,
         val groupMessagesBySection: Boolean = true,
     ) {
-        INBOX(R.string.inboxFolder, R.drawable.ic_drawer_inbox, 10, "inboxFolder"),
+        INBOX(R.string.inboxFolder, R.drawable.ic_drawer_inbox, 10, "inboxFolder", inboxRefreshStrategy),
         COMMERCIAL(R.string.commercialFolder, R.drawable.ic_promotions, 9, "commercialFolder"),
         SOCIALNETWORKS(R.string.socialNetworksFolder, R.drawable.ic_social_media, 8, "socialNetworksFolder"),
         SENT(R.string.sentFolder, R.drawable.ic_send, 7, "sentFolder"),
-        SNOOZED(R.string.snoozedFolder, R.drawable.ic_alarm_clock, 6, "snoozedFolder", FolderSort.Snooze, false),
+        SNOOZED(
+            folderNameRes = R.string.snoozedFolder,
+            folderIconRes = R.drawable.ic_alarm_clock,
+            order = 6,
+            matomoValue = "snoozedFolder",
+            refreshStrategy = snoozeRefreshStrategy,
+            folderSort = FolderSort.Snooze,
+            groupMessagesBySection = false,
+        ),
         SCHEDULED_DRAFTS(
-            R.string.scheduledMessagesFolder, R.drawable.ic_schedule_send, 5, "scheduledDraftsFolder", FolderSort.Scheduled, false
+            folderNameRes = R.string.scheduledMessagesFolder,
+            folderIconRes = R.drawable.ic_schedule_send,
+            order = 5,
+            matomoValue = "scheduledDraftsFolder",
+            refreshStrategy = scheduledDraftRefreshStrategy,
+            folderSort = FolderSort.Scheduled,
+            groupMessagesBySection = false,
         ),
         DRAFT(R.string.draftFolder, R.drawable.ic_draft, 4, "draftFolder"),
         SPAM(R.string.spamFolder, R.drawable.ic_spam, 3, "spamFolder"),

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -156,6 +156,8 @@ class Folder : RealmObject, Cloneable {
         else -> defaultRefreshStrategy
     }
 
+    fun getFolderSort() = role?.folderSort ?: FolderSort.Default
+
     fun getLocalizedName(context: Context): String {
         return role?.folderNameRes?.let(context::getString) ?: name
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -240,7 +240,7 @@ class ThreadListAdapter @Inject constructor(
             mailDate.text = dateDisplay.formatThreadDate(context, this)
             mailDateIcon.apply {
                 isVisible = dateDisplay.iconRes != null
-                dateDisplay.iconRes?.let { setImageResource(it) }
+                dateDisplay.iconRes?.let(::setImageResource)
                 dateDisplay.iconColorRes?.let { imageTintList = ColorStateList.valueOf(context.getColor(it)) }
             }
             draftPrefix.isVisible = hasDrafts


### PR DESCRIPTION
FolderSort and RefreshStrategy are very similar and should both be accessed through the Folder class instead of choosing a random default value somewhere in the code for custom folders. 

Also RefreshStrategy can be defined inside FolderRole the same way we define FolderSort. This will also avoid computing the `when` every time.

Depends on #2244 