### PR TITLE
fix: Add missing navargs definition that, only sometimes, prevents build

### DIFF
--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -258,6 +258,10 @@
             android:defaultValue="0L"
             app:argType="long" />
         <argument
+            android:name="currentlyScheduledEpochMillis"
+            android:defaultValue="0L"
+            app:argType="long" />
+        <argument
             android:name="isCurrentMailboxFree"
             android:defaultValue="true"
             app:argType="boolean" />


### PR DESCRIPTION
The dialog is defined twice in two navigations (main and new message), then a Dialog uses the generated navarg class to access arguments, but one of the two navigation definition was missing an argument present in the other. This led to the app sometimes (but not always?) not building