### PR TITLE
feat: Bind modify button of the snoozed thread header

### DIFF
--- a/.idea/navEditor.xml
+++ b/.idea/navEditor.xml
@@ -112,7 +112,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="2148" />
                           </Point>
                         </option>
@@ -124,8 +124,8 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="3282" />
-                            <option name="y" value="12" />
+                            <option name="x" value="744" />
+                            <option name="y" value="368" />
                           </Point>
                         </option>
                       </LayoutPositions>
@@ -136,7 +136,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="3928" />
                           </Point>
                         </option>
@@ -148,7 +148,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="1792" />
                           </Point>
                         </option>
@@ -160,7 +160,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="666" />
+                            <option name="x" value="1964" />
                             <option name="y" value="4547" />
                           </Point>
                         </option>
@@ -172,7 +172,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="12" />
+                            <option name="x" value="1232" />
                             <option name="y" value="368" />
                           </Point>
                         </option>
@@ -193,8 +193,8 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="2628" />
-                            <option name="y" value="12" />
+                            <option name="x" value="12" />
+                            <option name="y" value="368" />
                           </Point>
                         </option>
                       </LayoutPositions>
@@ -205,7 +205,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="3216" />
                           </Point>
                         </option>
@@ -217,7 +217,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1102" />
+                            <option name="x" value="2452" />
                             <option name="y" value="4682" />
                           </Point>
                         </option>
@@ -229,7 +229,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1102" />
+                            <option name="x" value="2452" />
                             <option name="y" value="3258" />
                           </Point>
                         </option>
@@ -241,7 +241,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1102" />
+                            <option name="x" value="2452" />
                             <option name="y" value="2546" />
                           </Point>
                         </option>
@@ -253,7 +253,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1102" />
+                            <option name="x" value="2452" />
                             <option name="y" value="2190" />
                           </Point>
                         </option>
@@ -265,7 +265,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="2504" />
                           </Point>
                         </option>
@@ -291,7 +291,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="368" />
                           </Point>
                         </option>
@@ -303,8 +303,8 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="12" />
-                            <option name="y" value="12" />
+                            <option name="x" value="1476" />
+                            <option name="y" value="368" />
                           </Point>
                         </option>
                       </LayoutPositions>
@@ -315,7 +315,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="12" />
+                            <option name="x" value="2692" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -327,7 +327,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="2860" />
                           </Point>
                         </option>
@@ -339,7 +339,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1102" />
+                            <option name="x" value="2452" />
                             <option name="y" value="3614" />
                           </Point>
                         </option>
@@ -351,7 +351,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="666" />
+                            <option name="x" value="1964" />
                             <option name="y" value="4903" />
                           </Point>
                         </option>
@@ -363,7 +363,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="230" />
+                            <option name="x" value="496" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -375,7 +375,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1102" />
+                            <option name="x" value="1960" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -387,7 +387,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="666" />
+                            <option name="x" value="1964" />
                             <option name="y" value="2494" />
                           </Point>
                         </option>
@@ -399,7 +399,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1538" />
+                            <option name="x" value="2448" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -411,7 +411,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="4326" />
                           </Point>
                         </option>
@@ -442,7 +442,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1320" />
+                            <option name="x" value="2204" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -454,7 +454,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="666" />
+                            <option name="x" value="984" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -466,7 +466,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="5394" />
                           </Point>
                         </option>
@@ -478,7 +478,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="666" />
+                            <option name="x" value="1964" />
                             <option name="y" value="5259" />
                           </Point>
                         </option>
@@ -499,7 +499,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="12" />
+                            <option name="x" value="988" />
                             <option name="y" value="368" />
                           </Point>
                         </option>
@@ -523,7 +523,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="12" />
+                            <option name="x" value="252" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -535,8 +535,8 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="3064" />
-                            <option name="y" value="12" />
+                            <option name="x" value="500" />
+                            <option name="y" value="368" />
                           </Point>
                         </option>
                       </LayoutPositions>
@@ -547,8 +547,8 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="2846" />
-                            <option name="y" value="12" />
+                            <option name="x" value="256" />
+                            <option name="y" value="368" />
                           </Point>
                         </option>
                       </LayoutPositions>
@@ -559,7 +559,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="2410" />
+                            <option name="x" value="3668" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -571,7 +571,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="1228" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -583,7 +583,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1974" />
+                            <option name="x" value="3180" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -595,7 +595,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="252" />
+                            <option name="x" value="1472" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -607,7 +607,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="666" />
+                            <option name="x" value="1964" />
                             <option name="y" value="368" />
                           </Point>
                         </option>
@@ -628,7 +628,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="3572" />
                           </Point>
                         </option>
@@ -654,7 +654,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="666" />
+                            <option name="x" value="1964" />
                             <option name="y" value="2850" />
                           </Point>
                         </option>
@@ -730,8 +730,20 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1102" />
+                            <option name="x" value="2452" />
                             <option name="y" value="4326" />
+                          </Point>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="snoozeBottomSheetDialog">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="1716" />
+                            <option name="y" value="12" />
                           </Point>
                         </option>
                       </LayoutPositions>
@@ -742,7 +754,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1102" />
+                            <option name="x" value="2452" />
                             <option name="y" value="3970" />
                           </Point>
                         </option>
@@ -754,7 +766,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1102" />
+                            <option name="x" value="2452" />
                             <option name="y" value="5038" />
                           </Point>
                         </option>
@@ -766,7 +778,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="5038" />
                           </Point>
                         </option>
@@ -787,7 +799,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="2192" />
+                            <option name="x" value="3424" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -799,7 +811,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="1436" />
                           </Point>
                         </option>
@@ -811,7 +823,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="666" />
+                            <option name="x" value="1964" />
                             <option name="y" value="5616" />
                           </Point>
                         </option>
@@ -823,7 +835,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="1080" />
                           </Point>
                         </option>
@@ -835,7 +847,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="448" />
+                            <option name="x" value="1720" />
                             <option name="y" value="4889" />
                           </Point>
                         </option>
@@ -891,7 +903,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="884" />
+                            <option name="x" value="2208" />
                             <option name="y" value="724" />
                           </Point>
                         </option>
@@ -903,7 +915,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="1756" />
+                            <option name="x" value="2936" />
                             <option name="y" value="12" />
                           </Point>
                         </option>
@@ -915,7 +927,7 @@
                       <LayoutPositions>
                         <option name="myPosition">
                           <Point>
-                            <option name="x" value="448" />
+                            <option name="x" value="740" />
                             <option name="y" value="12" />
                           </Point>
                         </option>

