### PR TITLE
refactor: Expose a `isSeen` property for a Thread instead of accessing `unseenMessagesCount` everytime

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -106,6 +106,8 @@ class Thread : RealmObject, Snoozable {
     var isLastInboxMessageSnoozed: Boolean = false
     //endregion
 
+    val isSeen get() = unseenMessagesCount == 0
+
     @Ignore
     override var snoozeState: SnoozeState? by apiEnum(::_snoozeState)
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -873,7 +873,7 @@ class MainViewModel @Inject constructor(
 
         val isSeen = when {
             message != null -> message.isSeen
-            threads.count() == 1 -> threads.single().unseenMessagesCount == 0
+            threads.count() == 1 -> threads.single().isSeen
             else -> !shouldRead
         }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -256,7 +256,7 @@ class ThreadListAdapter @Inject constructor(
             threadCountText.text = "$messagesCount"
             threadCountCard.isVisible = messagesCount > 1
 
-            if (unseenMessagesCount == 0) setThreadUiRead() else setThreadUiUnread()
+            if (isSeen) setThreadUiRead() else setThreadUiUnread()
         }
 
         selectionCardView.setOnClickListener { onThreadClicked(thread, position) }
@@ -562,7 +562,7 @@ class ThreadListAdapter @Inject constructor(
         fun getSwipeActionUiData(swipeAction: SwipeAction) = when (swipeAction) {
             SwipeAction.READ_UNREAD -> SwipeActionUiData(
                 colorRes = swipeAction.colorRes,
-                iconRes = if (unseenMessagesCount > 0) R.drawable.ic_envelope_open else swipeAction.iconRes,
+                iconRes = if (isSeen) swipeAction.iconRes else R.drawable.ic_envelope_open,
             )
             SwipeAction.FAVORITE -> SwipeActionUiData(
                 colorRes = swipeAction.colorRes,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListMultiSelection.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListMultiSelection.kt
@@ -226,7 +226,7 @@ class ThreadListMultiSelection {
             var shouldUnfavorite = selectedThreads.isNotEmpty()
 
             for (thread in selectedThreads) {
-                shouldUnread = shouldUnread && thread.unseenMessagesCount == 0
+                shouldUnread = shouldUnread && thread.isSeen
                 shouldUnfavorite = shouldUnfavorite && thread.isFavorite
 
                 if (!shouldUnread && !shouldUnfavorite) break

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -213,7 +213,7 @@ class ThreadViewModel @Inject constructor(
     private fun computeFirstIndexAfterBlock(thread: Thread, list: RealmResults<Message>): Int {
 
         val firstDefaultIndex = list.count() - 2
-        val firstUnreadIndex = if (thread.unseenMessagesCount > 0) list.indexOfFirstOrNull { !it.isSeen } else null
+        val firstUnreadIndex = if (thread.isSeen) null else list.indexOfFirstOrNull { !it.isSeen }
         val notNullFirstUnreadIndex = firstUnreadIndex ?: firstDefaultIndex
 
         return minOf(notNullFirstUnreadIndex, firstDefaultIndex)
@@ -313,7 +313,7 @@ class ThreadViewModel @Inject constructor(
         if (threadState.isFirstOpening) {
             threadState.isFirstOpening = false
             sendMatomoAndSentryAboutThreadMessagesCount(thread)
-            if (thread.unseenMessagesCount > 0) markThreadAsSeen(thread)
+            if (thread.isSeen.not()) markThreadAsSeen(thread)
         }
 
         emit(thread)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsBottomSheetDialog.kt
@@ -85,7 +85,7 @@ class ThreadActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
             isFromArchive = folderRole == FolderRole.ARCHIVE
             isFromSpam = folderRole == FolderRole.SPAM
 
-            setMarkAsReadUi(thread.unseenMessagesCount == 0)
+            setMarkAsReadUi(thread.isSeen)
             setArchiveUi(isFromArchive)
             setFavoriteUi(thread.isFavorite)
             setJunkUi()
@@ -171,7 +171,7 @@ class ThreadActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
                 }
 
                 override fun onReadUnread() {
-                    trackBottomSheetThreadActionsEvent(ACTION_MARK_AS_SEEN_NAME, value = thread.unseenMessagesCount == 0)
+                    trackBottomSheetThreadActionsEvent(ACTION_MARK_AS_SEEN_NAME, value = thread.isSeen)
                     mainViewModel.toggleThreadSeenStatus(threadUid)
                     twoPaneViewModel.closeThread()
                 }


### PR DESCRIPTION
Right now unseenMessagesCount is accessed a lot of times and I need to slightly alter its behavior in another PR. Yet most access are simply made in order to determine if the thread is in a read or unread state. I expose a `isSeen` property to split and factorize this concern in the new property. The name of the property is the same as for a Message.