### PR TITLE
feat: Add confirmation popup on delete/move/archive actions on a snoozed message

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -209,7 +209,7 @@ class MainActivity : BaseActivity() {
         )
 
         observeDeletedMessages()
-        observeDeleteThreadTrigger()
+        observeActivityDialogLoaderReset()
         observeDraftWorkerResults()
 
         binding.drawerLayout.addDrawerListener(drawerListener)
@@ -254,8 +254,8 @@ class MainActivity : BaseActivity() {
         }
     }
 
-    private fun observeDeleteThreadTrigger() {
-        mainViewModel.deleteThreadOrMessageTrigger.observe(this) { descriptionDialog.resetLoadingAndDismiss() }
+    private fun observeActivityDialogLoaderReset() {
+        mainViewModel.activityDialogLoaderResetTrigger.observe(this) { descriptionDialog.resetLoadingAndDismiss() }
     }
 
     private fun observeDraftWorkerResults() {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -116,7 +116,7 @@ class MainViewModel @Inject constructor(
     val isMovedToNewFolder = SingleLiveEvent<Boolean>()
     val toggleLightThemeForMessage = SingleLiveEvent<Message>()
     val deletedMessages = SingleLiveEvent<Set<String>>()
-    val deleteThreadOrMessageTrigger = SingleLiveEvent<Unit>()
+    val activityDialogLoaderResetTrigger = SingleLiveEvent<Unit>()
     val flushFolderTrigger = SingleLiveEvent<Unit>()
     val newFolderResultTrigger = MutableLiveData<Unit>()
     val reportPhishingTrigger = SingleLiveEvent<Unit>()
@@ -588,7 +588,7 @@ class MainViewModel @Inject constructor(
             }
         }
 
-        deleteThreadOrMessageTrigger.postValue(Unit)
+        activityDialogLoaderResetTrigger.postValue(Unit)
 
         if (apiResponses.atLeastOneSucceeded()) {
             if (shouldAutoAdvance(message, threadsUids)) autoAdvanceThreadsUids.postValue(threadsUids)
@@ -831,6 +831,8 @@ class MainViewModel @Inject constructor(
         val messages = sharedUtils.getMessagesToMove(threads, message)
 
         val apiResponses = ApiRepository.moveMessages(mailbox.uuid, messages.getUids(), destinationFolder.id)
+
+        activityDialogLoaderResetTrigger.postValue(Unit)
 
         if (apiResponses.atLeastOneSucceeded()) {
             if (shouldAutoAdvance(message, threadsUids)) autoAdvanceThreadsUids.postValue(threadsUids)

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/DescriptionAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/DescriptionAlertDialog.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -64,7 +64,7 @@ open class DescriptionAlertDialog @Inject constructor(
         description: CharSequence?,
         displayLoader: Boolean = true,
         displayCancelButton: Boolean = true,
-        @StringRes positiveButtonText: Int? = R.string.buttonConfirm,
+        @StringRes positiveButtonText: Int = R.string.buttonConfirm,
         @StringRes negativeButtonText: Int? = null,
         onPositiveButtonClicked: () -> Unit,
         onNegativeButtonClicked: (() -> Unit)? = null,
@@ -100,31 +100,11 @@ open class DescriptionAlertDialog @Inject constructor(
         }
     }
 
-    fun showDeletePermanentlyDialog(
-        deletedCount: Int,
-        displayLoader: Boolean,
-        onPositiveButtonClicked: () -> Unit,
-        onCancel: (() -> Unit)? = null,
-    ) = show(
-        title = activityContext.resources.getQuantityString(
-            R.plurals.threadListDeletionConfirmationAlertTitle,
-            deletedCount,
-            deletedCount,
-        ),
-        description = activityContext.resources.getQuantityString(
-            R.plurals.threadListDeletionConfirmationAlertDescription,
-            deletedCount,
-        ),
-        displayLoader = displayLoader,
-        onPositiveButtonClicked = onPositiveButtonClicked,
-        onCancel = onCancel,
-    )
-
     protected fun showDialogWithBasicInfo(
         title: String? = null,
         description: CharSequence? = null,
         displayCancelButton: Boolean = true,
-        @StringRes positiveButtonText: Int? = null,
+        @StringRes positiveButtonText: Int,
         @StringRes negativeButtonText: Int? = null,
     ) = with(binding) {
 
@@ -137,7 +117,7 @@ open class DescriptionAlertDialog @Inject constructor(
         }
 
         negativeButton.isVisible = displayCancelButton
-        positiveButtonText?.let(positiveButton::setText)
+        positiveButton.setText(positiveButtonText)
         negativeButtonText?.let(negativeButton::setText)
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -461,7 +461,6 @@ class ThreadListFragment : TwoPaneFragment() {
                 ) {
                     archiveThread(thread.uid)
                 }
-                folderRole == FolderRole.ARCHIVE // TODO: Why is this not `false` for everyone?
             }
             SwipeAction.DELETE -> {
                 descriptionDialog.deleteWithConfirmationPopup(
@@ -478,15 +477,20 @@ class ThreadListFragment : TwoPaneFragment() {
                         deleteThread(thread.uid, isSwipe = true)
                     },
                 )
-                isPermanentDeleteFolder
             }
             SwipeAction.FAVORITE -> {
                 toggleThreadFavoriteStatus(thread.uid)
                 true
             }
             SwipeAction.MOVE -> {
-                animatedNavigation(ThreadListFragmentDirections.actionThreadListFragmentToMoveFragment(arrayOf(thread.uid)))
-                false
+                val navController = findNavController()
+                descriptionDialog.moveWithConfirmationPopup(folderRole, count = 1) {
+                    navController.animatedNavigation(
+                        directions = ThreadListFragmentDirections.actionThreadListFragmentToMoveFragment(arrayOf(thread.uid)),
+                        currentClassName = javaClass.name,
+                    )
+                }
+                true
             }
             SwipeAction.QUICKACTIONS_MENU -> {
                 safeNavigate(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -450,8 +450,18 @@ class ThreadListFragment : TwoPaneFragment() {
                 true
             }
             SwipeAction.ARCHIVE -> {
-                archiveThread(thread.uid)
-                folderRole == FolderRole.ARCHIVE
+                descriptionDialog.archiveWithConfirmationPopup(
+                    folderRole = folderRole,
+                    count = 1, // TODO: displayLoader?
+                    onCancel = {
+                        // Notify only if the user cancelled the popup (e.g. the thread is not deleted),
+                        // otherwise it will notify the next item in the list and make it slightly blink
+                        if (threadListAdapter.dataSet.indexOf(thread) == position) threadListAdapter.notifyItemChanged(position)
+                    },
+                ) {
+                    archiveThread(thread.uid)
+                }
+                folderRole == FolderRole.ARCHIVE // TODO: Why is this not `false` for everyone?
             }
             SwipeAction.DELETE -> {
                 descriptionDialog.deleteWithConfirmationPopup(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -452,7 +452,8 @@ class ThreadListFragment : TwoPaneFragment() {
             SwipeAction.ARCHIVE -> {
                 descriptionDialog.archiveWithConfirmationPopup(
                     folderRole = folderRole,
-                    count = 1, // TODO: displayLoader?
+                    count = 1,
+                    displayLoader = false,
                     onCancel = {
                         // Notify only if the user cancelled the popup (e.g. the thread is not deleted),
                         // otherwise it will notify the next item in the list and make it slightly blink

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListMultiSelection.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListMultiSelection.kt
@@ -38,6 +38,7 @@ import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.ui.MainActivity
 import com.infomaniak.mail.ui.MainViewModel
 import com.infomaniak.mail.utils.Utils.runCatchingRealm
+import com.infomaniak.mail.utils.extensions.archiveWithConfirmationPopup
 import com.infomaniak.mail.utils.extensions.deleteWithConfirmationPopup
 import com.infomaniak.mail.utils.extensions.updateNavigationBarColor
 
@@ -79,9 +80,14 @@ class ThreadListMultiSelection {
                     isMultiSelectOn = false
                 }
                 R.id.quickActionArchive -> {
-                    threadListFragment.trackMultiSelectActionEvent(ACTION_ARCHIVE_NAME, selectedThreadsCount)
-                    archiveThreads(selectedThreadsUids)
-                    isMultiSelectOn = false
+                    threadListFragment.descriptionDialog.archiveWithConfirmationPopup(
+                        folderRole = getActionFolderRole(thread = selectedThreads.firstOrNull()),
+                        count = selectedThreadsCount,
+                    ) {
+                        threadListFragment.trackMultiSelectActionEvent(ACTION_ARCHIVE_NAME, selectedThreadsCount)
+                        archiveThreads(selectedThreadsUids)
+                        isMultiSelectOn = false
+                    }
                 }
                 R.id.quickActionFavorite -> {
                     threadListFragment.trackMultiSelectActionEvent(ACTION_FAVORITE_NAME, selectedThreadsCount)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -41,13 +41,13 @@ import com.infomaniak.lib.core.utils.getBackNavigationResult
 import com.infomaniak.lib.core.utils.safeNavigate
 import com.infomaniak.lib.core.views.DividerItemDecorator
 import com.infomaniak.mail.MatomoMail.ACTION_ARCHIVE_NAME
+import com.infomaniak.mail.MatomoMail.ACTION_CANCEL_SNOOZE_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_DELETE_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_FAVORITE_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_FORWARD_NAME
+import com.infomaniak.mail.MatomoMail.ACTION_MODIFY_SNOOZE_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_OPEN_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_REPLY_NAME
-import com.infomaniak.mail.MatomoMail.ACTION_CANCEL_SNOOZE_NAME
-import com.infomaniak.mail.MatomoMail.ACTION_MODIFY_SNOOZE_NAME
 import com.infomaniak.mail.MatomoMail.OPEN_ACTION_BOTTOM_SHEET
 import com.infomaniak.mail.MatomoMail.OPEN_FROM_DRAFT_NAME
 import com.infomaniak.mail.MatomoMail.trackAttachmentActionsEvent
@@ -678,8 +678,10 @@ class ThreadFragment : Fragment() {
                     threadViewModel.clickOnQuickActionBar(menuId)
                 }
                 R.id.quickActionArchive -> {
-                    trackThreadActionsEvent(ACTION_ARCHIVE_NAME, isFromArchive)
-                    mainViewModel.archiveThread(threadUid)
+                    descriptionDialog.archiveWithConfirmationPopup(folderRole, count = 1) {
+                        trackThreadActionsEvent(ACTION_ARCHIVE_NAME, isFromArchive)
+                        mainViewModel.archiveThread(threadUid)
+                    }
                 }
                 R.id.quickActionDelete -> {
                     descriptionDialog.deleteWithConfirmationPopup(folderRole, count = 1) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MessageActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MessageActionsBottomSheetDialog.kt
@@ -43,10 +43,7 @@ import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.ui.alertDialogs.DescriptionAlertDialog
 import com.infomaniak.mail.ui.main.move.MoveFragmentArgs
 import com.infomaniak.mail.ui.main.thread.PrintMailFragmentArgs
-import com.infomaniak.mail.utils.extensions.animatedNavigation
-import com.infomaniak.mail.utils.extensions.deleteWithConfirmationPopup
-import com.infomaniak.mail.utils.extensions.navigateToDownloadMessagesProgressDialog
-import com.infomaniak.mail.utils.extensions.safeNavigateToNewMessageActivity
+import com.infomaniak.mail.utils.extensions.*
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -130,8 +127,10 @@ class MessageActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
 
             //region Actions
             override fun onArchive() {
-                trackBottomSheetMessageActionsEvent(ACTION_ARCHIVE_NAME, message.folder.role == FolderRole.ARCHIVE)
-                mainViewModel.archiveMessage(threadUid, message)
+                descriptionDialog.archiveWithConfirmationPopup(message.folder.role, count = 1) {
+                    trackBottomSheetMessageActionsEvent(ACTION_ARCHIVE_NAME, message.folder.role == FolderRole.ARCHIVE)
+                    mainViewModel.archiveMessage(threadUid, message)
+                }
             }
 
             override fun onReadUnread() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MessageActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MessageActionsBottomSheetDialog.kt
@@ -20,6 +20,7 @@ package com.infomaniak.mail.ui.main.thread.actions
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.infomaniak.lib.core.utils.isNightModeEnabled
 import com.infomaniak.lib.core.utils.safeNavigate
@@ -141,11 +142,14 @@ class MessageActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
 
             override fun onMove() {
                 trackBottomSheetMessageActionsEvent(ACTION_MOVE_NAME)
-                animatedNavigation(
-                    resId = R.id.moveFragment,
-                    args = MoveFragmentArgs(arrayOf(threadUid), messageUid).toBundle(),
-                    currentClassName = currentClassName,
-                )
+                val navController = findNavController()
+                descriptionDialog.moveWithConfirmationPopup(message.folder.role, count = 1) {
+                    navController.animatedNavigation(
+                        resId = R.id.moveFragment,
+                        args = MoveFragmentArgs(arrayOf(threadUid), messageUid).toBundle(),
+                        currentClassName = currentClassName,
+                    )
+                }
             }
 
             override fun onSnooze() = Unit

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MessageActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MessageActionsBottomSheetDialog.kt
@@ -121,7 +121,7 @@ class MessageActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
             }
 
             override fun onDelete() {
-                descriptionDialog.deleteWithConfirmationPopup(folderRole, count = 1) {
+                descriptionDialog.deleteWithConfirmationPopup(message.folder.role, count = 1) {
                     trackBottomSheetMessageActionsEvent(ACTION_DELETE_NAME)
                     mainViewModel.deleteMessage(threadUid, message)
                 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MultiSelectBottomSheetDialog.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,6 +40,7 @@ import com.infomaniak.mail.ui.main.folder.ThreadListFragmentDirections
 import com.infomaniak.mail.ui.main.folder.ThreadListMultiSelection
 import com.infomaniak.mail.ui.main.folder.ThreadListMultiSelection.Companion.getReadIconAndShortText
 import com.infomaniak.mail.utils.extensions.animatedNavigation
+import com.infomaniak.mail.utils.extensions.archiveWithConfirmationPopup
 import com.infomaniak.mail.utils.extensions.deleteWithConfirmationPopup
 import com.infomaniak.mail.utils.extensions.navigateToDownloadMessagesProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -87,8 +88,13 @@ class MultiSelectBottomSheetDialog : ActionsBottomSheetDialog() {
                     toggleThreadsSeenStatus(threadsUids, shouldRead)
                 }
                 R.id.actionArchive -> {
-                    trackMultiSelectActionEvent(ACTION_ARCHIVE_NAME, threadsCount, isFromBottomSheet = true)
-                    archiveThreads(threadsUids)
+                    descriptionDialog.archiveWithConfirmationPopup(
+                        folderRole = getActionFolderRole(threads.firstOrNull()),
+                        count = threadsCount,
+                    ) {
+                        trackMultiSelectActionEvent(ACTION_ARCHIVE_NAME, threadsCount, isFromBottomSheet = true)
+                        archiveThreads(threadsUids)
+                    }
                 }
                 R.id.actionDelete -> {
                     descriptionDialog.deleteWithConfirmationPopup(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MultiSelectBottomSheetDialog.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
 import com.infomaniak.lib.core.utils.safeBinding
 import com.infomaniak.mail.MatomoMail.ACTION_ARCHIVE_NAME
 import com.infomaniak.mail.MatomoMail.ACTION_DELETE_NAME
@@ -39,10 +40,7 @@ import com.infomaniak.mail.ui.alertDialogs.DescriptionAlertDialog
 import com.infomaniak.mail.ui.main.folder.ThreadListFragmentDirections
 import com.infomaniak.mail.ui.main.folder.ThreadListMultiSelection
 import com.infomaniak.mail.ui.main.folder.ThreadListMultiSelection.Companion.getReadIconAndShortText
-import com.infomaniak.mail.utils.extensions.animatedNavigation
-import com.infomaniak.mail.utils.extensions.archiveWithConfirmationPopup
-import com.infomaniak.mail.utils.extensions.deleteWithConfirmationPopup
-import com.infomaniak.mail.utils.extensions.navigateToDownloadMessagesProgressDialog
+import com.infomaniak.mail.utils.extensions.*
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -75,13 +73,19 @@ class MultiSelectBottomSheetDialog : ActionsBottomSheetDialog() {
         binding.mainActions.setClosingOnClickListener(shouldCloseMultiSelection = true) { id: Int ->
             when (id) {
                 R.id.actionMove -> {
-                    trackMultiSelectActionEvent(ACTION_MOVE_NAME, threadsCount, isFromBottomSheet = true)
-                    animatedNavigation(
-                        directions = ThreadListFragmentDirections.actionThreadListFragmentToMoveFragment(
-                            threadsUids = threadsUids.toTypedArray(),
-                        ),
-                        currentClassName = currentClassName,
-                    )
+                    val navController = findNavController()
+                    descriptionDialog.moveWithConfirmationPopup(
+                        folderRole = getActionFolderRole(threads.firstOrNull()),
+                        count = threadsCount,
+                    ) {
+                        trackMultiSelectActionEvent(ACTION_MOVE_NAME, threadsCount, isFromBottomSheet = true)
+                        navController.animatedNavigation(
+                            directions = ThreadListFragmentDirections.actionThreadListFragmentToMoveFragment(
+                                threadsUids = threadsUids.toTypedArray(),
+                            ),
+                            currentClassName = currentClassName,
+                        )
+                    }
                 }
                 R.id.actionReadUnread -> {
                     trackMultiSelectActionEvent(ACTION_MARK_AS_SEEN_NAME, threadsCount, isFromBottomSheet = true)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsBottomSheetDialog.kt
@@ -168,8 +168,10 @@ class ThreadActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
 
                 //region Actions
                 override fun onArchive() = with(mainViewModel) {
-                    trackBottomSheetThreadActionsEvent(ACTION_ARCHIVE_NAME, isFromArchive)
-                    archiveThread(threadUid)
+                    descriptionDialog.archiveWithConfirmationPopup(folderRole, count = 1) {
+                        trackBottomSheetThreadActionsEvent(ACTION_ARCHIVE_NAME, isFromArchive)
+                        archiveThread(threadUid)
+                    }
                 }
 
                 override fun onReadUnread() {
@@ -179,8 +181,10 @@ class ThreadActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
                 }
 
                 override fun onMove() {
-                    trackBottomSheetThreadActionsEvent(ACTION_MOVE_NAME)
-                    animatedNavigation(R.id.moveFragment, MoveFragmentArgs(arrayOf(threadUid)).toBundle(), currentClassName)
+                    descriptionDialog.moveWithConfirmationPopup(folderRole, count = 1) {
+                        trackBottomSheetThreadActionsEvent(ACTION_MOVE_NAME)
+                        animatedNavigation(R.id.moveFragment, MoveFragmentArgs(arrayOf(threadUid)).toBundle(), currentClassName)
+                    }
                 }
 
                 override fun onSnooze() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsBottomSheetDialog.kt
@@ -167,10 +167,10 @@ class ThreadActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
                 //endregion
 
                 //region Actions
-                override fun onArchive() = with(mainViewModel) {
+                override fun onArchive() {
                     descriptionDialog.archiveWithConfirmationPopup(folderRole, count = 1) {
                         trackBottomSheetThreadActionsEvent(ACTION_ARCHIVE_NAME, isFromArchive)
-                        archiveThread(threadUid)
+                        mainViewModel.archiveThread(threadUid)
                     }
                 }
 
@@ -181,9 +181,14 @@ class ThreadActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
                 }
 
                 override fun onMove() {
+                    val navController = findNavController()
                     descriptionDialog.moveWithConfirmationPopup(folderRole, count = 1) {
                         trackBottomSheetThreadActionsEvent(ACTION_MOVE_NAME)
-                        animatedNavigation(R.id.moveFragment, MoveFragmentArgs(arrayOf(threadUid)).toBundle(), currentClassName)
+                        navController.animatedNavigation(
+                            resId = R.id.moveFragment,
+                            args = MoveFragmentArgs(arrayOf(threadUid)).toBundle(),
+                            currentClassName = currentClassName,
+                        )
                     }
                 }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/ConfirmationPopupExt.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/ConfirmationPopupExt.kt
@@ -1,0 +1,114 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.utils.extensions
+
+import com.infomaniak.lib.core.utils.context
+import com.infomaniak.mail.R
+import com.infomaniak.mail.data.models.Folder
+import com.infomaniak.mail.ui.alertDialogs.DescriptionAlertDialog
+import com.infomaniak.mail.utils.Utils
+
+fun DescriptionAlertDialog.deleteWithConfirmationPopup(
+    folderRole: Folder.FolderRole?,
+    count: Int,
+    displayLoader: Boolean = true,
+    onCancel: (() -> Unit)? = null,
+    callback: () -> Unit,
+): Boolean {
+    var isDialogShow = true
+    when {
+        folderRole == Folder.FolderRole.SNOOZED -> showDeleteSnoozeDialog(count, displayLoader, callback, onCancel)
+        Utils.isPermanentDeleteFolder(folderRole) && folderRole != Folder.FolderRole.DRAFT -> { // We don't want to display the popup for Drafts
+            showDeletePermanentlyDialog(count, displayLoader, callback, onCancel)
+        }
+        else -> {
+            isDialogShow = false
+            callback()
+        }
+    }
+    return isDialogShow
+}
+
+private fun DescriptionAlertDialog.showDeletePermanentlyDialog(
+    deletedCount: Int,
+    displayLoader: Boolean,
+    onPositiveButtonClicked: () -> Unit,
+    onCancel: (() -> Unit)? = null,
+) = show(
+    title = binding.context.resources.getQuantityString(
+        R.plurals.threadListDeletionConfirmationAlertTitle,
+        deletedCount,
+        deletedCount,
+    ),
+    description = binding.context.resources.getQuantityString(
+        R.plurals.threadListDeletionConfirmationAlertDescription,
+        deletedCount,
+    ),
+    displayLoader = displayLoader,
+    onPositiveButtonClicked = onPositiveButtonClicked,
+    onCancel = onCancel,
+)
+
+private fun DescriptionAlertDialog.showDeleteSnoozeDialog(
+    deletedCount: Int,
+    displayLoader: Boolean,
+    onPositiveButtonClicked: () -> Unit,
+    onCancel: (() -> Unit)? = null,
+) = show(
+    title = binding.context.getString(R.string.actionDelete),
+    description = binding.context.resources.getQuantityString(R.plurals.snoozeDeleteConfirmAlertDescription, deletedCount),
+    displayLoader = displayLoader,
+    onPositiveButtonClicked = onPositiveButtonClicked,
+    onCancel = onCancel,
+)
+
+fun DescriptionAlertDialog.moveWithConfirmationPopup(
+    folderRole: Folder.FolderRole?,
+    count: Int,
+    onPositiveButtonClicked: () -> Unit,
+) = if (folderRole == Folder.FolderRole.SNOOZED) {
+    show(
+        title = binding.context.getString(R.string.actionMove),
+        description = binding.context.resources.getQuantityString(R.plurals.snoozeMoveConfirmAlertDescription, count),
+        displayLoader = false,
+        onPositiveButtonClicked = onPositiveButtonClicked,
+    )
+} else {
+    onPositiveButtonClicked()
+}
+
+fun DescriptionAlertDialog.archiveWithConfirmationPopup(
+    folderRole: Folder.FolderRole?,
+    count: Int,
+    onCancel: (() -> Unit)? = null,
+    onPositiveButtonClicked: () -> Unit,
+): Boolean {
+    val isDialogShown = folderRole == Folder.FolderRole.SNOOZED
+    if (isDialogShown) {
+        show(
+            title = binding.context.getString(R.string.actionArchive),
+            description = binding.context.resources.getQuantityString(R.plurals.snoozeArchiveConfirmAlertDescription, count),
+            displayLoader = false,
+            onPositiveButtonClicked = onPositiveButtonClicked,
+            onCancel = onCancel,
+        )
+    } else {
+        onPositiveButtonClicked()
+    }
+    return isDialogShown
+}

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/ConfirmationPopupExt.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/ConfirmationPopupExt.kt
@@ -95,6 +95,7 @@ fun DescriptionAlertDialog.moveWithConfirmationPopup(
 fun DescriptionAlertDialog.archiveWithConfirmationPopup(
     folderRole: Folder.FolderRole?,
     count: Int,
+    displayLoader: Boolean = true,
     onCancel: (() -> Unit)? = null,
     onPositiveButtonClicked: () -> Unit,
 ): Boolean {
@@ -103,7 +104,7 @@ fun DescriptionAlertDialog.archiveWithConfirmationPopup(
         show(
             title = binding.context.getString(R.string.actionArchive),
             description = binding.context.resources.getQuantityString(R.plurals.snoozeArchiveConfirmAlertDescription, count),
-            displayLoader = false,
+            displayLoader = displayLoader,
             onPositiveButtonClicked = onPositiveButtonClicked,
             onCancel = onCancel,
         )

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -69,7 +69,6 @@ import com.infomaniak.dragdropswiperecyclerview.DragDropSwipeRecyclerView
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
-import com.infomaniak.lib.core.utils.context
 import com.infomaniak.lib.core.utils.hideKeyboard
 import com.infomaniak.lib.core.utils.removeAccents
 import com.infomaniak.lib.core.utils.showToast
@@ -91,7 +90,6 @@ import com.infomaniak.mail.data.models.draft.Draft.DraftMode
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.signature.Signature
 import com.infomaniak.mail.ui.alertDialogs.BaseAlertDialog
-import com.infomaniak.mail.ui.alertDialogs.DescriptionAlertDialog
 import com.infomaniak.mail.ui.login.IlluColors.IlluColors
 import com.infomaniak.mail.ui.main.SnackbarManager
 import com.infomaniak.mail.ui.main.folder.DateSeparatorItemDecoration
@@ -110,7 +108,6 @@ import com.infomaniak.mail.utils.JsoupParserUtil.jsoupParseWithLog
 import com.infomaniak.mail.utils.UiUtils.animateColorChange
 import com.infomaniak.mail.utils.Utils
 import com.infomaniak.mail.utils.Utils.TAG_SEPARATOR
-import com.infomaniak.mail.utils.Utils.isPermanentDeleteFolder
 import com.infomaniak.mail.utils.Utils.kSyncAccountUri
 import com.infomaniak.mail.utils.WebViewUtils
 import io.realm.kotlin.ext.copyFromRealm
@@ -409,96 +406,6 @@ fun List<Message>.getFoldersIds(exception: String? = null): ImpactedFolders {
 
 fun List<Message>.getUids(): List<String> = map { it.uid }
 //endregion
-
-fun DescriptionAlertDialog.deleteWithConfirmationPopup(
-    folderRole: FolderRole?,
-    count: Int,
-    displayLoader: Boolean = true,
-    onCancel: (() -> Unit)? = null,
-    callback: () -> Unit,
-): Boolean {
-    var isDialogShow = true
-    when {
-        folderRole == FolderRole.SNOOZED -> showDeleteSnoozeDialog(count, displayLoader, callback, onCancel)
-        isPermanentDeleteFolder(folderRole) && folderRole != FolderRole.DRAFT -> { // We don't want to display the popup for Drafts
-            showDeletePermanentlyDialog(count, displayLoader, callback, onCancel)
-        }
-        else -> {
-            isDialogShow = false
-            callback()
-        }
-    }
-    return isDialogShow
-}
-
-fun DescriptionAlertDialog.showDeletePermanentlyDialog(
-    deletedCount: Int,
-    displayLoader: Boolean,
-    onPositiveButtonClicked: () -> Unit,
-    onCancel: (() -> Unit)? = null,
-) = show(
-    title = binding.context.resources.getQuantityString(
-        R.plurals.threadListDeletionConfirmationAlertTitle,
-        deletedCount,
-        deletedCount,
-    ),
-    description = binding.context.resources.getQuantityString(
-        R.plurals.threadListDeletionConfirmationAlertDescription,
-        deletedCount,
-    ),
-    displayLoader = displayLoader,
-    onPositiveButtonClicked = onPositiveButtonClicked,
-    onCancel = onCancel,
-)
-
-fun DescriptionAlertDialog.showDeleteSnoozeDialog(
-    deletedCount: Int,
-    displayLoader: Boolean,
-    onPositiveButtonClicked: () -> Unit,
-    onCancel: (() -> Unit)? = null,
-) = show(
-    title = binding.context.getString(R.string.actionDelete),
-    description = binding.context.resources.getQuantityString(R.plurals.snoozeDeleteConfirmAlertDescription, deletedCount),
-    displayLoader = displayLoader,
-    onPositiveButtonClicked = onPositiveButtonClicked,
-    onCancel = onCancel,
-)
-
-fun DescriptionAlertDialog.moveWithConfirmationPopup(
-    folderRole: FolderRole?,
-    count: Int,
-    onPositiveButtonClicked: () -> Unit,
-) = if (folderRole == FolderRole.SNOOZED) {
-    show(
-        title = binding.context.getString(R.string.actionMove),
-        description = binding.context.resources.getQuantityString(R.plurals.snoozeMoveConfirmAlertDescription, count),
-        displayLoader = false,
-        onPositiveButtonClicked = onPositiveButtonClicked,
-    )
-} else {
-    onPositiveButtonClicked()
-}
-
-fun DescriptionAlertDialog.archiveWithConfirmationPopup(
-    folderRole: FolderRole?,
-    count: Int,
-    onCancel: (() -> Unit)? = null,
-    onPositiveButtonClicked: () -> Unit,
-): Boolean {
-    val isDialogShown = folderRole == FolderRole.SNOOZED
-    if (isDialogShown) {
-        show(
-            title = binding.context.getString(R.string.actionArchive),
-            description = binding.context.resources.getQuantityString(R.plurals.snoozeArchiveConfirmAlertDescription, count),
-            displayLoader = false,
-            onPositiveButtonClicked = onPositiveButtonClicked,
-            onCancel = onCancel,
-        )
-    } else {
-        onPositiveButtonClicked()
-    }
-    return isDialogShown
-}
 
 fun DragDropSwipeRecyclerView.addStickyDateDecoration(adapter: ThreadListAdapter, threadDensity: ThreadDensity) {
     addItemDecoration(HeaderItemDecoration(this, false) { position ->

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -475,6 +475,7 @@ fun DescriptionAlertDialog.moveWithConfirmationPopup(
 fun DescriptionAlertDialog.archiveWithConfirmationPopup(
     folderRole: FolderRole?,
     count: Int,
+    onCancel: (() -> Unit)? = null,
     onPositiveButtonClicked: () -> Unit,
 ) = if (folderRole == FolderRole.SNOOZED) {
     show(
@@ -482,6 +483,7 @@ fun DescriptionAlertDialog.archiveWithConfirmationPopup(
         description = binding.context.resources.getQuantityString(R.plurals.snoozeArchiveConfirmAlertDescription, count),
         displayLoader = false,
         onPositiveButtonClicked = onPositiveButtonClicked,
+        onCancel = onCancel,
     )
 } else {
     onPositiveButtonClicked()

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -416,12 +416,19 @@ fun DescriptionAlertDialog.deleteWithConfirmationPopup(
     displayLoader: Boolean = true,
     onCancel: (() -> Unit)? = null,
     callback: () -> Unit,
-) = when {
-    folderRole == FolderRole.SNOOZED -> showDeleteSnoozeDialog(count, displayLoader, callback, onCancel)
-    isPermanentDeleteFolder(folderRole) && folderRole != FolderRole.DRAFT -> { // We don't want to display the popup for Drafts
-        showDeletePermanentlyDialog(count, displayLoader, callback, onCancel)
+): Boolean {
+    var isDialogShow = true
+    when {
+        folderRole == FolderRole.SNOOZED -> showDeleteSnoozeDialog(count, displayLoader, callback, onCancel)
+        isPermanentDeleteFolder(folderRole) && folderRole != FolderRole.DRAFT -> { // We don't want to display the popup for Drafts
+            showDeletePermanentlyDialog(count, displayLoader, callback, onCancel)
+        }
+        else -> {
+            isDialogShow = false
+            callback()
+        }
     }
-    else -> callback()
+    return isDialogShow
 }
 
 fun DescriptionAlertDialog.showDeletePermanentlyDialog(
@@ -477,16 +484,20 @@ fun DescriptionAlertDialog.archiveWithConfirmationPopup(
     count: Int,
     onCancel: (() -> Unit)? = null,
     onPositiveButtonClicked: () -> Unit,
-) = if (folderRole == FolderRole.SNOOZED) {
-    show(
-        title = binding.context.getString(R.string.actionArchive),
-        description = binding.context.resources.getQuantityString(R.plurals.snoozeArchiveConfirmAlertDescription, count),
-        displayLoader = false,
-        onPositiveButtonClicked = onPositiveButtonClicked,
-        onCancel = onCancel,
-    )
-} else {
-    onPositiveButtonClicked()
+): Boolean {
+    val isDialogShown = folderRole == FolderRole.SNOOZED
+    if (isDialogShown) {
+        show(
+            title = binding.context.getString(R.string.actionArchive),
+            description = binding.context.resources.getQuantityString(R.plurals.snoozeArchiveConfirmAlertDescription, count),
+            displayLoader = false,
+            onPositiveButtonClicked = onPositiveButtonClicked,
+            onCancel = onCancel,
+        )
+    } else {
+        onPositiveButtonClicked()
+    }
+    return isDialogShown
 }
 
 fun DragDropSwipeRecyclerView.addStickyDateDecoration(adapter: ThreadListAdapter, threadDensity: ThreadDensity) {

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -62,13 +62,14 @@ import com.google.android.material.color.MaterialColors
 import com.google.android.material.imageview.ShapeableImageView
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
-import com.infomaniak.dragdropswiperecyclerview.DragDropSwipeRecyclerView
 import com.infomaniak.core.utils.endOfTheWeek
 import com.infomaniak.core.utils.startOfTheDay
 import com.infomaniak.core.utils.startOfTheWeek
+import com.infomaniak.dragdropswiperecyclerview.DragDropSwipeRecyclerView
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
+import com.infomaniak.lib.core.utils.context
 import com.infomaniak.lib.core.utils.hideKeyboard
 import com.infomaniak.lib.core.utils.removeAccents
 import com.infomaniak.lib.core.utils.showToast
@@ -415,10 +416,75 @@ fun DescriptionAlertDialog.deleteWithConfirmationPopup(
     displayLoader: Boolean = true,
     onCancel: (() -> Unit)? = null,
     callback: () -> Unit,
-) = if (isPermanentDeleteFolder(folderRole) && folderRole != FolderRole.DRAFT) { // We don't want to display the popup for Drafts
-    showDeletePermanentlyDialog(count, displayLoader, callback, onCancel)
+) = when {
+    folderRole == FolderRole.SNOOZED -> showDeleteSnoozeDialog(count, displayLoader, callback, onCancel)
+    isPermanentDeleteFolder(folderRole) && folderRole != FolderRole.DRAFT -> { // We don't want to display the popup for Drafts
+        showDeletePermanentlyDialog(count, displayLoader, callback, onCancel)
+    }
+    else -> callback()
+}
+
+fun DescriptionAlertDialog.showDeletePermanentlyDialog(
+    deletedCount: Int,
+    displayLoader: Boolean,
+    onPositiveButtonClicked: () -> Unit,
+    onCancel: (() -> Unit)? = null,
+) = show(
+    title = binding.context.resources.getQuantityString(
+        R.plurals.threadListDeletionConfirmationAlertTitle,
+        deletedCount,
+        deletedCount,
+    ),
+    description = binding.context.resources.getQuantityString(
+        R.plurals.threadListDeletionConfirmationAlertDescription,
+        deletedCount,
+    ),
+    displayLoader = displayLoader,
+    onPositiveButtonClicked = onPositiveButtonClicked,
+    onCancel = onCancel,
+)
+
+fun DescriptionAlertDialog.showDeleteSnoozeDialog(
+    deletedCount: Int,
+    displayLoader: Boolean,
+    onPositiveButtonClicked: () -> Unit,
+    onCancel: (() -> Unit)? = null,
+) = show(
+    title = binding.context.getString(R.string.actionDelete),
+    description = binding.context.resources.getQuantityString(R.plurals.snoozeDeleteConfirmAlertDescription, deletedCount),
+    displayLoader = displayLoader,
+    onPositiveButtonClicked = onPositiveButtonClicked,
+    onCancel = onCancel,
+)
+
+fun DescriptionAlertDialog.moveWithConfirmationPopup(
+    folderRole: FolderRole?,
+    count: Int,
+    onPositiveButtonClicked: () -> Unit,
+) = if (folderRole == FolderRole.SNOOZED) {
+    show(
+        title = binding.context.getString(R.string.actionMove),
+        description = binding.context.resources.getQuantityString(R.plurals.snoozeMoveConfirmAlertDescription, count),
+        displayLoader = false,
+        onPositiveButtonClicked = onPositiveButtonClicked,
+    )
 } else {
-    callback()
+    onPositiveButtonClicked()
+}
+
+fun DescriptionAlertDialog.archiveWithConfirmationPopup(
+    folderRole: FolderRole?,
+    count: Int,
+    onPositiveButtonClicked: () -> Unit,
+) = if (folderRole == FolderRole.SNOOZED) {
+    show(
+        title = binding.context.getString(R.string.actionArchive),
+        description = binding.context.resources.getQuantityString(R.plurals.snoozeArchiveConfirmAlertDescription, count),
+        displayLoader = false,
+        onPositiveButtonClicked = onPositiveButtonClicked,
+    )
+} else {
+    onPositiveButtonClicked()
 }
 
 fun DragDropSwipeRecyclerView.addStickyDateDecoration(adapter: ThreadListAdapter, threadDensity: ThreadDensity) {

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/NavigationExt.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/NavigationExt.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
@@ -56,6 +57,14 @@ fun Fragment.animatedNavigation(directions: NavDirections, currentClassName: Str
 
 fun Fragment.animatedNavigation(@IdRes resId: Int, args: Bundle? = null, currentClassName: String? = null) {
     if (canNavigate(currentClassName)) findNavController().navigate(resId, args, getAnimatedNavOptions())
+}
+
+fun NavController.animatedNavigation(directions: NavDirections, currentClassName: String) {
+    if (canNavigate(currentClassName, currentClassName)) navigate(directions, getAnimatedNavOptions())
+}
+
+fun NavController.animatedNavigation(@IdRes resId: Int, args: Bundle? = null, currentClassName: String) {
+    if (canNavigate(currentClassName, currentClassName)) navigate(resId, args, getAnimatedNavOptions())
 }
 
 fun Fragment.safeNavigateToNewMessageActivity(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -585,6 +585,18 @@
         <item quantity="other">Erinnerungen storniert. Ihre Nachrichten sind zurück in Ihrem Posteingang</item>
     </plurals>
     <string name="snoozeAlertTitle">Ausstehend bis: %s</string>
+    <plurals name="snoozeArchiveConfirmAlertDescription">
+        <item quantity="one">Diese Unterhaltung wird nicht mehr schlummern und wird archiviert</item>
+        <item quantity="other">Diese Unterhaltungen werden nicht mehr schlummern und werden archiviert</item>
+    </plurals>
+    <plurals name="snoozeDeleteConfirmAlertDescription">
+        <item quantity="one">Diese Unterhaltung wird nicht mehr schlummern und wird gelöscht</item>
+        <item quantity="other">Diese Unterhaltungen werden nicht mehr schlummern und werden gelöscht</item>
+    </plurals>
+    <plurals name="snoozeMoveConfirmAlertDescription">
+        <item quantity="one">Diese Unterhaltung wird nicht mehr schlummern und wird verschoben</item>
+        <item quantity="other">Diese Unterhaltungen werden nicht mehr schlummern und werden verschoben</item>
+    </plurals>
     <string name="snoozedFolder">In der Warteschlange</string>
     <string name="socialNetworksFolder">Soziale Netzwerke</string>
     <string name="spamFolder">Spam</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2022-2024 Infomaniak Network SA
+  ~ Copyright (C) 2022-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -586,16 +586,16 @@
     </plurals>
     <string name="snoozeAlertTitle">Ausstehend bis: %s</string>
     <plurals name="snoozeArchiveConfirmAlertDescription">
-        <item quantity="one">Diese Unterhaltung wird nicht mehr schlummern und wird archiviert</item>
-        <item quantity="other">Diese Unterhaltungen werden nicht mehr schlummern und werden archiviert</item>
+        <item quantity="one">Diese Unterhaltung wird nicht länger verschoben und wird archiviert</item>
+        <item quantity="other">Diese Unterhaltungen werden nicht länger verschoben und werden archiviert</item>
     </plurals>
     <plurals name="snoozeDeleteConfirmAlertDescription">
-        <item quantity="one">Diese Unterhaltung wird nicht mehr schlummern und wird gelöscht</item>
-        <item quantity="other">Diese Unterhaltungen werden nicht mehr schlummern und werden gelöscht</item>
+        <item quantity="one">Diese Unterhaltung wird nicht länger verschoben und wird gelöscht</item>
+        <item quantity="other">Diese Unterhaltungen werden nicht länger verschoben und werden gelöscht</item>
     </plurals>
     <plurals name="snoozeMoveConfirmAlertDescription">
-        <item quantity="one">Diese Unterhaltung wird nicht mehr schlummern und wird verschoben</item>
-        <item quantity="other">Diese Unterhaltungen werden nicht mehr schlummern und werden verschoben</item>
+        <item quantity="one">Diese Unterhaltung wird nicht länger verschoben und wird nun bewegt</item>
+        <item quantity="other">Diese Unterhaltungen werden nicht länger verschoben und werden nun bewegt</item>
     </plurals>
     <string name="snoozedFolder">In der Warteschlange</string>
     <string name="socialNetworksFolder">Soziale Netzwerke</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -585,6 +585,18 @@
         <item quantity="other">Recordatorios cancelados. Tus mensajes han vuelto a tu bandeja de entrada</item>
     </plurals>
     <string name="snoozeAlertTitle">En espera hasta: %s</string>
+    <plurals name="snoozeArchiveConfirmAlertDescription">
+        <item quantity="one">Esta conversación ya no estará en espera y será archivada</item>
+        <item quantity="other">Estas conversaciones ya no estarán en espera y serán archivadas</item>
+    </plurals>
+    <plurals name="snoozeDeleteConfirmAlertDescription">
+        <item quantity="one">Esta conversación ya no estará en espera y será eliminada</item>
+        <item quantity="other">Estas conversaciones ya no estarán en espera y serán eliminadas</item>
+    </plurals>
+    <plurals name="snoozeMoveConfirmAlertDescription">
+        <item quantity="one">Esta conversación ya no estará en espera y será movida</item>
+        <item quantity="other">Estas conversaciones ya no estarán en espera y serán movidas</item>
+    </plurals>
     <string name="snoozedFolder">En espera</string>
     <string name="socialNetworksFolder">Redes sociales</string>
     <string name="spamFolder">Spam</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -598,6 +598,21 @@
         <item quantity="many">Rappels annulés. Vos messages sont revenus dans votre boîte de réception</item>
     </plurals>
     <string name="snoozeAlertTitle">En attente jusqu’au : %s</string>
+    <plurals name="snoozeArchiveConfirmAlertDescription">
+        <item quantity="one">Cette conversation ne sera plus en attente et sera archivée</item>
+        <item quantity="other">Ces conversations ne seront plus en attente et seront archivées</item>
+        <item quantity="many">Ces conversations ne seront plus en attente et seront archivées</item>
+    </plurals>
+    <plurals name="snoozeDeleteConfirmAlertDescription">
+        <item quantity="one">Cette conversation ne sera plus en attente et sera supprimée</item>
+        <item quantity="other">Ces conversations ne seront plus en attente et seront supprimées</item>
+        <item quantity="many">Ces conversations ne seront plus en attente et seront supprimées</item>
+    </plurals>
+    <plurals name="snoozeMoveConfirmAlertDescription">
+        <item quantity="one">Cette conversation ne sera plus en attente et sera déplacée</item>
+        <item quantity="other">Ces conversations ne seront plus en attente et seront déplacées</item>
+        <item quantity="many">Ces conversations ne seront plus en attente et seront déplacées</item>
+    </plurals>
     <string name="snoozedFolder">En attente</string>
     <string name="socialNetworksFolder">Réseaux sociaux</string>
     <string name="spamFolder">Spam</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -585,6 +585,18 @@
         <item quantity="other">Promemoria annullati. I tuoi messaggi sono tornati nella tua casella di posta</item>
     </plurals>
     <string name="snoozeAlertTitle">In attesa fino al: %s</string>
+    <plurals name="snoozeArchiveConfirmAlertDescription">
+        <item quantity="one">Questa conversazione non sarà più posticipata e verrà archiviata</item>
+        <item quantity="other">Queste conversazioni non saranno più posticipate e verranno archiviate</item>
+    </plurals>
+    <plurals name="snoozeDeleteConfirmAlertDescription">
+        <item quantity="one">Questa conversazione non sarà più posticipata e verrà eliminata</item>
+        <item quantity="other">Queste conversazioni non saranno più posticipate e verranno eliminate</item>
+    </plurals>
+    <plurals name="snoozeMoveConfirmAlertDescription">
+        <item quantity="one">Questa conversazione non sarà più posticipata e verrà spostata</item>
+        <item quantity="other">Queste conversazioni non saranno più posticipate e verranno spostate</item>
+    </plurals>
     <string name="snoozedFolder">In attesa</string>
     <string name="socialNetworksFolder">Social Network</string>
     <string name="spamFolder">Spam</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -591,6 +591,18 @@
         <item quantity="other">Reminders canceled. Your messages are back in your inbox</item>
     </plurals>
     <string name="snoozeAlertTitle">Snoozed until: %s</string>
+    <plurals name="snoozeArchiveConfirmAlertDescription">
+        <item quantity="one">This conversation will no longer be snoozed and will be archived</item>
+        <item quantity="other">These conversations will no longer be snoozed and will be archived</item>
+    </plurals>
+    <plurals name="snoozeDeleteConfirmAlertDescription">
+        <item quantity="one">This conversation will no longer be snoozed and will be deleted</item>
+        <item quantity="other">These conversations will no longer be snoozed and will be deleted</item>
+    </plurals>
+    <plurals name="snoozeMoveConfirmAlertDescription">
+        <item quantity="one">This conversation will no longer be snoozed and will be moved</item>
+        <item quantity="other">These conversations will no longer be snoozed and will be moved</item>
+    </plurals>
     <string name="snoozedFolder">Snoozed</string>
     <string name="socialNetworksFolder">Social networks</string>
     <string name="spamFolder">Spam</string>


### PR DESCRIPTION
Executing one of these actions on a snoozed email will automatically unsnooze the thread on the api. We want to warn the user before he does it.

Depends on #2292 