--- a/app/src/main/java/com/infomaniak/mail/MatomoMail.kt
+++ b/app/src/main/java/com/infomaniak/mail/MatomoMail.kt
@@ -68,6 +68,8 @@ object MatomoMail : MatomoCore {
     const val SWITCH_MAILBOX_NAME = "switchMailbox"
     const val LAST_SELECTED_SCHEDULE = "lastSelectedSchedule"
     const val SCHEDULED_CUSTOM_DATE = "scheduledCustomDate"
+    const val MODIFY_SCHEDULE_FROM_HEADER = "modifyScheduleFromHeader"
+    const val CANCEL_SCHEDULE_FROM_HEADER = "cancelScheduleFromHeader"
     //endregion
 
     @SuppressLint("RestrictedApi") // This `SuppressLint` is there so the CI can build
@@ -282,6 +284,10 @@ object MatomoMail : MatomoCore {
     }
 
     fun Fragment.trackScheduleSendEvent(name: String) {
+        trackEvent("scheduleSend", name)
+    }
+
+    fun Context.trackScheduleSendEvent(name: String) {
         trackEvent("scheduleSend", name)
     }
 

--- a/app/src/main/java/com/infomaniak/mail/MatomoMail.kt
+++ b/app/src/main/java/com/infomaniak/mail/MatomoMail.kt
@@ -66,6 +66,8 @@ object MatomoMail : MatomoCore {
     const val SEARCH_DELETE_NAME = "deleteSearch"
     const val SEARCH_VALIDATE_NAME = "validateSearch"
     const val SWITCH_MAILBOX_NAME = "switchMailbox"
+    const val LAST_SELECTED_SCHEDULE = "lastSelectedSchedule"
+    const val SCHEDULED_CUSTOM_DATE = "scheduledCustomDate"
     //endregion
 
     @SuppressLint("RestrictedApi") // This `SuppressLint` is there so the CI can build
@@ -281,6 +283,10 @@ object MatomoMail : MatomoCore {
 
     fun Fragment.trackScheduleSendEvent(name: String) {
         trackEvent("scheduleSend", name)
+    }
+
+    fun Fragment.trackSnoozeEvent(name: String) {
+        trackEvent("snooze", name)
     }
 
     fun Fragment.trackMyKSuiteEvent(name: String) {

--- a/app/src/main/java/com/infomaniak/mail/MatomoMail.kt
+++ b/app/src/main/java/com/infomaniak/mail/MatomoMail.kt
@@ -59,6 +59,8 @@ object MatomoMail : MatomoCore {
     const val ACTION_SHARE_LINK_NAME = "shareLink"
     const val ACTION_SAVE_TO_KDRIVE_NAME = "saveInkDrive"
     const val ACTION_POSTPONE_NAME = "postpone"
+    const val ACTION_MODIFY_SNOOZE_NAME= "modifySnooze"
+    const val ACTION_CANCEL_SNOOZE_NAME = "cancelSnooze"
     const val ADD_MAILBOX_NAME = "addMailbox"
     const val DISCOVER_LATER = "discoverLater"
     const val DISCOVER_NOW = "discoverNow"
@@ -68,8 +70,6 @@ object MatomoMail : MatomoCore {
     const val SWITCH_MAILBOX_NAME = "switchMailbox"
     const val LAST_SELECTED_SCHEDULE = "lastSelectedSchedule"
     const val SCHEDULED_CUSTOM_DATE = "scheduledCustomDate"
-    const val MODIFY_SCHEDULE_FROM_HEADER = "modifyScheduleFromHeader"
-    const val CANCEL_SCHEDULE_FROM_HEADER = "cancelScheduleFromHeader"
     //endregion
 
     @SuppressLint("RestrictedApi") // This `SuppressLint` is there so the CI can build

--- a/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
@@ -68,6 +68,7 @@ class LocalSettings private constructor(context: Context) : SharedValues {
     var showWebViewOutdated by sharedValue("showWebViewOutdatedKey", true)
     var accessTokenApiCallRecord by sharedValue<ApiCallRecord>("accessTokenApiCallRecordKey", null)
     var lastSelectedScheduleEpochMillis by sharedValue<Long>("lastSelectedScheduleEpochKey", null)
+    var lastSelectedSnoozeEpochMillis by sharedValue<Long>("lastSelectedSnoozeEpochMillisKey", null)
     var storageBannerDisplayAppLaunches by sharedValue("storageBannerDisplayAppLaunchesKey", 0)
     var hasClosedStorageBanner by sharedValue("hasClosedStorageBannerKey", false)
 

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -19,6 +19,7 @@ package com.infomaniak.mail.data.api
 
 import com.infomaniak.core.myksuite.ui.data.MyKSuiteData
 import com.infomaniak.core.utils.FORMAT_FULL_DATE_WITH_HOUR
+import com.infomaniak.core.utils.FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR
 import com.infomaniak.core.utils.format
 import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.R
@@ -343,6 +344,16 @@ object ApiRepository : ApiRepositoryCore() {
 
     fun blockUser(mailboxUuid: String, folderId: String, shortUid: Int): ApiResponse<Boolean> {
         return callApi(ApiRoutes.blockUser(mailboxUuid, folderId, shortUid), POST)
+    }
+
+    fun rescheduleSnoozedThread(snoozeActions: List<String>, newDate: Date): List<ApiResponse<Boolean>> {
+        return batchOver(snoozeActions, limit = 1) { snoozeAction ->
+            callApi(
+                url = ApiRoutes.resource(snoozeAction.single()),
+                method = PUT,
+                body = mapOf("end_date" to newDate.format(FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR))
+            )
+        }
     }
 
     fun unsnoozeThread(mailboxUuid: String, snoozeUuid: String): ApiResponse<Boolean> {

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -348,7 +348,7 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.blockUser(mailboxUuid, folderId, shortUid), POST)
     }
 
-    fun rescheduleSnoozedThread(
+    fun rescheduleSnoozedThreads(
         mailboxUuid: String,
         snoozeUuids: List<String>,
         newDate: Date,

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -54,6 +54,8 @@ import com.infomaniak.mail.data.models.mailbox.*
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.signature.Signature
 import com.infomaniak.mail.data.models.signature.SignaturesResult
+import com.infomaniak.mail.data.models.snooze.BatchSnoozeCancelResponse
+import com.infomaniak.mail.data.models.snooze.BatchSnoozeUpdateResponse
 import com.infomaniak.mail.data.models.thread.ThreadResult
 import com.infomaniak.mail.ui.newMessage.AiViewModel.Shortcut
 import com.infomaniak.mail.utils.AccountUtils

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -346,12 +346,16 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.blockUser(mailboxUuid, folderId, shortUid), POST)
     }
 
-    fun rescheduleSnoozedThread(snoozeActions: List<String>, newDate: Date): List<ApiResponse<Boolean>> {
-        return batchOver(snoozeActions, limit = 1) { snoozeAction ->
+    fun rescheduleSnoozedThread(
+        mailboxUuid: String,
+        snoozeUuids: List<String>,
+        newDate: Date,
+    ): List<ApiResponse<BatchSnoozeUpdateResponse>> {
+        return batchOver(snoozeUuids, limit = Utils.MAX_UUIDS_PER_CALL_SNOOZE) {
             callApi(
-                url = ApiRoutes.resource(snoozeAction.single()),
+                url = ApiRoutes.snooze(mailboxUuid),
                 method = PUT,
-                body = mapOf("end_date" to newDate.format(FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR))
+                body = mapOf("uuids" to it, "end_date" to newDate.format(FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR))
             )
         }
     }
@@ -360,8 +364,8 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.snoozeAction(mailboxUuid, snoozeUuid), DELETE)
     }
 
-    fun unsnoozeThreads(mailboxUuid: String, snoozeUuids: List<String>): List<ApiResponse<BatchSnoozeResponse>> {
-        return batchOver(snoozeUuids, limit = Utils.MAX_UUIDS_PER_CALL_SNOOZE_DELETE) {
+    fun unsnoozeThreads(mailboxUuid: String, snoozeUuids: List<String>): List<ApiResponse<BatchSnoozeCancelResponse>> {
+        return batchOver(snoozeUuids, limit = Utils.MAX_UUIDS_PER_CALL_SNOOZE) {
             callApi(ApiRoutes.snooze(mailboxUuid), DELETE, mapOf("uuids" to it))
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ImpactedFolders.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ImpactedFolders.kt
@@ -24,6 +24,8 @@ data class ImpactedFolders(
     private val folderIds: MutableSet<String> = mutableSetOf(),
     private val folderRoles: MutableSet<FolderRole> = mutableSetOf(),
 ) {
+    constructor(roles: MutableSet<FolderRole>) : this(folderRoles = roles)
+
     operator fun plusAssign(folderId: String) {
         folderIds += folderId
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -35,7 +35,6 @@ import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.SentryDebug.displayForSentry
 import com.infomaniak.mail.utils.SharedUtils.Companion.AutomaticUnsnoozeResult
-import com.infomaniak.mail.utils.SharedUtils.Companion.UnsnoozeResult
 import com.infomaniak.mail.utils.extensions.replaceContent
 import com.infomaniak.mail.utils.extensions.throwErrorAsException
 import com.infomaniak.mail.utils.extensions.toRealmInstant

--- a/app/src/main/java/com/infomaniak/mail/data/models/BatchSnoozeCancelResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/BatchSnoozeCancelResponse.kt
@@ -1,0 +1,25 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+class BatchSnoozeCancelResponse {
+    val cancelled: List<String> = emptyList()
+}

--- a/app/src/main/java/com/infomaniak/mail/data/models/BatchSnoozeUpdateResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/BatchSnoozeUpdateResponse.kt
@@ -20,6 +20,6 @@ package com.infomaniak.mail.data.models
 import kotlinx.serialization.Serializable
 
 @Serializable
-class BatchSnoozeResponse {
-    val cancelled: List<String> = emptyList()
+class BatchSnoozeUpdateResponse {
+    val updated: List<String> = emptyList()
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeCancelResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeCancelResponse.kt
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.infomaniak.mail.data.models
+package com.infomaniak.mail.data.models.snooze
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeCancelResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeCancelResponse.kt
@@ -17,9 +17,11 @@
  */
 package com.infomaniak.mail.data.models
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-class BatchSnoozeUpdateResponse {
-    val updated: List<String> = emptyList()
+class BatchSnoozeCancelResponse : BatchSnoozeResponse {
+    @SerialName("cancelled")
+    override val processedUuids: List<String> = emptyList()
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeResponse.kt
@@ -15,11 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.infomaniak.mail.data.models
+package com.infomaniak.mail.data.models.snooze
 
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.mail.data.cache.mailboxContent.ImpactedFolders
-import com.infomaniak.mail.utils.SharedUtils.Companion.BatchSnoozeResult
 import com.infomaniak.mail.utils.extensions.getFirstTranslatedError
 
 interface BatchSnoozeResponse {

--- a/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeResponse.kt
@@ -1,0 +1,40 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.models
+
+import com.infomaniak.lib.core.models.ApiResponse
+import com.infomaniak.mail.data.cache.mailboxContent.ImpactedFolders
+import com.infomaniak.mail.utils.SharedUtils.Companion.BatchSnoozeResult
+import com.infomaniak.mail.utils.extensions.getFirstTranslatedError
+
+interface BatchSnoozeResponse {
+    val processedUuids: List<String>
+
+    companion object {
+        fun <T: BatchSnoozeResponse> List<ApiResponse<T>>.computeSnoozeResult(impactedFolderIds: ImpactedFolders) = when {
+            all { it.isSuccess().not() } -> {
+                val translatedError = getFirstTranslatedError()
+                if (translatedError == null) BatchSnoozeResult.Error.Unknown else BatchSnoozeResult.Error.ApiError(translatedError)
+            }
+            any { it.isSuccess() && it.data?.processedUuids?.isNotEmpty() == true } -> {
+                BatchSnoozeResult.Success(impactedFolderIds)
+            }
+            else -> BatchSnoozeResult.Error.NoneSucceeded
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeResult.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeResult.kt
@@ -17,11 +17,14 @@
  */
 package com.infomaniak.mail.data.models.snooze
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import androidx.annotation.StringRes
+import com.infomaniak.mail.data.cache.mailboxContent.ImpactedFolders
 
-@Serializable
-class BatchSnoozeUpdateResponse : BatchSnoozeResponse {
-    @SerialName("updated")
-    override val processedUuids: List<String> = emptyList()
+sealed interface BatchSnoozeResult {
+    data class Success(val impactedFolders: ImpactedFolders) : BatchSnoozeResult
+    sealed interface Error : BatchSnoozeResult {
+        data object NoneSucceeded : Error
+        data class ApiError(@StringRes val translatedError: Int) : Error
+        data object Unknown : Error
+    }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeUpdateResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeUpdateResponse.kt
@@ -17,9 +17,11 @@
  */
 package com.infomaniak.mail.data.models
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-class BatchSnoozeCancelResponse {
-    val cancelled: List<String> = emptyList()
+class BatchSnoozeUpdateResponse : BatchSnoozeResponse {
+    @SerialName("updated")
+    override val processedUuids: List<String> = emptyList()
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -1108,7 +1108,7 @@ class MainViewModel @Inject constructor(
     //endregion
 
     //region Snooze
-    suspend fun rescheduleSnoozedThread(date: Date, threads: List<Thread>): BatchSnoozeResult {
+    suspend fun rescheduleSnoozedThreads(date: Date, threads: List<Thread>): BatchSnoozeResult {
         var rescheduleResult: BatchSnoozeResult = BatchSnoozeResult.Error.Unknown
 
         viewModelScope.launch(ioCoroutineContext) {
@@ -1116,7 +1116,7 @@ class MainViewModel @Inject constructor(
             if (snoozedThreadUuids.isEmpty()) return@launch
 
             val currentMailbox = currentMailbox.value!!
-            val result = rescheduleSnoozedThread(currentMailbox, snoozedThreadUuids, date)
+            val result = rescheduleSnoozedThreads(currentMailbox, snoozedThreadUuids, date)
             if (result is BatchSnoozeResult.Success) refreshFoldersAsync(currentMailbox, result.impactedFolders)
 
             rescheduleResult = result
@@ -1125,8 +1125,8 @@ class MainViewModel @Inject constructor(
         return rescheduleResult
     }
 
-    private fun rescheduleSnoozedThread(currentMailbox: Mailbox, snoozeUuids: List<String>, date: Date): BatchSnoozeResult {
-        val responses = ApiRepository.rescheduleSnoozedThread(currentMailbox.uuid, snoozeUuids, date)
+    private fun rescheduleSnoozedThreads(currentMailbox: Mailbox, snoozeUuids: List<String>, date: Date): BatchSnoozeResult {
+        val responses = ApiRepository.rescheduleSnoozedThreads(currentMailbox.uuid, snoozeUuids, date)
         return responses.computeSnoozeResult(ImpactedFolders(mutableSetOf(FolderRole.SNOOZED)))
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -1110,8 +1110,8 @@ class MainViewModel @Inject constructor(
     fun rescheduleSnoozedThread(date: Date, thread: Thread) = viewModelScope.launch(ioCoroutineContext) {
         if (thread.isSnoozed().not()) return@launch
 
-        thread.snoozeAction?.let {
-            val responses = ApiRepository.rescheduleSnoozedThread(listOf(it), date)
+        thread.snoozeUuid?.let {
+            val responses = ApiRepository.rescheduleSnoozedThread(listOf(it), date) // TODO: Use correct api call
             if (responses.atLeastOneSucceeded()) {
                 refreshFoldersAsync(currentMailbox.value!!, ImpactedFolders(mutableSetOf(FolderRole.SNOOZED)))
             } else {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -38,7 +38,7 @@ import com.infomaniak.mail.data.cache.mailboxInfo.PermissionsController
 import com.infomaniak.mail.data.cache.mailboxInfo.QuotasController
 import com.infomaniak.mail.data.cache.userInfo.AddressBookController
 import com.infomaniak.mail.data.cache.userInfo.MergedContactController
-import com.infomaniak.mail.data.models.BatchSnoozeResponse.Companion.computeSnoozeResult
+import com.infomaniak.mail.data.models.snooze.BatchSnoozeResponse.Companion.computeSnoozeResult
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.MoveResult
@@ -57,7 +57,7 @@ import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.ContactUtils.getPhoneContacts
 import com.infomaniak.mail.utils.ContactUtils.mergeApiContactsIntoPhoneContacts
 import com.infomaniak.mail.utils.NotificationUtils.Companion.cancelNotification
-import com.infomaniak.mail.utils.SharedUtils.Companion.BatchSnoozeResult
+import com.infomaniak.mail.data.models.snooze.BatchSnoozeResult
 import com.infomaniak.mail.utils.SharedUtils.Companion.updateSignatures
 import com.infomaniak.mail.utils.Utils.EML_CONTENT_TYPE
 import com.infomaniak.mail.utils.Utils.isPermanentDeleteFolder

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -42,6 +42,7 @@ import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.MoveResult
 import com.infomaniak.mail.data.models.correspondent.Recipient
+import com.infomaniak.mail.data.models.isSnoozed
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.mailbox.SendersRestrictions
 import com.infomaniak.mail.data.models.message.Message
@@ -1107,6 +1108,14 @@ class MainViewModel @Inject constructor(
     //endregion
 
     //region Snooze
+    fun rescheduleSnoozedThread(date: Date, thread: Thread) = viewModelScope.launch(ioCoroutineContext) {
+        if (thread.isSnoozed().not()) return@launch
+
+        thread.snoozeAction?.let {
+            ApiRepository.rescheduleSnoozedThread(listOf(it), date)
+        }
+    }
+
     suspend fun unsnoozeThreads(threads: List<Thread>): UnsnoozeResult {
         var unsnoozeResult: UnsnoozeResult = UnsnoozeResult.Error.Unknown
 

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
@@ -34,7 +34,7 @@ open class SelectDateAndTimeForScheduledDraftDialog @Inject constructor(
     @ActivityContext private val activityContext: Context,
 ) : SelectDateAndTimeDialog(activityContext) {
 
-    override val positiveButtonText: Int = R.string.buttonScheduleTitle
+    override val positiveButtonText: Int = R.string.buttonConfirm
 
     override fun defineCalendarConstraint(): CalendarConstraints.Builder {
         val dateValidators = listOf(

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForSnoozeDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForSnoozeDialog.kt
@@ -30,11 +30,11 @@ import java.util.Date
 import javax.inject.Inject
 
 @ActivityScoped
-open class SelectDateAndTimeForScheduledDraftDialog @Inject constructor(
+open class SelectDateAndTimeForSnoozeDialog @Inject constructor(
     @ActivityContext private val activityContext: Context,
 ) : SelectDateAndTimeDialog(activityContext) {
 
-    override val positiveButtonText: Int = R.string.buttonScheduleTitle
+    override val positiveButtonText: Int = R.string.buttonSnooze
 
     override fun defineCalendarConstraint(): CalendarConstraints.Builder {
         val dateValidators = listOf(
@@ -45,11 +45,11 @@ open class SelectDateAndTimeForScheduledDraftDialog @Inject constructor(
     }
 
     override fun getDelayTooShortErrorMessage(): String = activityContext.getString(
-        R.string.errorScheduleDelayTooShort,
+        R.string.errorScheduledSnoozeDelayTooShort,
         MIN_SELECTABLE_DATE_MINUTES,
     )
 
     companion object {
-        const val MAX_SCHEDULE_DELAY_YEARS = 10
+        const val MAX_SCHEDULE_DELAY_YEARS = 1
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForSnoozeDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForSnoozeDialog.kt
@@ -34,7 +34,7 @@ open class SelectDateAndTimeForSnoozeDialog @Inject constructor(
     @ActivityContext private val activityContext: Context,
 ) : SelectDateAndTimeDialog(activityContext) {
 
-    override val positiveButtonText: Int = R.string.buttonSnooze
+    override val positiveButtonText: Int = R.string.buttonConfirm
 
     override fun defineCalendarConstraint(): CalendarConstraints.Builder {
         val dateValidators = listOf(

--- a/app/src/main/java/com/infomaniak/mail/ui/bottomSheetDialogs/SnoozeBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/bottomSheetDialogs/SnoozeBottomSheetDialog.kt
@@ -21,16 +21,16 @@ import androidx.navigation.fragment.navArgs
 import com.infomaniak.lib.core.utils.setBackNavigationResult
 import com.infomaniak.mail.MatomoMail.LAST_SELECTED_SCHEDULE
 import com.infomaniak.mail.MatomoMail.SCHEDULED_CUSTOM_DATE
-import com.infomaniak.mail.MatomoMail.trackScheduleSendEvent
+import com.infomaniak.mail.MatomoMail.trackSnoozeEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.utils.openMyKSuiteUpgradeBottomSheet
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ScheduleSendBottomSheetDialog @Inject constructor() : SelectScheduleOptionBottomSheet() {
+class SnoozeBottomSheetDialog @Inject constructor() : SelectScheduleOptionBottomSheet() {
 
-    private val navigationArgs: ScheduleSendBottomSheetDialogArgs by navArgs()
+    private val navigationArgs: SnoozeBottomSheetDialogArgs by navArgs()
 
     override val isCurrentMailboxFree: Boolean by lazy { navigationArgs.isCurrentMailboxFree }
 
@@ -39,30 +39,30 @@ class ScheduleSendBottomSheetDialog @Inject constructor() : SelectScheduleOption
     override val lastSelectedEpoch: Long? by lazy { navigationArgs.lastSelectedScheduleEpochMillis.takeIf { it != 0L } }
     override val currentlyScheduledEpochMillis: Long? by lazy { navigationArgs.currentlyScheduledEpochMillis.takeIf { it != 0L } }
 
-    override val titleRes: Int = R.string.scheduleSendingTitle
+    override val titleRes: Int = R.string.snoozeBottomSheetTitle
 
     override fun onLastScheduleOptionClicked() {
         if (lastSelectedEpoch != null) {
-            trackScheduleSendEvent(LAST_SELECTED_SCHEDULE)
-            setBackNavigationResult(SCHEDULE_DRAFT_RESULT, lastSelectedEpoch)
+            trackSnoozeEvent(LAST_SELECTED_SCHEDULE)
+            setBackNavigationResult(SNOOZE_RESULT, lastSelectedEpoch)
         }
     }
 
     override fun onScheduleOptionClicked(dateItem: ScheduleOption) {
-        trackScheduleSendEvent(dateItem.matomoValue)
-        setBackNavigationResult(SCHEDULE_DRAFT_RESULT, dateItem.date().time)
+        trackSnoozeEvent(dateItem.matomoValue)
+        setBackNavigationResult(SNOOZE_RESULT, dateItem.date().time)
     }
 
     override fun onCustomScheduleOptionClicked() {
         if (navigationArgs.isCurrentMailboxFree) {
             openMyKSuiteUpgradeBottomSheet(SCHEDULED_CUSTOM_DATE)
         } else {
-            setBackNavigationResult(OPEN_SCHEDULE_DRAFT_DATE_AND_TIME_PICKER, true)
+            setBackNavigationResult(OPEN_SNOOZE_DATE_AND_TIME_PICKER, true)
         }
     }
 
     companion object {
-        const val SCHEDULE_DRAFT_RESULT = "schedule_draft_result"
-        const val OPEN_SCHEDULE_DRAFT_DATE_AND_TIME_PICKER = "open_schedule_draft_date_and_time_picker"
+        const val SNOOZE_RESULT = "snooze_result"
+        const val OPEN_SNOOZE_DATE_AND_TIME_PICKER = "open_snooze_date_and_time_picker"
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -44,8 +44,8 @@ import com.infomaniak.core.utils.FORMAT_DATE_DAY_FULL_MONTH_YEAR_WITH_TIME
 import com.infomaniak.core.utils.format
 import com.infomaniak.lib.core.utils.context
 import com.infomaniak.lib.core.utils.isNightModeEnabled
-import com.infomaniak.mail.MatomoMail.CANCEL_SCHEDULE_FROM_HEADER
-import com.infomaniak.mail.MatomoMail.MODIFY_SCHEDULE_FROM_HEADER
+import com.infomaniak.mail.MatomoMail.ACTION_CANCEL_SNOOZE_NAME
+import com.infomaniak.mail.MatomoMail.ACTION_MODIFY_SNOOZE_NAME
 import com.infomaniak.mail.MatomoMail.trackMessageEvent
 import com.infomaniak.mail.MatomoMail.trackScheduleSendEvent
 import com.infomaniak.mail.R
@@ -466,7 +466,7 @@ class ThreadAdapter(
     private fun MessageViewHolder.bindAlerts(message: Message) = with(binding) {
         message.draftResource?.let { draftResource ->
             scheduleAlert.onAction1 {
-                context.trackScheduleSendEvent(MODIFY_SCHEDULE_FROM_HEADER)
+                context.trackScheduleSendEvent(ACTION_MODIFY_SNOOZE_NAME)
                 threadAdapterCallbacks?.onRescheduleClicked?.invoke(
                     draftResource,
                     message.displayDate.takeIf { message.isScheduledDraft }?.epochSeconds?.times(1_000),
@@ -475,7 +475,7 @@ class ThreadAdapter(
         }
 
         scheduleAlert.onAction2 {
-            context.trackScheduleSendEvent(CANCEL_SCHEDULE_FROM_HEADER)
+            context.trackScheduleSendEvent(ACTION_CANCEL_SNOOZE_NAME)
             threadAdapterCallbacks?.onModifyScheduledClicked?.invoke(message)
         }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -44,7 +44,10 @@ import com.infomaniak.core.utils.FORMAT_DATE_DAY_FULL_MONTH_YEAR_WITH_TIME
 import com.infomaniak.core.utils.format
 import com.infomaniak.lib.core.utils.context
 import com.infomaniak.lib.core.utils.isNightModeEnabled
+import com.infomaniak.mail.MatomoMail.CANCEL_SCHEDULE_FROM_HEADER
+import com.infomaniak.mail.MatomoMail.MODIFY_SCHEDULE_FROM_HEADER
 import com.infomaniak.mail.MatomoMail.trackMessageEvent
+import com.infomaniak.mail.MatomoMail.trackScheduleSendEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Attachable
 import com.infomaniak.mail.data.models.Attachment
@@ -463,6 +466,7 @@ class ThreadAdapter(
     private fun MessageViewHolder.bindAlerts(message: Message) = with(binding) {
         message.draftResource?.let { draftResource ->
             scheduleAlert.onAction1 {
+                context.trackScheduleSendEvent(MODIFY_SCHEDULE_FROM_HEADER)
                 threadAdapterCallbacks?.onRescheduleClicked?.invoke(
                     draftResource,
                     message.displayDate.takeIf { message.isScheduledDraft }?.epochSeconds?.times(1_000),
@@ -470,7 +474,10 @@ class ThreadAdapter(
             }
         }
 
-        scheduleAlert.onAction2 { threadAdapterCallbacks?.onModifyScheduledClicked?.invoke(message) }
+        scheduleAlert.onAction2 {
+            context.trackScheduleSendEvent(CANCEL_SCHEDULE_FROM_HEADER)
+            threadAdapterCallbacks?.onModifyScheduledClicked?.invoke(message)
+        }
 
         distantImagesAlert.onAction1 {
             bodyWebViewClient.unblockDistantResources()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -88,7 +88,7 @@ import com.infomaniak.mail.ui.main.thread.ThreadAdapter.ThreadAdapterCallbacks
 import com.infomaniak.mail.ui.main.thread.actions.*
 import com.infomaniak.mail.ui.main.thread.calendar.AttendeesBottomSheetDialogArgs
 import com.infomaniak.mail.utils.PermissionUtils
-import com.infomaniak.mail.utils.SharedUtils.Companion.BatchSnoozeResult
+import com.infomaniak.mail.data.models.snooze.BatchSnoozeResult
 import com.infomaniak.mail.utils.UiUtils
 import com.infomaniak.mail.utils.UiUtils.dividerDrawable
 import com.infomaniak.mail.utils.Utils.runCatchingRealm

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -618,14 +618,17 @@ class ThreadFragment : Fragment() {
             val result = mainViewModel.rescheduleSnoozedThread(Date(timestamp), listOf(thread))
             binding.snoozeAlert.hideAction1Progress(R.string.buttonModify)
 
-            if (result is SnoozeRescheduleResult.Error) {
-                val errorMessageRes = when (result) {
-                    SnoozeRescheduleResult.Error.NoneSucceeded -> R.string.errorSnoozeFailedModify
-                    is SnoozeRescheduleResult.Error.ApiError -> result.translatedError
-                    SnoozeRescheduleResult.Error.Unknown -> com.infomaniak.lib.core.R.string.anErrorHasOccurred
-                }
+            when (result) {
+                is SnoozeRescheduleResult.Success -> twoPaneViewModel.closeThread()
+                is SnoozeRescheduleResult.Error -> {
+                    val errorMessageRes = when (result) {
+                        SnoozeRescheduleResult.Error.NoneSucceeded -> R.string.errorSnoozeFailedModify
+                        is SnoozeRescheduleResult.Error.ApiError -> result.translatedError
+                        SnoozeRescheduleResult.Error.Unknown -> com.infomaniak.lib.core.R.string.anErrorHasOccurred
+                    }
 
-                snackbarManager.postValue(requireContext().getString(errorMessageRes))
+                    snackbarManager.postValue(requireContext().getString(errorMessageRes))
+                }
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -604,7 +604,7 @@ class ThreadFragment : Fragment() {
                 onDateSelected = { timestamp ->
                     localSettings.lastSelectedSnoozeEpochMillis = timestamp
                     threadViewModel.threadLive.value?.let { thread ->
-                        rescheduleThread(timestamp, thread)
+                        rescheduleSnoozedThread(timestamp, thread)
                     }
                 },
                 onAbort = ::navigateToSnoozeBottomSheet,
@@ -613,12 +613,12 @@ class ThreadFragment : Fragment() {
 
         getBackNavigationResult(SNOOZE_RESULT) { selectedScheduleEpoch: Long ->
             threadViewModel.threadLive.value?.let { thread ->
-                rescheduleThread(selectedScheduleEpoch, thread)
+                rescheduleSnoozedThread(selectedScheduleEpoch, thread)
             }
         }
     }
 
-    private fun rescheduleThread(timestamp: Long, thread: Thread) {
+    private fun rescheduleSnoozedThread(timestamp: Long, thread: Thread) {
         lifecycleScope.launch {
             binding.snoozeAlert.showAction1Progress()
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -71,7 +71,6 @@ import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.databinding.FragmentThreadBinding
 import com.infomaniak.mail.ui.MainViewModel
-import com.infomaniak.mail.ui.MainViewModel.SnoozeRescheduleResult
 import com.infomaniak.mail.ui.alertDialogs.*
 import com.infomaniak.mail.ui.bottomSheetDialogs.ScheduleSendBottomSheetDialog.Companion.OPEN_SCHEDULE_DRAFT_DATE_AND_TIME_PICKER
 import com.infomaniak.mail.ui.bottomSheetDialogs.ScheduleSendBottomSheetDialog.Companion.SCHEDULE_DRAFT_RESULT
@@ -89,7 +88,7 @@ import com.infomaniak.mail.ui.main.thread.ThreadAdapter.ThreadAdapterCallbacks
 import com.infomaniak.mail.ui.main.thread.actions.*
 import com.infomaniak.mail.ui.main.thread.calendar.AttendeesBottomSheetDialogArgs
 import com.infomaniak.mail.utils.PermissionUtils
-import com.infomaniak.mail.utils.SharedUtils.Companion.UnsnoozeResult
+import com.infomaniak.mail.utils.SharedUtils.Companion.BatchSnoozeResult
 import com.infomaniak.mail.utils.UiUtils
 import com.infomaniak.mail.utils.UiUtils.dividerDrawable
 import com.infomaniak.mail.utils.Utils.runCatchingRealm
@@ -626,12 +625,12 @@ class ThreadFragment : Fragment() {
             binding.snoozeAlert.hideAction1Progress(R.string.buttonModify)
 
             when (result) {
-                is SnoozeRescheduleResult.Success -> twoPaneViewModel.closeThread()
-                is SnoozeRescheduleResult.Error -> {
+                is BatchSnoozeResult.Success -> twoPaneViewModel.closeThread()
+                is BatchSnoozeResult.Error -> {
                     val errorMessageRes = when (result) {
-                        SnoozeRescheduleResult.Error.NoneSucceeded -> R.string.errorSnoozeFailedModify
-                        is SnoozeRescheduleResult.Error.ApiError -> result.translatedError
-                        SnoozeRescheduleResult.Error.Unknown -> com.infomaniak.lib.core.R.string.anErrorHasOccurred
+                        BatchSnoozeResult.Error.NoneSucceeded -> R.string.errorSnoozeFailedModify
+                        is BatchSnoozeResult.Error.ApiError -> result.translatedError
+                        BatchSnoozeResult.Error.Unknown -> com.infomaniak.lib.core.R.string.anErrorHasOccurred
                     }
 
                     snackbarManager.postValue(requireContext().getString(errorMessageRes))
@@ -849,12 +848,12 @@ class ThreadFragment : Fragment() {
             snoozeAlert.hideAction2Progress(R.string.buttonCancelReminder)
 
             when (result) {
-                is UnsnoozeResult.Success -> twoPaneViewModel.closeThread()
-                is UnsnoozeResult.Error -> {
+                is BatchSnoozeResult.Success -> twoPaneViewModel.closeThread()
+                is BatchSnoozeResult.Error -> {
                     val errorMessageRes = when (result) {
-                        UnsnoozeResult.Error.NoneSucceeded -> R.string.errorSnoozeFailedCancel
-                        is UnsnoozeResult.Error.ApiError -> result.translatedError
-                        UnsnoozeResult.Error.Unknown -> RCore.string.anErrorHasOccurred
+                        BatchSnoozeResult.Error.NoneSucceeded -> R.string.errorSnoozeFailedCancel
+                        is BatchSnoozeResult.Error.ApiError -> result.translatedError
+                        BatchSnoozeResult.Error.Unknown -> RCore.string.anErrorHasOccurred
                     }
 
                     snackbarManager.postValue(getString(errorMessageRes))

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -142,6 +142,9 @@ class ThreadFragment : Fragment() {
     lateinit var dateAndTimeScheduleDialog: SelectDateAndTimeForScheduledDraftDialog
 
     @Inject
+    lateinit var dateAndTimeSnoozeDialog: SelectDateAndTimeForSnoozeDialog
+
+    @Inject
     lateinit var confirmScheduledDraftModificationDialog: ConfirmScheduledDraftModificationDialog
 
     private var _binding: FragmentThreadBinding? = null
@@ -589,7 +592,7 @@ class ThreadFragment : Fragment() {
         }
 
         getBackNavigationResult(OPEN_SNOOZE_DATE_AND_TIME_PICKER) { _: Boolean ->
-            dateAndTimeScheduleDialog.show(
+            dateAndTimeSnoozeDialog.show(
                 onDateSelected = { timestamp ->
                     localSettings.lastSelectedSnoozeEpochMillis = timestamp
                     threadViewModel.threadLive.value?.let { thread ->

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -596,7 +596,7 @@ class ThreadFragment : Fragment() {
                 onDateSelected = { timestamp ->
                     localSettings.lastSelectedSnoozeEpochMillis = timestamp
                     threadViewModel.threadLive.value?.let { thread ->
-                        mainViewModel.rescheduleSnoozedThread(Date(timestamp), thread)
+                        mainViewModel.rescheduleSnoozedThread(Date(timestamp), listOf(thread))
                     }
                 },
                 onAbort = ::navigateToSnoozeBottomSheet,
@@ -605,7 +605,7 @@ class ThreadFragment : Fragment() {
 
         getBackNavigationResult(SNOOZE_RESULT) { selectedScheduleEpoch: Long ->
             threadViewModel.threadLive.value?.let { thread ->
-                mainViewModel.rescheduleSnoozedThread(Date(selectedScheduleEpoch), thread)
+                mainViewModel.rescheduleSnoozedThread(Date(selectedScheduleEpoch), listOf(thread))
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -46,12 +46,15 @@ import com.infomaniak.mail.MatomoMail.ACTION_FAVORITE_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_FORWARD_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_OPEN_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_REPLY_NAME
+import com.infomaniak.mail.MatomoMail.CANCEL_SCHEDULE_FROM_HEADER
+import com.infomaniak.mail.MatomoMail.MODIFY_SCHEDULE_FROM_HEADER
 import com.infomaniak.mail.MatomoMail.OPEN_ACTION_BOTTOM_SHEET
 import com.infomaniak.mail.MatomoMail.OPEN_FROM_DRAFT_NAME
 import com.infomaniak.mail.MatomoMail.trackAttachmentActionsEvent
 import com.infomaniak.mail.MatomoMail.trackBlockUserAction
 import com.infomaniak.mail.MatomoMail.trackMessageActionsEvent
 import com.infomaniak.mail.MatomoMail.trackNewMessageEvent
+import com.infomaniak.mail.MatomoMail.trackSnoozeEvent
 import com.infomaniak.mail.MatomoMail.trackThreadActionsEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
@@ -464,10 +467,14 @@ class ThreadFragment : Fragment() {
 
             snoozeAlert.apply {
                 onAction1 {
+                    trackSnoozeEvent(MODIFY_SCHEDULE_FROM_HEADER)
                     threadViewModel.reschedulingCurrentlySnoozedEpochMillis = thread.snoozeEndDate?.epochSeconds?.times(1000)
                     navigateToSnoozeBottomSheet()
                 }
-                onAction2 { unsnoozeThread(thread) }
+                onAction2 {
+                    trackSnoozeEvent(CANCEL_SCHEDULE_FROM_HEADER)
+                    unsnoozeThread(thread)
+                }
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -621,7 +621,7 @@ class ThreadFragment : Fragment() {
         lifecycleScope.launch {
             binding.snoozeAlert.showAction1Progress()
 
-            val result = mainViewModel.rescheduleSnoozedThread(Date(timestamp), listOf(thread))
+            val result = mainViewModel.rescheduleSnoozedThreads(Date(timestamp), listOf(thread))
             binding.snoozeAlert.hideAction1Progress(R.string.buttonModify)
 
             when (result) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -46,8 +46,8 @@ import com.infomaniak.mail.MatomoMail.ACTION_FAVORITE_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_FORWARD_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_OPEN_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_REPLY_NAME
-import com.infomaniak.mail.MatomoMail.CANCEL_SCHEDULE_FROM_HEADER
-import com.infomaniak.mail.MatomoMail.MODIFY_SCHEDULE_FROM_HEADER
+import com.infomaniak.mail.MatomoMail.ACTION_CANCEL_SNOOZE_NAME
+import com.infomaniak.mail.MatomoMail.ACTION_MODIFY_SNOOZE_NAME
 import com.infomaniak.mail.MatomoMail.OPEN_ACTION_BOTTOM_SHEET
 import com.infomaniak.mail.MatomoMail.OPEN_FROM_DRAFT_NAME
 import com.infomaniak.mail.MatomoMail.trackAttachmentActionsEvent
@@ -466,11 +466,11 @@ class ThreadFragment : Fragment() {
 
             snoozeAlert.apply {
                 onAction1 {
-                    trackSnoozeEvent(MODIFY_SCHEDULE_FROM_HEADER)
+                    trackSnoozeEvent(ACTION_MODIFY_SNOOZE_NAME)
                     navigateToSnoozeBottomSheet()
                 }
                 onAction2 {
-                    trackSnoozeEvent(CANCEL_SCHEDULE_FROM_HEADER)
+                    trackSnoozeEvent(ACTION_CANCEL_SNOOZE_NAME)
                     unsnoozeThread(thread)
                 }
             }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -68,6 +68,7 @@ import com.infomaniak.mail.data.models.SwissTransferFile
 import com.infomaniak.mail.data.models.calendar.Attendee
 import com.infomaniak.mail.data.models.draft.Draft.DraftMode
 import com.infomaniak.mail.data.models.message.Message
+import com.infomaniak.mail.data.models.snooze.BatchSnoozeResult
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.databinding.FragmentThreadBinding
 import com.infomaniak.mail.ui.MainViewModel
@@ -88,7 +89,6 @@ import com.infomaniak.mail.ui.main.thread.ThreadAdapter.ThreadAdapterCallbacks
 import com.infomaniak.mail.ui.main.thread.actions.*
 import com.infomaniak.mail.ui.main.thread.calendar.AttendeesBottomSheetDialogArgs
 import com.infomaniak.mail.utils.PermissionUtils
-import com.infomaniak.mail.data.models.snooze.BatchSnoozeResult
 import com.infomaniak.mail.utils.UiUtils
 import com.infomaniak.mail.utils.UiUtils.dividerDrawable
 import com.infomaniak.mail.utils.Utils.runCatchingRealm
@@ -467,7 +467,6 @@ class ThreadFragment : Fragment() {
             snoozeAlert.apply {
                 onAction1 {
                     trackSnoozeEvent(MODIFY_SCHEDULE_FROM_HEADER)
-                    threadViewModel.reschedulingCurrentlySnoozedEpochMillis = thread.snoozeEndDate?.epochSeconds?.times(1000)
                     navigateToSnoozeBottomSheet()
                 }
                 onAction2 {
@@ -833,7 +832,7 @@ class ThreadFragment : Fragment() {
             resId = R.id.snoozeBottomSheetDialog,
             args = SnoozeBottomSheetDialogArgs(
                 lastSelectedScheduleEpochMillis = localSettings.lastSelectedSnoozeEpochMillis ?: 0L,
-                currentlyScheduledEpochMillis = threadViewModel.reschedulingCurrentlySnoozedEpochMillis ?: 0L,
+                currentlyScheduledEpochMillis = threadViewModel.threadLive.value?.snoozeEndDate?.epochSeconds?.times(1000) ?: 0L,
                 isCurrentMailboxFree = mainViewModel.currentMailbox.value?.isFreeMailbox ?: true,
             ).toBundle(),
             currentClassName = ThreadFragment::class.java.name,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -97,6 +97,9 @@ class ThreadViewModel @Inject constructor(
     // Save the current scheduled date of the draft we're rescheduling to be able to pass it to the schedule bottom sheet
     var reschedulingCurrentlyScheduledEpochMillis: Long? = null
 
+    // Save the current scheduled date of the message we're rescheduling to be able to pass it to the snooze bottom sheet
+    var reschedulingCurrentlySnoozedEpochMillis: Long? = null
+
     val isThreadSnoozeHeaderVisible = Utils.waitInitMediator(currentMailboxLive, threadLive).map { (mailbox, thread) ->
         mailbox?.featureFlags?.contains(FeatureFlag.SNOOZE) == true
                 && thread?.isSnoozed() == true

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -97,9 +97,6 @@ class ThreadViewModel @Inject constructor(
     // Save the current scheduled date of the draft we're rescheduling to be able to pass it to the schedule bottom sheet
     var reschedulingCurrentlyScheduledEpochMillis: Long? = null
 
-    // Save the current scheduled date of the message we're rescheduling to be able to pass it to the snooze bottom sheet
-    var reschedulingCurrentlySnoozedEpochMillis: Long? = null
-
     val isThreadSnoozeHeaderVisible = Utils.waitInitMediator(currentMailboxLive, threadLive).map { (mailbox, thread) ->
         mailbox?.featureFlags?.contains(FeatureFlag.SNOOZE) == true
                 && thread?.isSnoozed() == true

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -64,7 +64,7 @@ import com.infomaniak.mail.ui.MainActivity
 import com.infomaniak.mail.ui.alertDialogs.DescriptionAlertDialog
 import com.infomaniak.mail.ui.alertDialogs.InformationAlertDialog
 import com.infomaniak.mail.ui.alertDialogs.SelectDateAndTimeForScheduledDraftDialog
-import com.infomaniak.mail.ui.bottomSheetDialogs.ScheduleSendBottomSheetDialog.Companion.OPEN_DATE_AND_TIME_SCHEDULE_DIALOG
+import com.infomaniak.mail.ui.bottomSheetDialogs.ScheduleSendBottomSheetDialog.Companion.OPEN_SCHEDULE_DRAFT_DATE_AND_TIME_PICKER
 import com.infomaniak.mail.ui.bottomSheetDialogs.ScheduleSendBottomSheetDialog.Companion.SCHEDULE_DRAFT_RESULT
 import com.infomaniak.mail.ui.bottomSheetDialogs.ScheduleSendBottomSheetDialogArgs
 import com.infomaniak.mail.ui.main.SnackbarManager
@@ -220,7 +220,7 @@ class NewMessageFragment : Fragment() {
             tryToSendEmail(scheduled = true)
         }
 
-        getBackNavigationResult(OPEN_DATE_AND_TIME_SCHEDULE_DIALOG) { _: Boolean ->
+        getBackNavigationResult(OPEN_SCHEDULE_DRAFT_DATE_AND_TIME_PICKER) { _: Boolean ->
             dateAndTimeScheduleDialog.show(
                 onDateSelected = { timestamp ->
                     localSettings.lastSelectedScheduleEpochMillis = timestamp

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -17,7 +17,6 @@
  */
 package com.infomaniak.mail.utils
 
-import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.mail.MatomoMail.trackEvent
@@ -32,11 +31,12 @@ import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshCa
 import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshMode
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
-import com.infomaniak.mail.data.models.BatchSnoozeResponse.Companion.computeSnoozeResult
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.isSnoozed
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message
+import com.infomaniak.mail.data.models.snooze.BatchSnoozeResponse.Companion.computeSnoozeResult
+import com.infomaniak.mail.data.models.snooze.BatchSnoozeResult
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.ui.main.settings.SettingRadioGroupView
@@ -279,15 +279,6 @@ class SharedUtils @Inject constructor(
             scope?.ensureActive()
 
             return apiResponses.computeSnoozeResult(ImpactedFolders(impactedFolderIds))
-        }
-
-        sealed interface BatchSnoozeResult {
-            data class Success(val impactedFolders: ImpactedFolders) : BatchSnoozeResult
-            sealed interface Error : BatchSnoozeResult {
-                data object NoneSucceeded : Error
-                data class ApiError(@StringRes val translatedError: Int) : Error
-                data object Unknown : Error
-            }
         }
 
         sealed interface AutomaticUnsnoozeResult {

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -32,6 +32,7 @@ import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshCa
 import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshMode
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
+import com.infomaniak.mail.data.models.BatchSnoozeResponse.Companion.computeSnoozeResult
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.isSnoozed
 import com.infomaniak.mail.data.models.mailbox.Mailbox
@@ -40,7 +41,10 @@ import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.ui.main.settings.SettingRadioGroupView
 import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
-import com.infomaniak.mail.utils.extensions.*
+import com.infomaniak.mail.utils.extensions.atLeastOneSucceeded
+import com.infomaniak.mail.utils.extensions.getApiException
+import com.infomaniak.mail.utils.extensions.getFoldersIds
+import com.infomaniak.mail.utils.extensions.getUids
 import io.realm.kotlin.Realm
 import io.realm.kotlin.ext.toRealmList
 import io.sentry.Sentry
@@ -110,22 +114,18 @@ class SharedUtils @Inject constructor(
         }
     }
 
-    suspend fun unsnoozeThreads(mailbox: Mailbox, threads: List<Thread>): UnsnoozeResult {
+    suspend fun unsnoozeThreads(mailbox: Mailbox, threads: List<Thread>): BatchSnoozeResult {
         val unsnoozeResult = ioDispatcher {
             unsnoozeThreadsWithoutRefresh(scope = null, mailbox, threads)
         }
 
-        if (unsnoozeResult is UnsnoozeResult.Success && unsnoozeResult.impactedFolderUids.isNotEmpty()) {
-            refreshFolders(
-                mailbox = mailbox,
-                // When removing the snooze state of a thread, we absolutely need to refresh the snooze folder. Refreshing the
-                // snooze folder is the only way of updating the snooze status of messages. The folder snooze will never be
-                // returned inside impactedFolders because no message ever mentions the snooze folder, we need to add it manually.
-                messagesFoldersIds = ImpactedFolders(
-                    unsnoozeResult.impactedFolderUids.toMutableSet(),
-                    mutableSetOf(FolderRole.SNOOZED),
-                ),
-            )
+        if (unsnoozeResult is BatchSnoozeResult.Success) {
+            // When removing the snooze state of a thread, we absolutely need to refresh the snooze folder. Refreshing the
+            // snooze folder is the only way of updating the snooze status of messages. The folder snooze will never be
+            // returned inside impactedFolders because no message ever mentions the snooze folder, we need to add it manually.
+            unsnoozeResult.impactedFolders += FolderRole.SNOOZED
+
+            refreshFolders(mailbox = mailbox, messagesFoldersIds = unsnoozeResult.impactedFolders)
         }
 
         return unsnoozeResult
@@ -259,7 +259,7 @@ class SharedUtils @Inject constructor(
             scope: CoroutineScope?,
             mailbox: Mailbox,
             threads: List<Thread>
-        ): UnsnoozeResult {
+        ): BatchSnoozeResult {
             val snoozeUuids: MutableList<String> = mutableListOf()
             val impactedFolderIds: MutableSet<String> = mutableSetOf()
 
@@ -273,26 +273,17 @@ class SharedUtils @Inject constructor(
                 impactedFolderIds += targetMessage.folderId
             }
 
-            if (snoozeUuids.isEmpty()) return UnsnoozeResult.Error.Unknown
+            if (snoozeUuids.isEmpty()) return BatchSnoozeResult.Error.Unknown
 
             val apiResponses = ApiRepository.unsnoozeThreads(mailbox.uuid, snoozeUuids)
             scope?.ensureActive()
 
-            return when {
-                apiResponses.all { it.isSuccess().not() } -> {
-                    val translatedError = apiResponses.getFirstTranslatedError()
-                    if (translatedError == null) UnsnoozeResult.Error.Unknown else UnsnoozeResult.Error.ApiError(translatedError)
-                }
-                apiResponses.any { it.isSuccess() && it.data?.cancelled?.isNotEmpty() == true } -> {
-                    UnsnoozeResult.Success(impactedFolderIds)
-                }
-                else -> UnsnoozeResult.Error.NoneSucceeded
-            }
+            return apiResponses.computeSnoozeResult(ImpactedFolders(impactedFolderIds))
         }
 
-        sealed interface UnsnoozeResult {
-            data class Success(val impactedFolderUids: Set<String>) : UnsnoozeResult
-            sealed interface Error : UnsnoozeResult {
+        sealed interface BatchSnoozeResult {
+            data class Success(val impactedFolders: ImpactedFolders) : BatchSnoozeResult
+            sealed interface Error : BatchSnoozeResult {
                 data object NoneSucceeded : Error
                 data class ApiError(@StringRes val translatedError: Int) : Error
                 data object Unknown : Error

--- a/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
@@ -49,7 +49,7 @@ object Utils {
     const val MAX_OLD_PAGES_TO_FETCH_TO_GET_ENOUGH_THREADS = 5 // We don't want to spam the API, so we just get a few pages
 
     const val MAX_UIDS_PER_CALL = 1_000 // Beware: the API refuses a MAX_UIDS_PER_CALL bigger than 1000
-    const val MAX_UUIDS_PER_CALL_SNOOZE_DELETE = 100
+    const val MAX_UUIDS_PER_CALL_SNOOZE = 100 // Only for DELETE and PUT
 
     const val TAG_SEPARATOR = " "
 

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -267,6 +267,25 @@
             app:argType="boolean" />
     </dialog>
 
+    <dialog
+        android:id="@+id/snoozeBottomSheetDialog"
+        android:name="com.infomaniak.mail.ui.bottomSheetDialogs.SnoozeBottomSheetDialog"
+        android:label="SnoozeBottomSheetDialog"
+        tools:layout="@layout/bottom_sheet_schedule_options">
+        <argument
+            android:name="lastSelectedScheduleEpochMillis"
+            android:defaultValue="0L"
+            app:argType="long" />
+        <argument
+            android:name="currentlyScheduledEpochMillis"
+            android:defaultValue="0L"
+            app:argType="long" />
+        <argument
+            android:name="isCurrentMailboxFree"
+            android:defaultValue="true"
+            app:argType="boolean" />
+    </dialog>
+
     <fragment
         android:id="@+id/moveFragment"
         android:name="com.infomaniak.mail.ui.main.move.MoveFragment"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -161,11 +161,9 @@
     <string name="buttonReschedule">Neu planen</string>
     <string name="buttonRestoreEmails">E-Mails wiederherstellen</string>
     <string name="buttonSchedule">Planen Sie den Versand von E-Mails für einen späteren Zeitpunkt</string>
-    <string name="buttonScheduleTitle">Programmieren</string>
     <string name="buttonSee">Siehe</string>
     <string name="buttonSelectAll">Alle</string>
     <string name="buttonShare">Teilen Sie</string>
-    <string name="buttonSnooze">Erinnern</string>
     <string name="buttonStart">Anfangen</string>
     <string name="buttonStartSync">Start der Synchronisierung</string>
     <string name="buttonStrikeThrough">Durchstreichen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -165,6 +165,7 @@
     <string name="buttonSee">Siehe</string>
     <string name="buttonSelectAll">Alle</string>
     <string name="buttonShare">Teilen Sie</string>
+    <string name="buttonSnooze">Erinnern</string>
     <string name="buttonStart">Anfangen</string>
     <string name="buttonStartSync">Start der Synchronisierung</string>
     <string name="buttonStrikeThrough">Durchstreichen</string>
@@ -298,10 +299,8 @@
     <string name="errorNewFolderNameTooLong">Der Ordnername sollte nicht länger als 255 Zeichen sein.</string>
     <string name="errorRefusedRecipients">Der Server lehnt alle Empfänger ab</string>
     <string name="errorRefusedSender">Der Server lehnt den Absender ab</string>
-    <plurals name="errorScheduleDelayTooShort">
-        <item quantity="one">Sie können E-Mails frühestens in %d Minute senden</item>
-        <item quantity="other">Wählen Sie ein zukünftiges Datum, das mindestens %d Minuten in der Zukunft liegt</item>
-    </plurals>
+    <string name="errorScheduleDelayTooShort">Wählen Sie ein zukünftiges Datum, das mindestens %d Minuten in der Zukunft liegt</string>
+    <string name="errorScheduledSnoozeDelayTooShort">Die Mindestzeit zum Schlummern einer E-Mail beträgt %d Minuten</string>
     <string name="errorSendLimitExceeded">Versandlimit erreicht</string>
     <string name="errorSnoozeFailedCancel">Abbruch fehlgeschlagen</string>
     <string name="errorTooManyRecipients">Zu viele Empfänger</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -577,6 +577,7 @@
         <item quantity="other">Unterhaltungen in %s verschoben</item>
     </plurals>
     <string name="snoozeAlertTitle">Ausstehend bis: %s</string>
+    <string name="snoozeBottomSheetTitle">In die Warteschlange verschieben</string>
     <string name="snoozedFolder">In der Warteschlange</string>
     <string name="socialNetworksFolder">Soziale Netzwerke</string>
     <string name="spamFolder">Spam</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -303,6 +303,7 @@
     <string name="errorScheduledSnoozeDelayTooShort">Die Mindestzeit zum Schlummern einer E-Mail beträgt %d Minuten</string>
     <string name="errorSendLimitExceeded">Versandlimit erreicht</string>
     <string name="errorSnoozeFailedCancel">Abbruch fehlgeschlagen</string>
+    <string name="errorSnoozeFailedModify">Änderung fehlgeschlagen</string>
     <string name="errorTooManyRecipients">Zu viele Empfänger</string>
     <string name="errorUnableToCreateFolder">Ordner kann nicht erstellt werden</string>
     <string name="errorUnableToFlushFolder">Der Ordner kann nicht geleert werden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -165,6 +165,7 @@
     <string name="buttonSee">Véase</string>
     <string name="buttonSelectAll">Todos</string>
     <string name="buttonShare">Compartir</string>
+    <string name="buttonSnooze">Recordar</string>
     <string name="buttonStart">Empezar</string>
     <string name="buttonStartSync">Iniciar sincronización</string>
     <string name="buttonStrikeThrough">Huelga a través de</string>
@@ -298,10 +299,8 @@
     <string name="errorNewFolderNameTooLong">El nombre de la carpeta no debe superar los 255 caracteres</string>
     <string name="errorRefusedRecipients">El servidor rechaza todos los destinatarios</string>
     <string name="errorRefusedSender">El servidor rechaza el remitente</string>
-    <plurals name="errorScheduleDelayTooShort">
-        <item quantity="one">No puedes programar un correo electrónico para dentro de menos de %d minuto</item>
-        <item quantity="other">No puedes programar un correo electrónico para dentro de menos de %d minutos</item>
-    </plurals>
+    <string name="errorScheduleDelayTooShort">No puedes programar un correo electrónico para dentro de menos de %d minutos</string>
+    <string name="errorScheduledSnoozeDelayTooShort">El tiempo mínimo para aplazar un correo electrónico es de %d minutos</string>
     <string name="errorSendLimitExceeded">Límite de envío alcanzado</string>
     <string name="errorSnoozeFailedCancel">Cancelación fallida</string>
     <string name="errorTooManyRecipients">Demasiados destinatarios</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -577,6 +577,7 @@
         <item quantity="other">Conversaciones trasladadas a %s</item>
     </plurals>
     <string name="snoozeAlertTitle">En espera hasta: %s</string>
+    <string name="snoozeBottomSheetTitle">Poner en espera</string>
     <string name="snoozedFolder">En espera</string>
     <string name="socialNetworksFolder">Redes sociales</string>
     <string name="spamFolder">Spam</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -303,6 +303,7 @@
     <string name="errorScheduledSnoozeDelayTooShort">El tiempo mínimo para aplazar un correo electrónico es de %d minutos</string>
     <string name="errorSendLimitExceeded">Límite de envío alcanzado</string>
     <string name="errorSnoozeFailedCancel">Cancelación fallida</string>
+    <string name="errorSnoozeFailedModify">Modificación fallida</string>
     <string name="errorTooManyRecipients">Demasiados destinatarios</string>
     <string name="errorUnableToCreateFolder">No se puede crear la carpeta</string>
     <string name="errorUnableToFlushFolder">Imposible vaciar la carpeta</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -161,11 +161,9 @@
     <string name="buttonReschedule">Reprogramar</string>
     <string name="buttonRestoreEmails">Restaurar correos electrónicos</string>
     <string name="buttonSchedule">Programar un correo electrónico para enviarlo más tarde</string>
-    <string name="buttonScheduleTitle">Programar</string>
     <string name="buttonSee">Véase</string>
     <string name="buttonSelectAll">Todos</string>
     <string name="buttonShare">Compartir</string>
-    <string name="buttonSnooze">Recordar</string>
     <string name="buttonStart">Empezar</string>
     <string name="buttonStartSync">Iniciar sincronización</string>
     <string name="buttonStrikeThrough">Huelga a través de</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -167,6 +167,7 @@
     <string name="buttonSee">Consulter</string>
     <string name="buttonSelectAll">Tout</string>
     <string name="buttonShare">Partager</string>
+    <string name="buttonSnooze">Rappeler</string>
     <string name="buttonStart">Commencer</string>
     <string name="buttonStartSync">Commencer la synchronisation</string>
     <string name="buttonStrikeThrough">Barrer</string>
@@ -300,11 +301,8 @@
     <string name="errorNewFolderNameTooLong">Le nom du dossier ne doit pas dépasser 255 caractères</string>
     <string name="errorRefusedRecipients">Le serveur refuse tous les destinataires</string>
     <string name="errorRefusedSender">Le serveur refuse l’expéditeur</string>
-    <plurals name="errorScheduleDelayTooShort">
-        <item quantity="one">Vous ne pouvez pas programmer un e-mail dans moins de %d minute</item>
-        <item quantity="other">Vous ne pouvez pas programmer un e-mail dans moins de %d minutes</item>
-        <item quantity="many">Vous ne pouvez pas programmer un e-mail dans moins de %d de minutes</item>
-    </plurals>
+    <string name="errorScheduleDelayTooShort">Vous ne pouvez pas programmer un e-mail dans moins de %d minutes</string>
+    <string name="errorScheduledSnoozeDelayTooShort">Le délai minimum pour mettre un e-mail en attente est de %d minutes</string>
     <string name="errorSendLimitExceeded">Limite d’envoi atteinte</string>
     <string name="errorSnoozeFailedCancel">Échec de l’annulation</string>
     <string name="errorTooManyRecipients">Trop de destinataires</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -305,6 +305,7 @@
     <string name="errorScheduledSnoozeDelayTooShort">Le délai minimum pour mettre un e-mail en attente est de %d minutes</string>
     <string name="errorSendLimitExceeded">Limite d’envoi atteinte</string>
     <string name="errorSnoozeFailedCancel">Échec de l’annulation</string>
+    <string name="errorSnoozeFailedModify">Échec de la modification</string>
     <string name="errorTooManyRecipients">Trop de destinataires</string>
     <string name="errorUnableToCreateFolder">Impossible de créer le dossier</string>
     <string name="errorUnableToFlushFolder">Impossible de vider le dossier</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -163,11 +163,9 @@
     <string name="buttonReschedule">Reprogrammer</string>
     <string name="buttonRestoreEmails">Restaurer des e-mails</string>
     <string name="buttonSchedule">Programmer l’envoi de l’e-mail</string>
-    <string name="buttonScheduleTitle">Programmer</string>
     <string name="buttonSee">Consulter</string>
     <string name="buttonSelectAll">Tout</string>
     <string name="buttonShare">Partager</string>
-    <string name="buttonSnooze">Rappeler</string>
     <string name="buttonStart">Commencer</string>
     <string name="buttonStartSync">Commencer la synchronisation</string>
     <string name="buttonStrikeThrough">Barrer</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -589,6 +589,7 @@
         <item quantity="many">Conversations déplacées vers %s</item>
     </plurals>
     <string name="snoozeAlertTitle">En attente jusqu’au : %s</string>
+    <string name="snoozeBottomSheetTitle">Mettre en attente</string>
     <string name="snoozedFolder">En attente</string>
     <string name="socialNetworksFolder">Réseaux sociaux</string>
     <string name="spamFolder">Spam</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -303,6 +303,7 @@
     <string name="errorScheduledSnoozeDelayTooShort">Il tempo minimo per posticipare un’email è di %d minuti</string>
     <string name="errorSendLimitExceeded">Limite d’invio raggiunto</string>
     <string name="errorSnoozeFailedCancel">Cancellazione non riuscita</string>
+    <string name="errorSnoozeFailedModify">Modifica non riuscita</string>
     <string name="errorTooManyRecipients">Troppi destinatari</string>
     <string name="errorUnableToCreateFolder">Impossibile creare la cartella</string>
     <string name="errorUnableToFlushFolder">Impossibile svuotare la cartella</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -165,6 +165,7 @@
     <string name="buttonSee">Vedi</string>
     <string name="buttonSelectAll">Tutti</string>
     <string name="buttonShare">Condividi</string>
+    <string name="buttonSnooze">Ricordare</string>
     <string name="buttonStart">Inizia</string>
     <string name="buttonStartSync">Avvio della sincronizzazione</string>
     <string name="buttonStrikeThrough">Sciopero attraverso</string>
@@ -298,10 +299,8 @@
     <string name="errorNewFolderNameTooLong">Il nome della cartella non deve superare i 255 caratteri</string>
     <string name="errorRefusedRecipients">Il server respinge tutti i destinatari</string>
     <string name="errorRefusedSender">Il server respinge il mittente</string>
-    <plurals name="errorScheduleDelayTooShort">
-        <item quantity="one">Non puoi programmare l’invio di una e-mail tra meno di %d minuto</item>
-        <item quantity="other">Non puoi programmare l’invio di una e-mail tra meno di %d minuti</item>
-    </plurals>
+    <string name="errorScheduleDelayTooShort">Non puoi programmare l’invio di una e-mail tra meno di %d minuti</string>
+    <string name="errorScheduledSnoozeDelayTooShort">Il tempo minimo per posticipare un’email è di %d minuti</string>
     <string name="errorSendLimitExceeded">Limite d’invio raggiunto</string>
     <string name="errorSnoozeFailedCancel">Cancellazione non riuscita</string>
     <string name="errorTooManyRecipients">Troppi destinatari</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -577,6 +577,7 @@
         <item quantity="other">Conversazioni spostate in %s</item>
     </plurals>
     <string name="snoozeAlertTitle">In attesa fino al: %s</string>
+    <string name="snoozeBottomSheetTitle">Metti in attesa</string>
     <string name="snoozedFolder">In attesa</string>
     <string name="socialNetworksFolder">Social Network</string>
     <string name="spamFolder">Spam</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -161,11 +161,9 @@
     <string name="buttonReschedule">Riprogrammare</string>
     <string name="buttonRestoreEmails">Ripristino delle e-mail</string>
     <string name="buttonSchedule">Programmare l’invio di un’e-mail in un secondo momento</string>
-    <string name="buttonScheduleTitle">Pianifica</string>
     <string name="buttonSee">Vedi</string>
     <string name="buttonSelectAll">Tutti</string>
     <string name="buttonShare">Condividi</string>
-    <string name="buttonSnooze">Ricordare</string>
     <string name="buttonStart">Inizia</string>
     <string name="buttonStartSync">Avvio della sincronizzazione</string>
     <string name="buttonStrikeThrough">Sciopero attraverso</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@
     <string name="buttonSee">See</string>
     <string name="buttonSelectAll">All</string>
     <string name="buttonShare">Share</string>
+    <string name="buttonSnooze">Snooze</string>
     <string name="buttonStart">Start</string>
     <string name="buttonStartSync">Start synchronization</string>
     <string name="buttonStrikeThrough">Strike through</string>
@@ -304,10 +305,8 @@
     <string name="errorNewFolderNameTooLong">The folder name should not exceed 255 characters</string>
     <string name="errorRefusedRecipients">The server is refusing all recipients</string>
     <string name="errorRefusedSender">The server is refusing the sender</string>
-    <plurals name="errorScheduleDelayTooShort">
-        <item quantity="one">You can’t schedule an email less than %d minute in the future</item>
-        <item quantity="other">You can’t schedule an email less than %d minutes in the future</item>
-    </plurals>
+    <string name="errorScheduleDelayTooShort">You can’t schedule an email less than %d minutes in the future</string>
+    <string name="errorScheduledSnoozeDelayTooShort">The minimum time to snooze an email is %d minutes</string>
     <string name="errorSendLimitExceeded">Sending limit reached</string>
     <string name="errorSnoozeFailedCancel">Failed to cancel</string>
     <string name="errorTooManyRecipients">Too many recipients</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -309,6 +309,7 @@
     <string name="errorScheduledSnoozeDelayTooShort">The minimum time to snooze an email is %d minutes</string>
     <string name="errorSendLimitExceeded">Sending limit reached</string>
     <string name="errorSnoozeFailedCancel">Failed to cancel</string>
+    <string name="errorSnoozeFailedModify">Failed to modify</string>
     <string name="errorTooManyRecipients">Too many recipients</string>
     <string name="errorUnableToCreateFolder">Unable to create the folder</string>
     <string name="errorUnableToFlushFolder">Folder cannot be emptied</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,11 +167,9 @@
     <string name="buttonReschedule">Reschedule</string>
     <string name="buttonRestoreEmails">Restore emails</string>
     <string name="buttonSchedule">Schedule email to send later</string>
-    <string name="buttonScheduleTitle">Schedule</string>
     <string name="buttonSee">See</string>
     <string name="buttonSelectAll">All</string>
     <string name="buttonShare">Share</string>
-    <string name="buttonSnooze">Snooze</string>
     <string name="buttonStart">Start</string>
     <string name="buttonStartSync">Start synchronization</string>
     <string name="buttonStrikeThrough">Strike through</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -583,6 +583,7 @@
         <item quantity="other">Conversations moved to %s</item>
     </plurals>
     <string name="snoozeAlertTitle">Snoozed until: %s</string>
+    <string name="snoozeBottomSheetTitle">Snooze</string>
     <string name="snoozedFolder">Snoozed</string>
     <string name="socialNetworksFolder">Social networks</string>
     <string name="spamFolder">Spam</string>


### PR DESCRIPTION
This PR adds the possibility to click on the "modify" button of the snooze header in a thread.

This required to reuse UI related to the picking of a scheduled date and factorizing some logic with the "cancel snooze" action

Depends on #2283 