### PR TITLE
fix: Display snoozed threads as such in the search

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -78,6 +78,12 @@ class Thread : RealmObject {
     var isAnswered: Boolean = false
     @SerialName("forwarded")
     var isForwarded: Boolean = false
+    @SerialName("snooze_state")
+    private var _snoozeState: String? = null
+    @SerialName("snooze_end_date")
+    var snoozeEndDate: RealmInstant? = null
+    @SerialName("snooze_action")
+    var snoozeAction: String? = null
     //endregion
 
     //region Local data (Transient)
@@ -99,12 +105,6 @@ class Thread : RealmObject {
     var isLocallyMovedOut: Boolean = false
     @Transient
     var numberOfScheduledDrafts: Int = 0
-    @Transient
-    private var _snoozeState: String? = null
-    @Transient
-    var snoozeEndDate: RealmInstant? = null
-    @Transient
-    var snoozeAction: String? = null
     //endregion
 
     @Ignore
@@ -183,6 +183,7 @@ class Thread : RealmObject {
 
     fun recomputeThread(realm: MutableRealm? = null) {
 
+        // TODO: Remove this or modify it to be like iOS
         // Delete Thread if empty. Do not rely on this deletion code being part of the method's logic, it's a temporary fix. If
         // threads should be deleted, then they need to be deleted outside this method.
         if (messages.none { it.folderId == folderId }) {


### PR DESCRIPTION
This PR required to modify the code that deletes empty threads inside `recomputeThread()` because modifying a snoozed thread by, for exemple, reading it would trigger a `recomputeThread()` which would instantly delete the opened Thread.

In the search, some threads (such as threads from the snooze folder) won't have any messages with the same folderId as the thread folderId. This is an expected behavior and we don't want to delete it this case. We just need to fallback on the last message of the thread when looking for the `lastMessage`.

This reproduces some of the logic of iOS. We keep the same logic we always had if we're not from the search but we can fallback on `messages.lastOrNull()` when we're on a thread from the search. Threads from the search are expected to not always have messages from the same `folderId` as the thread's `folderId`