### PR TITLE
refactor: Simplify and make code more readable

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/DefaultRefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/DefaultRefreshStrategy.kt
@@ -39,7 +39,7 @@ interface DefaultRefreshStrategy : RefreshStrategy {
         return ThreadController.getThreadsByFolderId(folderId, realm)
     }
 
-    override fun otherFolderRolesToQueryThreads(): List<FolderRole> = emptyList()
+    override fun twinFolderRoles(): List<FolderRole> = emptyList()
 
     override fun shouldHideEmptyFolder(): Boolean = false
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/InboxRefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/InboxRefreshStrategy.kt
@@ -28,7 +28,7 @@ val inboxRefreshStrategy = object : DefaultRefreshStrategy {
         return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = false, realm = realm)
     }
 
-    override fun otherFolderRolesToQueryThreads(): List<FolderRole> = listOf(FolderRole.SNOOZED)
+    override fun twinFolderRoles(): List<FolderRole> = listOf(FolderRole.SNOOZED)
 
     override fun addFolderToImpactedFolders(folderId: String, impactedFolders: ImpactedFolders) {
         impactedFolders += folderId

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/RefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/RefreshStrategy.kt
@@ -30,7 +30,14 @@ import kotlinx.coroutines.CoroutineScope
 interface RefreshStrategy {
     fun queryFolderThreads(folderId: String, realm: TypedRealm): List<Thread>
 
-    fun otherFolderRolesToQueryThreads(): List<FolderRole>
+
+    /**
+     * The list of other folder roles that need to query their threads again when the current folder has its threads queried.
+     *
+     * Some folders such as INBOX and Snooze require to query again the other folder's threads as well. For example, if a
+     * message uid is returned as "added" or "deleted" in the snooze folder, it should disappear or appear from inbox as well.
+     */
+    fun twinFolderRoles(): List<FolderRole>
 
     fun shouldHideEmptyFolder(): Boolean
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/SnoozeRefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/SnoozeRefreshStrategy.kt
@@ -35,7 +35,7 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
         return ThreadController.getInboxThreadsWithSnoozeFilter(withSnooze = true, realm = realm)
     }
 
-    override fun otherFolderRolesToQueryThreads(): List<FolderRole> = listOf(FolderRole.INBOX)
+    override fun twinFolderRoles(): List<FolderRole> = listOf(FolderRole.INBOX)
 
     override fun shouldHideEmptyFolder(): Boolean = true
 


### PR DESCRIPTION
Introduces the naming concept of "twin folders". They are folders where their thread dependant properties need to be recomputed together when one of them changes.