### PR TITLE
refactor: Rename mail const defined in core with a more generic name

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
@@ -17,7 +17,7 @@
  */
 package com.infomaniak.mail.data.api
 
-import com.infomaniak.core.utils.FORMAT_SCHEDULE_MAIL
+import com.infomaniak.core.utils.FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR
 import com.infomaniak.core.utils.format
 import com.infomaniak.lib.core.BuildConfig.INFOMANIAK_API_V1
 import com.infomaniak.mail.BuildConfig.MAIL_API
@@ -228,7 +228,7 @@ object ApiRoutes {
     }
 
     fun rescheduleDraft(draftResource: String, scheduleDate: Date): String {
-        val formatedDate = scheduleDate.format(FORMAT_SCHEDULE_MAIL)
+        val formatedDate = scheduleDate.format(FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR)
         return "${MAIL_API}${draftResource}/schedule?schedule_date=${URLEncoder.encode(formatedDate, "UTF-8")}"
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -37,7 +37,7 @@ import androidx.navigation.NavDestination
 import androidx.navigation.fragment.NavHostFragment
 import androidx.work.Data
 import com.airbnb.lottie.LottieAnimationView
-import com.infomaniak.core.utils.FORMAT_SCHEDULE_MAIL
+import com.infomaniak.core.utils.FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR
 import com.infomaniak.core.utils.year
 import com.infomaniak.lib.core.MatomoCore.TrackerAction
 import com.infomaniak.lib.core.utils.SentryLog
@@ -312,8 +312,9 @@ class MainActivity : BaseActivity() {
                     val scheduleDate = getString(DraftsActionsWorker.SCHEDULED_DRAFT_DATE_KEY)
                     val unscheduleDraftUrl = getString(DraftsActionsWorker.UNSCHEDULE_DRAFT_URL_KEY)
                     if (scheduleDate != null && unscheduleDraftUrl != null) {
+                        val dateFormat = SimpleDateFormat(FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR, Locale.getDefault())
                         showScheduledDraftSnackbar(
-                            scheduleDate = SimpleDateFormat(FORMAT_SCHEDULE_MAIL, Locale.getDefault()).parse(scheduleDate)!!,
+                            scheduleDate = dateFormat.parse(scheduleDate)!!,
                             unscheduleDraftUrl = unscheduleDraftUrl,
                         )
                     }

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -26,7 +26,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.net.MailTo
 import androidx.core.net.toUri
 import androidx.lifecycle.*
-import com.infomaniak.core.utils.FORMAT_SCHEDULE_MAIL
+import com.infomaniak.core.utils.FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR
 import com.infomaniak.core.utils.format
 import com.infomaniak.lib.core.MatomoCore.TrackerAction
 import com.infomaniak.lib.core.utils.*
@@ -865,7 +865,7 @@ class NewMessageViewModel @Inject constructor(
         val localUuid = draftLocalUuid ?: return@launch
         mailboxContentRealm().write {
             DraftController.getDraft(localUuid, realm = this)?.also { draft ->
-                draft.scheduleDate = date?.format(FORMAT_SCHEDULE_MAIL)
+                draft.scheduleDate = date?.format(FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR)
             }
         }
     }


### PR DESCRIPTION
It will be reused for snooze as well, but I can already put this in its own PR on master

Depends on https://github.com/Infomaniak/android-core/pull/314