### PR TITLE
fix: Scheduled message's sorting order

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -212,7 +212,7 @@ class Folder : RealmObject, Cloneable {
         companion object {
             val Default = FolderSort()
             val Snooze = FolderSort(Sort.ASCENDING, Thread::snoozeEndDate)
-            val Scheduled = FolderSort(Sort.ASCENDING)
+            val Scheduled = FolderSort(Sort.ASCENDING, Thread::displayDate)
         }
     }
 


### PR DESCRIPTION
The internal date represents the date the draft has been created at and not the date at which the draft will be sent. The scheduled drafts folder needs to sort messages by the date they will be sent at with the most recent one at the top of the list