### PR TITLE
refactor: Turn refresh strategy and folder sort getter methods into property methods

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -271,7 +271,7 @@ class RefreshController @Inject constructor(
 
         var inboxUnreadCount: Int? = null
         write {
-            val refreshStrategy = folder.refreshStrategy()
+            val refreshStrategy = folder.refreshStrategy
             val impactedFolders = ImpactedFolders()
             impactedFolders += handleDeletedUids(scope, activities.deletedShortUids, folder.id, refreshStrategy)
             impactedFolders += handleUpdatedUids(scope, activities.updatedMessages, folder.id, refreshStrategy)
@@ -507,7 +507,7 @@ class RefreshController @Inject constructor(
 
         val impactedThreadsManaged = mutableSetOf<Thread>()
         val addedMessagesUids = mutableListOf<Int>()
-        val refreshStrategy = folder.refreshStrategy()
+        val refreshStrategy = folder.refreshStrategy
 
         remoteMessages.forEach { remoteMessage ->
             scope.ensureActive()
@@ -651,7 +651,7 @@ class RefreshController @Inject constructor(
         getUpToDateFolder(folderId).let { currentFolder ->
             recomputeThreadsDependantProperties(currentFolder, folderId)
             extraFolderUpdates?.invoke(currentFolder)
-            currentFolderRefreshStrategy = currentFolder.refreshStrategy()
+            currentFolderRefreshStrategy = currentFolder.refreshStrategy
         }
 
         currentFolderRefreshStrategy.twinFolderRoles().forEach { otherFolderRole ->
@@ -662,7 +662,7 @@ class RefreshController @Inject constructor(
     }
 
     private fun MutableRealm.recomputeThreadsDependantProperties(folder: Folder, folderIdToQueryOn: String) {
-        val refreshStrategy = folder.refreshStrategy()
+        val refreshStrategy = folder.refreshStrategy
         val allThreads = refreshStrategy.queryFolderThreads(folderIdToQueryOn, realm = this)
         folder.threads.replaceContent(list = allThreads)
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -239,7 +239,7 @@ class ThreadController @Inject constructor(
 
             val notFromSearch = "${Thread::isFromSearch.name} == false"
             val notLocallyMovedOut = " AND ${Thread::isLocallyMovedOut.name} == false"
-            val folderSort = folder.getFolderSort()
+            val folderSort = folder.folderSort
             val realmQuery = folder.threads
                 .query(notFromSearch + notLocallyMovedOut)
                 .sort(folderSort.sortBy, folderSort.sortOrder)

--- a/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Folder.kt
@@ -120,6 +120,10 @@ class Folder : RealmObject, Cloneable {
     val isRootAndCustom: Boolean
         inline get() = role == null && isRoot
 
+    val refreshStrategy: RefreshStrategy get() = role?.refreshStrategy ?: defaultRefreshStrategy
+
+    val folderSort get() = role?.folderSort ?: FolderSort.Default
+
     fun initLocalValues(
         lastUpdatedAt: RealmInstant?,
         cursor: String?,
@@ -148,10 +152,6 @@ class Folder : RealmObject, Cloneable {
     }
 
     fun messages(realm: TypedRealm): List<Message> = MessageController.getMessagesByFolderId(id, realm)
-
-    fun refreshStrategy(): RefreshStrategy = role?.refreshStrategy ?: defaultRefreshStrategy
-
-    fun getFolderSort() = role?.folderSort ?: FolderSort.Default
 
     fun getLocalizedName(context: Context): String {
         return role?.folderNameRes?.let(context::getString) ?: name


### PR DESCRIPTION
Motivated by the change request of the first part of the snooze PR

Depends on #2259 