### PR TITLE
feat: Hide currently scheduled date when prompt the user to choose another scheduled date

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -65,6 +65,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.kotlin.Realm
 import io.realm.kotlin.ext.toRealmList
 import io.realm.kotlin.notifications.ResultsChange
+import io.realm.kotlin.types.RealmInstant
 import io.sentry.Attachment
 import io.sentry.Sentry
 import io.sentry.SentryLevel
@@ -249,6 +250,8 @@ class MainViewModel @Inject constructor(
 
     //region Scheduled Draft
     var draftResource: String? = null
+    // Save the current scheduled date of the draft we're rescheduling to be able to pass it to the schedule bottom sheet
+    var reschedulingCurrentlyScheduledDate: RealmInstant? = null
     //endregion
 
     //region Share Thread URL

--- a/app/src/main/java/com/infomaniak/mail/ui/bottomSheetDialogs/ScheduleSendBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/bottomSheetDialogs/ScheduleSendBottomSheetDialog.kt
@@ -35,6 +35,7 @@ class ScheduleSendBottomSheetDialog @Inject constructor() : SelectScheduleOption
     // Navigation args does not support nullable primitive types, so we use 0L
     // as a replacement (corresponding to Thursday 1 January 1970 00:00:00 UT).
     override val lastSelectedEpoch: Long? by lazy { navigationArgs.lastSelectedScheduleEpoch.takeIf { it != 0L } }
+    override val currentlyScheduledEpoch: Long? by lazy { navigationArgs.currentlyScheduledEpoch.takeIf { it != 0L } }
 
     override val titleRes: Int = R.string.scheduleSendingTitle
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -68,6 +68,7 @@ import com.infomaniak.mail.utils.date.DateFormatUtils.fullDateWithYear
 import com.infomaniak.mail.utils.date.MailDateFormatUtils.mailFormattedDate
 import com.infomaniak.mail.utils.extensions.*
 import com.infomaniak.mail.utils.extensions.AttachmentExt.AttachmentIntentType
+import io.realm.kotlin.types.RealmInstant
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.CoroutineScope
@@ -457,7 +458,12 @@ class ThreadAdapter(
 
     private fun MessageViewHolder.bindAlerts(message: Message) = with(binding) {
         message.draftResource?.let { draftResource ->
-            scheduleAlert.onAction1 { threadAdapterCallbacks?.onRescheduleClicked?.invoke(draftResource) }
+            scheduleAlert.onAction1 {
+                threadAdapterCallbacks?.onRescheduleClicked?.invoke(
+                    draftResource,
+                    message.displayDate.takeIf { message.isScheduledDraft },
+                )
+            }
         }
 
         scheduleAlert.onAction2 { threadAdapterCallbacks?.onModifyScheduledClicked?.invoke(message) }
@@ -769,7 +775,7 @@ class ThreadAdapter(
         var navigateToDownloadProgressDialog: ((Attachment, AttachmentIntentType) -> Unit)? = null,
         var replyToCalendarEvent: ((AttendanceState, Message) -> Unit)? = null,
         var promptLink: ((String, ContextMenuType) -> Unit)? = null,
-        var onRescheduleClicked: ((String) -> Unit)? = null,
+        var onRescheduleClicked: ((String, RealmInstant?) -> Unit)? = null,
         var onModifyScheduledClicked: ((Message) -> Unit)? = null,
     )
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -87,6 +87,7 @@ import com.infomaniak.mail.utils.Utils.runCatchingRealm
 import com.infomaniak.mail.utils.extensions.*
 import com.infomaniak.mail.utils.extensions.AttachmentExt.openAttachment
 import dagger.hilt.android.AndroidEntryPoint
+import io.realm.kotlin.types.RealmInstant
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import java.util.Date
@@ -725,8 +726,9 @@ class ThreadFragment : Fragment() {
         )
     }
 
-    private fun rescheduleDraft(draftResource: String) {
+    private fun rescheduleDraft(draftResource: String, currentScheduledDate: RealmInstant?) {
         mainViewModel.draftResource = draftResource
+        mainViewModel.reschedulingCurrentlyScheduledDate = currentScheduledDate
         navigateToScheduleSendBottomSheet()
     }
 
@@ -735,6 +737,7 @@ class ThreadFragment : Fragment() {
             resId = R.id.scheduleSendBottomSheetDialog,
             args = ScheduleSendBottomSheetDialogArgs(
                 lastSelectedScheduleEpoch = localSettings.lastSelectedScheduleEpoch ?: 0L,
+                currentlyScheduledEpoch = mainViewModel.reschedulingCurrentlyScheduledDate?.epochSeconds?.times(1000) ?: 0L,
                 isCurrentMailboxFree = mainViewModel.currentMailbox.value?.isFreeMailbox ?: true,
             ).toBundle(),
             currentClassName = ThreadFragment::class.java.name,

--- a/app/src/main/res/navigation/new_message_navigation.xml
+++ b/app/src/main/res/navigation/new_message_navigation.xml
@@ -92,6 +92,10 @@
             android:defaultValue="0L"
             app:argType="long" />
         <argument
+            android:name="currentlyScheduledEpoch"
+            android:defaultValue="0L"
+            app:argType="long" />
+        <argument
             android:name="isCurrentMailboxFree"
             android:defaultValue="true"
             app:argType="boolean" />


### PR DESCRIPTION
When rescheduling a draft, the already selected date is displayed and can be selected again. This PR hides it. It's also going to be useful for snoozed messages when the scheduling feature will come