### PR TITLE
fix: Define displayDate in realm so we can query on it

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -161,7 +161,7 @@ object RealmDatabase {
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 3L
         const val MAILBOX_INFO_SCHEMA_VERSION = 8L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 24L
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 25L
         //endregion
 
         //region Configurations names

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -56,11 +56,16 @@ class Message : RealmObject {
     var uid: String = ""
     @SerialName("msg_id")
     var messageId: String? = null
-    @SerialName("date")
-    var originalDate: RealmInstant? = null
-        private set
     @SerialName("internal_date")
     var internalDate: RealmInstant = Date().toRealmInstant() // This date is always defined, so the default value is meaningless
+        private set
+
+    /**
+     * [displayDate] is different than [internalDate] because it must be used when displaying the date of an email but it can't be
+     * used to sort messages chronologically.
+     */
+    @SerialName("date")
+    var displayDate: RealmInstant = internalDate
         private set
     var subject: String? = null
     var from = realmListOf<Recipient>()
@@ -175,13 +180,6 @@ class Message : RealmObject {
 
     @Ignore
     var snoozeState: SnoozeState? by apiEnum(::_snoozeState)
-
-    /**
-     * [displayDate] is different than [internalDate] because it must be used when displaying
-     * the date of an email but it can't be used to sort messages chronologically.
-     * A message's [originalDate] is not always defined. When this happens, we want to display the [internalDate] in its place.
-     */
-    val displayDate: RealmInstant get() = originalDate ?: internalDate
 
     val threads by backlinks(Thread::messages)
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -60,11 +60,11 @@ class Thread : RealmObject {
     @PrimaryKey
     var uid: String = ""
     var messages = realmListOf<Message>()
-    @SerialName("date")
-    private var originalDate: RealmInstant? = null
     // This value should always be provided because messages always have at least an internalDate. Because of this, the initial value is meaningless
     @SerialName("internal_date")
     var internalDate: RealmInstant = Date().toRealmInstant()
+    @SerialName("date")
+    var displayDate: RealmInstant = internalDate
     @SerialName("unseen_messages")
     var unseenMessagesCount: Int = 0
     var from = realmListOf<Recipient>()
@@ -110,8 +110,6 @@ class Thread : RealmObject {
     @Ignore
     var snoozeState: SnoozeState? by apiEnum(::_snoozeState)
         private set
-
-    val displayDate: RealmInstant get() = originalDate ?: internalDate
 
     // TODO: Put this back in `private` when the Threads parental issues are fixed
     val _folders by backlinks(Folder::threads)
@@ -264,7 +262,7 @@ class Thread : RealmObject {
          */
         duplicates.forEach(::updateSnoozeStatesBasedOn)
 
-        originalDate = lastMessage.originalDate
+        displayDate = lastMessage.displayDate
         internalDate = lastMessage.internalDate
         subject = messages.first().subject
     }


### PR DESCRIPTION
We were sorting the realm query by `displayDate` which is a method and therefore caused the sorting to crash. Now we define `displayDate` directly inside realm like iOS.