### PR TITLE
feat: Unsnooze messages and threads on the api when they receive a new message

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -345,6 +345,10 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.blockUser(mailboxUuid, folderId, shortUid), POST)
     }
 
+    fun unsnoozeThread(mailboxUuid: String, snoozeUuid: String): ApiResponse<Boolean> {
+        return callApi(ApiRoutes.snoozeAction(mailboxUuid, snoozeUuid), DELETE)
+    }
+
     fun unsnoozeThreads(mailboxUuid: String, snoozeUuids: List<String>): List<ApiResponse<Unit>> {
         return batchOver(snoozeUuids, limit = Utils.MAX_UUIDS_PER_CALL_SNOOZE_DELETE) {
             callApi(ApiRoutes.snooze(mailboxUuid), DELETE, mapOf("uuids" to it))

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -347,7 +347,7 @@ object ApiRepository : ApiRepositoryCore() {
 
     fun unsnoozeMessages(mailboxUuid: String, messageUids: List<String>): List<ApiResponse<Unit>> {
         return batchOver(messageUids, limit = Utils.MAX_UIDS_PER_CALL_SNOOZE_DELETE) {
-            callApi(ApiRoutes.snooze(mailboxUuid), DELETE, mapOf("uids" to it))
+            callApi(ApiRoutes.snooze(mailboxUuid), DELETE, mapOf("uuids" to it)) // TODO: Change into uids when api fixes the argument name
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -346,7 +346,7 @@ object ApiRepository : ApiRepositoryCore() {
     }
 
     fun unsnoozeMessages(mailboxUuid: String, snoozeUuids: List<String>): List<ApiResponse<Unit>> {
-        return batchOver(snoozeUuids, limit = Utils.MAX_UIDS_PER_CALL_SNOOZE_DELETE) {
+        return batchOver(snoozeUuids, limit = Utils.MAX_UUIDS_PER_CALL_SNOOZE_DELETE) {
             callApi(ApiRoutes.snooze(mailboxUuid), DELETE, mapOf("uuids" to it))
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -345,6 +345,12 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.blockUser(mailboxUuid, folderId, shortUid), POST)
     }
 
+    fun unsnoozeMessages(mailboxUuid: String, messageUids: List<String>): List<ApiResponse<Unit>> {
+        return batchOver(messageUids, limit = Utils.MAX_UIDS_PER_CALL_SNOOZE_DELETE) {
+            callApi(ApiRoutes.snooze(mailboxUuid), DELETE, mapOf("uids" to it))
+        }
+    }
+
     fun searchThreads(mailboxUuid: String, folderId: String, filters: String, resource: String?): ApiResponse<ThreadResult> {
 
         val url = if (resource.isNullOrBlank()) {

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -345,7 +345,7 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.blockUser(mailboxUuid, folderId, shortUid), POST)
     }
 
-    fun unsnoozeMessages(mailboxUuid: String, snoozeUuids: List<String>): List<ApiResponse<Unit>> {
+    fun unsnoozeThreads(mailboxUuid: String, snoozeUuids: List<String>): List<ApiResponse<Unit>> {
         return batchOver(snoozeUuids, limit = Utils.MAX_UUIDS_PER_CALL_SNOOZE_DELETE) {
             callApi(ApiRoutes.snooze(mailboxUuid), DELETE, mapOf("uuids" to it))
         }

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -345,9 +345,9 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.blockUser(mailboxUuid, folderId, shortUid), POST)
     }
 
-    fun unsnoozeMessages(mailboxUuid: String, messageUids: List<String>): List<ApiResponse<Unit>> {
-        return batchOver(messageUids, limit = Utils.MAX_UIDS_PER_CALL_SNOOZE_DELETE) {
-            callApi(ApiRoutes.snooze(mailboxUuid), DELETE, mapOf("uuids" to it)) // TODO: Change into uids when api fixes the argument name
+    fun unsnoozeMessages(mailboxUuid: String, snoozeUuids: List<String>): List<ApiResponse<Unit>> {
+        return batchOver(snoozeUuids, limit = Utils.MAX_UIDS_PER_CALL_SNOOZE_DELETE) {
+            callApi(ApiRoutes.snooze(mailboxUuid), DELETE, mapOf("uuids" to it))
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
@@ -281,6 +281,10 @@ object ApiRoutes {
     fun snooze(mailboxUuid: String): String {
         return "${mailMailbox(mailboxUuid)}/snoozes"
     }
+
+    fun snoozeAction(mailboxUuid: String, snoozeUuid: String): String {
+        return "${snooze(mailboxUuid)}/$snoozeUuid"
+    }
     //endregion
 
     private fun mailboxUuidParameter(mailboxUuid: String): String {

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
@@ -277,6 +277,12 @@ object ApiRoutes {
     }
     //endregion
 
+    //region Snooze
+    fun snooze(mailboxUuid: String): String {
+        return "${mailMailbox(mailboxUuid)}/snoozes"
+    }
+    //endregion
+
     private fun mailboxUuidParameter(mailboxUuid: String): String {
         return "?mailbox_uuid=$mailboxUuid"
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -164,7 +164,7 @@ object RealmDatabase {
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 3L
         const val MAILBOX_INFO_SCHEMA_VERSION = 9L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 27L
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 28L
         //endregion
 
         //region Configurations names

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
@@ -46,7 +46,7 @@ val MAILBOX_CONTENT_MIGRATION = AutomaticSchemaMigration { migrationContext ->
     migrationContext.initializeInternalDateAsDateAfterTwentySecondMigration()
     migrationContext.replaceOriginalDateWithDisplayDateAfterTwentyFourthMigration()
     migrationContext.deserializeSnoozeUuidDirectlyAfterTwentyFifthMigration()
-    migrationContext.initIsLastMessageSnoozedAfterTwentySeventhMigration()
+    migrationContext.initIsLastInboxMessageSnoozedAfterTwentySeventhMigration()
 }
 
 // Migrate to version #1
@@ -186,7 +186,7 @@ private fun MigrationContext.deserializeSnoozeUuidDirectlyAfterTwentyFifthMigrat
 //endregion
 
 // Migrate from version #27
-private fun MigrationContext.initIsLastMessageSnoozedAfterTwentySeventhMigration() {
+private fun MigrationContext.initIsLastInboxMessageSnoozedAfterTwentySeventhMigration() {
 
     if (oldRealm.schemaVersion() <= 27L) {
         enumerate(className = "Thread") { oldObject: DynamicRealmObject, newObject: DynamicMutableRealmObject? ->
@@ -203,7 +203,7 @@ private fun MigrationContext.initIsLastMessageSnoozedAfterTwentySeventhMigration
                 val snoozeUuid = lastMessage.getNullableValue<String>("snoozeUuid")
                 val isSnoozed = snoozeState == SnoozeState.Snoozed.apiValue && snoozeEndDate != null && snoozeUuid != null
 
-                newThread.set(propertyName = "isLastMessageSnoozed", value = isSnoozed)
+                newThread.set(propertyName = "isLastInboxMessageSnoozed", value = isSnoozed)
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
@@ -189,7 +189,7 @@ private fun MigrationContext.deserializeSnoozeUuidDirectlyAfterTwentyFifthMigrat
 private fun MigrationContext.initIsLastInboxMessageSnoozedAfterTwentySeventhMigration() {
 
     if (oldRealm.schemaVersion() <= 27L) {
-        enumerate(className = "Thread") { oldObject: DynamicRealmObject, newObject: DynamicMutableRealmObject? ->
+        enumerate(className = "Thread") { _: DynamicRealmObject, newObject: DynamicMutableRealmObject? ->
             newObject?.let { newThread ->
                 // Initialize new property by computing it based on other fields
                 val threadFolderId = newObject.getValue<String>("folderId")

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -262,6 +262,12 @@ class RefreshController @Inject constructor(
 
             write {
                 cannotBeUnsnoozedThreadUids.forEach { manuallyUnsnoozeOutOfSyncThread(it) }
+
+                if (cannotBeUnsnoozedThreadUids.isNotEmpty()) {
+                    FolderController.getFolder(FolderRole.SNOOZED, realm = this)?.id?.let { snoozeFolderId ->
+                        recomputeTwinFoldersThreadsDependantProperties(snoozeFolderId)
+                    }
+                }
             }
 
             impactedFolders

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -111,6 +111,13 @@ class RefreshController @Inject constructor(
 
             ThreadController.deleteEmptyThreadsInFolder(folder.id, realm)
 
+            if (folder.role == FolderRole.INBOX) {
+                val snoozedThreadsWithNewMessage = ThreadController.getSnoozedThreadsWithNewMessage(folder.id, realm)
+                snoozedThreadsWithNewMessage.forEach { thread ->
+                    // TODO: Send api call to remove the snooze status of each thread that received a new message
+                }
+            }
+
             if (threads != null) {
                 onStop?.invoke()
                 SentryLog.d("API", "End of refreshing threads with mode: $refreshMode | (${folder.displayForSentry()})")

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -31,11 +31,8 @@ import com.infomaniak.mail.data.models.getMessages.*
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
-import com.infomaniak.mail.utils.ApiErrorException
-import com.infomaniak.mail.utils.ErrorCode
-import com.infomaniak.mail.utils.SentryDebug
+import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.SentryDebug.displayForSentry
-import com.infomaniak.mail.utils.Utils
 import com.infomaniak.mail.utils.extensions.replaceContent
 import com.infomaniak.mail.utils.extensions.throwErrorAsException
 import com.infomaniak.mail.utils.extensions.toRealmInstant
@@ -58,6 +55,7 @@ class RefreshController @Inject constructor(
     private val localSettings: LocalSettings,
     private val mailboxController: MailboxController,
     private val delayApiCallManager: DelayApiCallManager,
+    private val sharedUtils: SharedUtils,
 ) {
 
     private var refreshThreadsJob: Job? = null
@@ -226,12 +224,10 @@ class RefreshController @Inject constructor(
         return impactedThreads
     }
 
-    private fun removeSnoozeStateOfThreadsWithNewMessages(folder: Folder) {
+    private suspend fun removeSnoozeStateOfThreadsWithNewMessages(folder: Folder) {
         if (folder.role == FolderRole.INBOX) {
             val snoozedThreadsWithNewMessage = ThreadController.getSnoozedThreadsWithNewMessage(folder.id, realm)
-            snoozedThreadsWithNewMessage.forEach { thread ->
-                // TODO: Send api call to remove the snooze status of each thread that received a new message
-            }
+            sharedUtils.unsnoozeThreads(mailbox, snoozedThreadsWithNewMessage)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -237,7 +237,7 @@ class RefreshController @Inject constructor(
                 FolderController.getFolder(folderId, realm = this)?.let {
                     mainRefresh(scope, folder = it)
                 }
-            }
+            }.cancellable()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -55,7 +55,6 @@ class RefreshController @Inject constructor(
     private val localSettings: LocalSettings,
     private val mailboxController: MailboxController,
     private val delayApiCallManager: DelayApiCallManager,
-    private val sharedUtils: SharedUtils,
 ) {
 
     private var refreshThreadsJob: Job? = null
@@ -236,7 +235,7 @@ class RefreshController @Inject constructor(
     private fun removeSnoozeStateOfThreadsWithNewMessages(scope: CoroutineScope, folder: Folder): Set<String> {
         return if (folder.role == FolderRole.INBOX) {
             val snoozedThreadsWithNewMessage = ThreadController.getSnoozedThreadsWithNewMessage(folder.id, realm)
-            sharedUtils.unsnoozeThreadsWithoutRefresh(scope, mailbox, snoozedThreadsWithNewMessage)
+            SharedUtils.unsnoozeThreadsWithoutRefresh(scope, mailbox, snoozedThreadsWithNewMessage)
         } else {
             emptySet()
         }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -219,9 +219,8 @@ class RefreshController @Inject constructor(
         impactedThreads += fetchAllNewPages(scope, folder.id)
         fetchAllOldPages(scope, folder.id)
 
-        val folderIds = removeSnoozeStateOfThreadsWithNewMessages(scope, folder)
-
-        folderIds.forEach { folderId ->
+        val impactedFolderIds = removeSnoozeStateOfThreadsWithNewMessages(scope, folder)
+        impactedFolderIds.forEach { folderId ->
             scope.ensureActive()
 
             runCatching {
@@ -237,8 +236,10 @@ class RefreshController @Inject constructor(
     private fun removeSnoozeStateOfThreadsWithNewMessages(scope: CoroutineScope, folder: Folder): Set<String> {
         return if (folder.role == FolderRole.INBOX) {
             val snoozedThreadsWithNewMessage = ThreadController.getSnoozedThreadsWithNewMessage(folder.id, realm)
-            sharedUtils.unsnoozeThreads(scope, mailbox, snoozedThreadsWithNewMessage)
-        } else emptySet()
+            sharedUtils.unsnoozeThreadsWithoutRefresh(scope, mailbox, snoozedThreadsWithNewMessage)
+        } else {
+            emptySet()
+        }
     }
 
     private suspend fun Realm.fetchOnePageOfOldMessages(scope: CoroutineScope, folderId: String) {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -111,13 +111,6 @@ class RefreshController @Inject constructor(
 
             ThreadController.deleteEmptyThreadsInFolder(folder.id, realm)
 
-            if (folder.role == FolderRole.INBOX) {
-                val snoozedThreadsWithNewMessage = ThreadController.getSnoozedThreadsWithNewMessage(folder.id, realm)
-                snoozedThreadsWithNewMessage.forEach { thread ->
-                    // TODO: Send api call to remove the snooze status of each thread that received a new message
-                }
-            }
-
             if (threads != null) {
                 onStop?.invoke()
                 SentryLog.d("API", "End of refreshing threads with mode: $refreshMode | (${folder.displayForSentry()})")
@@ -228,7 +221,18 @@ class RefreshController @Inject constructor(
         impactedThreads += fetchAllNewPages(scope, folder.id)
         fetchAllOldPages(scope, folder.id)
 
+        removeSnoozeStateOfThreadsWithNewMessages(folder)
+
         return impactedThreads
+    }
+
+    private fun removeSnoozeStateOfThreadsWithNewMessages(folder: Folder) {
+        if (folder.role == FolderRole.INBOX) {
+            val snoozedThreadsWithNewMessage = ThreadController.getSnoozedThreadsWithNewMessage(folder.id, realm)
+            snoozedThreadsWithNewMessage.forEach { thread ->
+                // TODO: Send api call to remove the snooze status of each thread that received a new message
+            }
+        }
     }
 
     private suspend fun Realm.fetchOnePageOfOldMessages(scope: CoroutineScope, folderId: String) {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -229,6 +229,9 @@ class RefreshController @Inject constructor(
     }
 
     private suspend fun Realm.extraRefresh(scope: CoroutineScope, folder: Folder) {
+        // No need to check realm, there can't be any snoozed thread with a new message when there's a single message per thread
+        if (localSettings.threadMode == ThreadMode.MESSAGE) return
+
         val impactedFolderIds = removeSnoozeStateOfThreadsWithNewMessages(scope, folder)
         impactedFolderIds.forEach { folderId ->
             scope.ensureActive()

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -321,7 +321,7 @@ class ThreadController @Inject constructor(
 
         fun getSnoozedThreadsWithNewMessage(inboxFolderId: String, realm: Realm): List<Thread> {
             val isInFolder = "${Thread::folderId.name} == $0"
-            val hasNewMessage = "${Thread::isLastMessageSnoozed.name} == false"
+            val hasNewMessage = "${Thread::isLastInboxMessageSnoozed.name} == false"
             return realm.query<Thread>("$isInFolder AND $hasNewMessage AND $isSnoozedState", inboxFolderId).find()
         }
         //endregion

--- a/app/src/main/java/com/infomaniak/mail/data/models/Snoozable.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Snoozable.kt
@@ -17,13 +17,24 @@
  */
 package com.infomaniak.mail.data.models
 
+import androidx.annotation.CallSuper
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import io.realm.kotlin.types.RealmInstant
 
 interface Snoozable {
-    val snoozeState: SnoozeState?
+    var snoozeState: SnoozeState?
     var snoozeEndDate: RealmInstant?
     var snoozeUuid: String?
+
+    /**
+     * Only used for when the api tells us we're trying to automatically unsnooze a thread that's not snoozed
+     */
+    @CallSuper
+    fun manuallyUnsnooze() {
+        snoozeState = null
+        snoozeEndDate = null
+        snoozeUuid = null
+    }
 }
 
 /**

--- a/app/src/main/java/com/infomaniak/mail/data/models/Snoozable.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Snoozable.kt
@@ -18,7 +18,6 @@
 package com.infomaniak.mail.data.models
 
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
-import com.infomaniak.mail.data.models.thread.Thread
 import io.realm.kotlin.types.RealmInstant
 
 interface Snoozable {
@@ -29,7 +28,6 @@ interface Snoozable {
 
 /**
  * Keep the snooze state condition of [Snoozable.isSnoozed] the same as
- * the condition used in [ThreadController.getThreadsWithSnoozeFilterQuery].
- * As in, check that [Thread.snoozeEndDate] and [Thread.snoozeUuid] are not null.
+ * the condition used in [ThreadController.Companion.isSnoozedState].
  */
 fun Snoozable.isSnoozed() = snoozeState == SnoozeState.Snoozed && snoozeEndDate != null && snoozeUuid != null

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -105,7 +105,7 @@ class Thread : RealmObject, Snoozable {
     @Transient
     var numberOfScheduledDrafts: Int = 0
     @Transient
-    var isLastMessageSnoozed: Boolean = false
+    var isLastInboxMessageSnoozed: Boolean = false
     //endregion
 
     @Ignore
@@ -222,7 +222,7 @@ class Thread : RealmObject, Snoozable {
         snoozeState = null
         snoozeEndDate = null
         snoozeUuid = null
-        isLastMessageSnoozed = false
+        isLastInboxMessageSnoozed = false
     }
 
     private fun updateThread(lastMessage: Message) {
@@ -268,7 +268,7 @@ class Thread : RealmObject, Snoozable {
         internalDate = lastMessage.internalDate
         subject = messages.first().subject
 
-        isLastMessageSnoozed = messages.isLastInboxMessageSnoozed()
+        isLastInboxMessageSnoozed = messages.isLastInboxMessageSnoozed()
     }
 
     /**

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -110,7 +110,6 @@ class Thread : RealmObject, Snoozable {
 
     @Ignore
     override var snoozeState: SnoozeState? by apiEnum(::_snoozeState)
-        private set
 
     // TODO: Put this back in `private` when the Threads parental issues are fixed
     val _folders by backlinks(Folder::threads)
@@ -295,10 +294,10 @@ class Thread : RealmObject, Snoozable {
     /**
      * Only used for when the api tells us we're trying to automatically unsnooze a thread that's not snoozed
      */
-    fun manuallyUnsnooze() {
-        snoozeState = null
-        snoozeEndDate = null
-        snoozeUuid = null
+    override fun manuallyUnsnooze() {
+        super.manuallyUnsnooze()
+        messages.forEach(Message::manuallyUnsnooze)
+        duplicates.forEach(Message::manuallyUnsnooze)
     }
 
     fun computeAvatarRecipient(): Pair<Recipient?, Bimi?> = runCatching {

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -104,6 +104,8 @@ class Thread : RealmObject, Snoozable {
     var isLocallyMovedOut: Boolean = false
     @Transient
     var numberOfScheduledDrafts: Int = 0
+    @Transient
+    var isLastMessageSnoozed: Boolean = false
     //endregion
 
     @Ignore
@@ -220,6 +222,7 @@ class Thread : RealmObject, Snoozable {
         snoozeState = null
         snoozeEndDate = null
         snoozeUuid = null
+        isLastMessageSnoozed = false
     }
 
     private fun updateThread(lastMessage: Message) {
@@ -264,6 +267,7 @@ class Thread : RealmObject, Snoozable {
         displayDate = lastMessage.displayDate
         internalDate = lastMessage.internalDate
         subject = messages.first().subject
+        isLastMessageSnoozed = lastMessage.isSnoozed()
     }
 
     fun computeAvatarRecipient(): Pair<Recipient?, Bimi?> = runCatching {

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -292,6 +292,15 @@ class Thread : RealmObject, Snoozable {
         return lastOrNull { it.folderId == folderId }?.isSnoozed() ?: false
     }
 
+    /**
+     * Only used for when the api tells us we're trying to automatically unsnooze a thread that's not snoozed
+     */
+    fun manuallyUnsnooze() {
+        snoozeState = null
+        snoozeEndDate = null
+        snoozeUuid = null
+    }
+
     fun computeAvatarRecipient(): Pair<Recipient?, Bimi?> = runCatching {
 
         val message = messages.lastOrNull {

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -267,7 +267,29 @@ class Thread : RealmObject, Snoozable {
         displayDate = lastMessage.displayDate
         internalDate = lastMessage.internalDate
         subject = messages.first().subject
-        isLastMessageSnoozed = lastMessage.isSnoozed()
+
+        isLastMessageSnoozed = messages.isLastInboxMessageSnoozed()
+    }
+
+    /**
+     * This method determines whether the last inbox message in the list is snoozed. If there are none, it returns false.
+     *
+     * Instead of querying Realm every time to retrieve the inbox folder ID, we rely on the fact that [Snoozable.isSnoozed] only
+     * returns `true` for messages whose [Message.folderId] matches the inbox folder ID.
+     *
+     * To illustrate the reasoning:
+     * | folderId == inbox | isSnoozed() | Comment                        | Result         |
+     * |-------------------|-------------|--------------------------------|----------------|
+     * | false             | false       | isSnoozed always returns false | false          |
+     * | false             | true        | This situation doesn't exist   | doesn't matter |
+     * |-------------------|-------------|--------------------------------|----------------|
+     * | true              | false       |                                | false          |
+     * | true              | true        |                                | true           |
+     *
+     * => Only returns true when the last message of inbox is snoozed
+     */
+    private fun List<Message>.isLastInboxMessageSnoozed(): Boolean {
+        return lastOrNull { it.folderId == folderId }?.isSnoozed() ?: false
     }
 
     fun computeAvatarRecipient(): Pair<Recipient?, Bimi?> = runCatching {

--- a/app/src/main/java/com/infomaniak/mail/utils/ErrorCode.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ErrorCode.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -92,6 +92,10 @@ object ErrorCode {
     const val MAX_SYNTAX_TOKENS_REACHED = "max_token_reached"
     const val TOO_MANY_REQUESTS = "too_many_request"
     const val OBJECT_NOT_FOUND = "object_not_found"
+    //endregion
+
+    //region Snooze
+    const val MAIL_MESSAGE_NOT_SNOOZED = "mail__message_not_snoozed"
     //endregion
 
     val apiErrorCodes = listOf(

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -227,7 +227,7 @@ class SharedUtils @Inject constructor(
 
             if (snoozeUuids.isEmpty()) return emptySet()
 
-            val apiResponses = ApiRepository.unsnoozeMessages(mailbox.uuid, snoozeUuids)
+            val apiResponses = ApiRepository.unsnoozeThreads(mailbox.uuid, snoozeUuids)
             scope.ensureActive()
 
             return if (apiResponses.atLeastOneSucceeded()) impactedFolderIds else emptySet()

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -212,20 +212,22 @@ class SharedUtils @Inject constructor(
         }
 
         fun unsnoozeThreadsWithoutRefresh(scope: CoroutineScope, mailbox: Mailbox, threads: List<Thread>): Set<String> {
-            val messagesUids: MutableList<String> = mutableListOf()
+            val snoozeUuids: MutableList<String> = mutableListOf()
             val impactedFolderIds: MutableSet<String> = mutableSetOf()
 
             for (thread in threads) {
                 scope.ensureActive()
 
-                val targetMessage = thread.messages.lastOrNull(Message::isSnoozed) ?: continue
-                messagesUids += targetMessage.uid
+                val targetMessage = thread.messages.lastOrNull(Message::isSnoozed)
+                val targetMessageSnoozeUuid = targetMessage?.snoozeUuid ?: continue
+
+                snoozeUuids += targetMessageSnoozeUuid
                 impactedFolderIds += targetMessage.folderId
             }
 
-            if (messagesUids.isEmpty()) return emptySet()
+            if (snoozeUuids.isEmpty()) return emptySet()
 
-            val apiResponses = ApiRepository.unsnoozeMessages(mailbox.uuid, messagesUids)
+            val apiResponses = ApiRepository.unsnoozeMessages(mailbox.uuid, snoozeUuids)
             scope.ensureActive()
 
             return if (apiResponses.atLeastOneSucceeded()) impactedFolderIds else emptySet()

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -215,10 +215,10 @@ class SharedUtils @Inject constructor(
             val messagesUids: MutableList<String> = mutableListOf()
             val impactedFolderIds: MutableSet<String> = mutableSetOf()
 
-            threads.forEach { thread ->
+            for (thread in threads) {
                 scope.ensureActive()
 
-                val targetMessage = thread.messages.last(Message::isSnoozed) // TODO: Fix crash if message not found
+                val targetMessage = thread.messages.lastOrNull(Message::isSnoozed) ?: continue
                 messagesUids += targetMessage.uid
                 impactedFolderIds += targetMessage.folderId
             }

--- a/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
@@ -49,7 +49,7 @@ object Utils {
     const val MAX_OLD_PAGES_TO_FETCH_TO_GET_ENOUGH_THREADS = 5 // We don't want to spam the API, so we just get a few pages
 
     const val MAX_UIDS_PER_CALL = 1_000 // Beware: the API refuses a MAX_UIDS_PER_CALL bigger than 1000
-    const val MAX_UIDS_PER_CALL_SNOOZE_DELETE = 50
+    const val MAX_UIDS_PER_CALL_SNOOZE_DELETE = 100
 
     const val TAG_SEPARATOR = " "
 

--- a/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,6 +49,7 @@ object Utils {
     const val MAX_OLD_PAGES_TO_FETCH_TO_GET_ENOUGH_THREADS = 5 // We don't want to spam the API, so we just get a few pages
 
     const val MAX_UIDS_PER_CALL = 1_000 // Beware: the API refuses a MAX_UIDS_PER_CALL bigger than 1000
+    const val MAX_UIDS_PER_CALL_SNOOZE_DELETE = 50
 
     const val TAG_SEPARATOR = " "
 

--- a/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
@@ -49,7 +49,7 @@ object Utils {
     const val MAX_OLD_PAGES_TO_FETCH_TO_GET_ENOUGH_THREADS = 5 // We don't want to spam the API, so we just get a few pages
 
     const val MAX_UIDS_PER_CALL = 1_000 // Beware: the API refuses a MAX_UIDS_PER_CALL bigger than 1000
-    const val MAX_UIDS_PER_CALL_SNOOZE_DELETE = 100
+    const val MAX_UUIDS_PER_CALL_SNOOZE_DELETE = 100
 
     const val TAG_SEPARATOR = " "
 


### PR DESCRIPTION
This PR reproduces the hack that the webmail has to do to let snoozed threads with new messages be unsnoozed and reappear in the inbox.

When refreshing folders, we need to detect snoozed threads that have their last message belonging to inbox not snoozed. This state is the state we need to fix, by making an "unsnooze" api call so the thread will come back into inbox.

If the api doesn't lets us unsnooze this specific uuid, the thread could be detected on every refresh and try to be unsnoozed forever, so we take the party to manually unsnooze it and its snoozed messages in the database in this strange case.

Also, the migration for `isLastInboxMessageSnoozed` might be overkill, initializing to `false` would only mean that existing threads in this very rare state won't be automatically unsnoozed by the hack. But they would later be unsnoozed if the thread is recomputed

Depends on #2293