### PR TITLE
refactor: Display snackbars directly from viewmodel so it's centralized for each calling place

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -105,7 +105,6 @@ import kotlin.math.absoluteValue
 import kotlin.math.min
 import kotlin.math.roundToInt
 import com.google.android.material.R as RMaterial
-import com.infomaniak.core.R as RCore
 
 
 @AndroidEntryPoint
@@ -623,18 +622,7 @@ class ThreadFragment : Fragment() {
             val result = mainViewModel.rescheduleSnoozedThreads(Date(timestamp), listOf(thread))
             binding.snoozeAlert.hideAction1Progress(R.string.buttonModify)
 
-            when (result) {
-                is BatchSnoozeResult.Success -> twoPaneViewModel.closeThread()
-                is BatchSnoozeResult.Error -> {
-                    val errorMessageRes = when (result) {
-                        BatchSnoozeResult.Error.NoneSucceeded -> R.string.errorSnoozeFailedModify
-                        is BatchSnoozeResult.Error.ApiError -> result.translatedError
-                        BatchSnoozeResult.Error.Unknown -> com.infomaniak.lib.core.R.string.anErrorHasOccurred
-                    }
-
-                    snackbarManager.postValue(requireContext().getString(errorMessageRes))
-                }
-            }
+            if (result is BatchSnoozeResult.Success) twoPaneViewModel.closeThread()
         }
     }
 
@@ -846,18 +834,7 @@ class ThreadFragment : Fragment() {
             val result = mainViewModel.unsnoozeThreads(listOf(thread))
             snoozeAlert.hideAction2Progress(R.string.buttonCancelReminder)
 
-            when (result) {
-                is BatchSnoozeResult.Success -> twoPaneViewModel.closeThread()
-                is BatchSnoozeResult.Error -> {
-                    val errorMessageRes = when (result) {
-                        BatchSnoozeResult.Error.NoneSucceeded -> R.string.errorSnoozeFailedCancel
-                        is BatchSnoozeResult.Error.ApiError -> result.translatedError
-                        BatchSnoozeResult.Error.Unknown -> RCore.string.anErrorHasOccurred
-                    }
-
-                    snackbarManager.postValue(getString(errorMessageRes))
-                }
-            }
+            if (result is BatchSnoozeResult.Success) twoPaneViewModel.closeThread()
         }
     }
 


### PR DESCRIPTION
Later, the MainViewModel methods will be called by multiple fragments, but the error display can be handled once for all calling places if handled inside the view model. This PR moves the snackbar displaying code to the MainViewModel methods

Depends on #2287 