### PR TITLE
feat: Hide snooze actions in the thread header like the webmail does when not in snooze folder

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/MessageAlertView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/MessageAlertView.kt
@@ -100,6 +100,10 @@ class MessageAlertView @JvmOverloads constructor(
             isEnabled = true
         }
     }
+
+    fun setActionsVisibility(isVisible: Boolean) {
+        binding.actionsLayout.isVisible = isVisible
+    }
 }
 
 private fun MaterialButton.showProgress() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -574,7 +574,8 @@ class ThreadFragment : Fragment() {
 
     private fun observeSnoozeHeaderVisibility() {
         threadViewModel.isThreadSnoozeHeaderVisible.observe(viewLifecycleOwner) {
-            binding.threadAlertsLayout.isVisible = it
+            binding.threadAlertsLayout.isGone = it == ThreadViewModel.ThreadHeaderVisibility.NONE
+            binding.snoozeAlert.setActionsVisibility(it == ThreadViewModel.ThreadHeaderVisibility.DATE_AND_ACTIONS)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -86,7 +86,7 @@ import com.infomaniak.mail.ui.main.folder.TwoPaneViewModel.NavData
 import com.infomaniak.mail.ui.main.thread.SubjectFormatter.SubjectData
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.ContextMenuType
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.ThreadAdapterCallbacks
-import com.infomaniak.mail.ui.main.thread.ThreadViewModel.SnoozeScheduleType
+import com.infomaniak.mail.ui.main.thread.ThreadViewModel.*
 import com.infomaniak.mail.ui.main.thread.actions.*
 import com.infomaniak.mail.ui.main.thread.actions.ThreadActionsBottomSheetDialog.Companion.OPEN_SNOOZE_BOTTOM_SHEET
 import com.infomaniak.mail.ui.main.thread.calendar.AttendeesBottomSheetDialogArgs
@@ -572,10 +572,10 @@ class ThreadFragment : Fragment() {
         }
     }
 
-    private fun observeSnoozeHeaderVisibility() {
+    private fun observeSnoozeHeaderVisibility() = with(binding) {
         threadViewModel.isThreadSnoozeHeaderVisible.observe(viewLifecycleOwner) {
-            binding.threadAlertsLayout.isGone = it == ThreadViewModel.ThreadHeaderVisibility.NONE
-            binding.snoozeAlert.setActionsVisibility(it == ThreadViewModel.ThreadHeaderVisibility.DATE_AND_ACTIONS)
+            threadAlertsLayout.isGone = it == ThreadHeaderVisibility.NONE
+            snoozeAlert.setActionsVisibility(it == ThreadHeaderVisibility.MESSAGE_AND_ACTIONS)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -24,6 +24,7 @@ import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.utils.SingleLiveEvent
 import com.infomaniak.mail.MatomoMail.trackUserInfo
 import com.infomaniak.mail.data.LocalSettings
+import com.infomaniak.mail.data.LocalSettings.*
 import com.infomaniak.mail.data.api.ApiRepository
 import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.cache.mailboxContent.MessageController
@@ -105,16 +106,18 @@ class ThreadViewModel @Inject constructor(
     var snoozeScheduleType: SnoozeScheduleType? = null
 
     val isThreadSnoozeHeaderVisible = Utils.waitInitMediator(currentMailboxLive, threadLive).map { (mailbox, thread) ->
-        if (thread?.isSnoozed() != true) {
-            ThreadHeaderVisibility.NONE
-        } else if (
+        when {
+            thread?.isSnoozed() != true -> {
+                ThreadHeaderVisibility.NONE
+            }
             mailbox?.featureFlags?.contains(FeatureFlag.SNOOZE) == true
-            && thread.folder.role == FolderRole.SNOOZED
-            && localSettings.threadMode == LocalSettings.ThreadMode.CONVERSATION
-        ) {
-            ThreadHeaderVisibility.DATE_AND_ACTIONS
-        } else {
-            ThreadHeaderVisibility.DATE_ONLY
+                    && thread.folder.role == FolderRole.SNOOZED
+                    && localSettings.threadMode == ThreadMode.CONVERSATION -> {
+                ThreadHeaderVisibility.MESSAGE_AND_ACTIONS
+            }
+            else -> {
+                ThreadHeaderVisibility.MESSAGE_ONLY
+            }
         }
     }
 
@@ -491,9 +494,7 @@ class ThreadViewModel @Inject constructor(
     )
 
     private enum class MessageBehavior {
-        DISPLAYED,
-        COLLAPSED,
-        FIRST_AFTER_BLOCK,
+        DISPLAYED, COLLAPSED, FIRST_AFTER_BLOCK,
     }
 
     sealed interface SnoozeScheduleType : Parcelable {
@@ -511,7 +512,7 @@ class ThreadViewModel @Inject constructor(
     }
 
     enum class ThreadHeaderVisibility {
-        DATE_AND_ACTIONS, DATE_ONLY, NONE
+        MESSAGE_AND_ACTIONS, MESSAGE_ONLY, NONE,
     }
 
     companion object {

--- a/app/src/main/res/layout/view_message_alert.xml
+++ b/app/src/main/res/layout/view_message_alert.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2023-2024 Infomaniak Network SA
+  ~ Copyright (C) 2023-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <ImageView
         android:id="@+id/icon"
@@ -42,12 +42,15 @@
         android:layout_marginTop="@dimen/marginStandardSmall"
         android:layout_marginEnd="@dimen/marginStandardMedium"
         app:layout_constrainedWidth="true"
+        app:layout_constraintBottom_toTopOf="@id/actionsLayout"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/icon"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_goneMarginBottom="@dimen/marginStandardSmall"
         tools:text="@string/alertBlockedImagesDescription" />
 
     <com.google.android.flexbox.FlexboxLayout
+        android:id="@+id/actionsLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="-16dp"
@@ -57,6 +60,7 @@
         app:flexDirection="row"
         app:flexWrap="wrap"
         app:justifyContent="flex_start"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@id/description"
         app:layout_constraintTop_toBottomOf="@id/description">


### PR DESCRIPTION
Actions should not be accessible when not in the snooze folder or inbox. This also applies to the thread header that I missed till now. This PR hides the buttons in this case.