### PR TITLE
fix: Display generic new mails notification less often, and send some missing Sentry logs

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/NotificationUtils.kt
@@ -47,7 +47,6 @@ import com.infomaniak.mail.receivers.NotificationActionsReceiver.Companion.UNDO_
 import com.infomaniak.mail.ui.LaunchActivity
 import com.infomaniak.mail.ui.LaunchActivityArgs
 import io.realm.kotlin.Realm
-import io.sentry.SentryLevel
 import kotlinx.coroutines.*
 import java.util.UUID
 import javax.inject.Inject
@@ -167,13 +166,7 @@ class NotificationUtils @Inject constructor(
         payload: NotificationPayload,
     ): Boolean = with(payload) {
         val mailbox = MailboxController.getMailbox(userId, mailboxId, mailboxInfoRealm) ?: run {
-            SentryDebug.sendFailedNotification(
-                reason = "Created Notif: no Mailbox in Realm",
-                sentryLevel = SentryLevel.ERROR,
-                userId = userId,
-                mailboxId = mailboxId,
-                messageUid = messageUid,
-            )
+            SentryDebug.sendFailedNotification("Created Notif: no Mailbox in Realm", userId, mailboxId, messageUid)
             return@with false
         }
         val contentIntent = getContentIntent(payload = this, isUndo)

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -229,19 +229,21 @@ object SentryDebug {
             throwable?.let { scope.setExtra("throwable", it.stackTraceToString()) }
         }
 
-        addInfoBreadcrumb(
-            category = category,
-            data = mutableMapOf(
-                "1_userId" to "${userId?.toString()}",
-                "2_currentUserId" to "[${AccountUtils.currentUserId}]",
-                "3_mailboxId" to "${mailboxId?.toString()}",
-                "4_mailbox.email" to "[${mailbox?.email}]",
-                "5_currentMailboxEmail" to "[${AccountUtils.currentMailboxEmail}]",
-                "6_messageUid" to "$messageUid",
-            ).also { map ->
-                throwable?.let { map.put("7_throwable", it.stackTraceToString()) }
-            },
-        )
+        // TODO: If the generic new mails notification still pops up too often, maybe put back
+        //  these breadcrumbs and the Sentry log in `displayGenericNewMailsNotification()`.
+        // addInfoBreadcrumb(
+        //     category = category,
+        //     data = mutableMapOf(
+        //         "1_userId" to "${userId?.toString()}",
+        //         "2_currentUserId" to "[${AccountUtils.currentUserId}]",
+        //         "3_mailboxId" to "${mailboxId?.toString()}",
+        //         "4_mailbox.email" to "[${mailbox?.email}]",
+        //         "5_currentMailboxEmail" to "[${AccountUtils.currentMailboxEmail}]",
+        //         "6_messageUid" to "$messageUid",
+        //     ).also { map ->
+        //         throwable?.let { map.put("7_throwable", it.stackTraceToString()) }
+        //     },
+        // )
     }
 
     fun sendOrphanMessages(previousCursor: String?, folder: Folder, realm: TypedRealm): List<Message> {

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -210,14 +210,13 @@ object SentryDebug {
 
     fun sendFailedNotification(
         reason: String,
-        sentryLevel: SentryLevel,
         userId: Int? = null,
         mailboxId: Int? = null,
         messageUid: String? = null,
         mailbox: Mailbox? = null,
         throwable: Throwable? = null,
     ) {
-        Sentry.captureMessage("Failed Notif : $reason", sentryLevel) { scope ->
+        Sentry.captureMessage("Failed Notif : $reason", SentryLevel.ERROR) { scope ->
             scope.setExtra("userId", "${userId?.toString()}")
             scope.setExtra("currentUserId", "[${AccountUtils.currentUserId}]")
             scope.setExtra("mailboxId", "${mailboxId?.toString()}")

--- a/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SentryDebug.kt
@@ -216,7 +216,10 @@ object SentryDebug {
         mailbox: Mailbox? = null,
         throwable: Throwable? = null,
     ) {
-        Sentry.captureMessage("Failed Notif : $reason", SentryLevel.ERROR) { scope ->
+
+        val category = "Failed Notif : $reason"
+
+        Sentry.captureMessage(category, SentryLevel.ERROR) { scope ->
             scope.setExtra("userId", "${userId?.toString()}")
             scope.setExtra("currentUserId", "[${AccountUtils.currentUserId}]")
             scope.setExtra("mailboxId", "${mailboxId?.toString()}")
@@ -225,6 +228,20 @@ object SentryDebug {
             scope.setExtra("messageUid", "$messageUid")
             throwable?.let { scope.setExtra("throwable", it.stackTraceToString()) }
         }
+
+        addInfoBreadcrumb(
+            category = category,
+            data = mutableMapOf(
+                "1_userId" to "${userId?.toString()}",
+                "2_currentUserId" to "[${AccountUtils.currentUserId}]",
+                "3_mailboxId" to "${mailboxId?.toString()}",
+                "4_mailbox.email" to "[${mailbox?.email}]",
+                "5_currentMailboxEmail" to "[${AccountUtils.currentMailboxEmail}]",
+                "6_messageUid" to "$messageUid",
+            ).also { map ->
+                throwable?.let { map.put("7_throwable", it.stackTraceToString()) }
+            },
+        )
     }
 
     fun sendOrphanMessages(previousCursor: String?, folder: Folder, realm: TypedRealm): List<Message> {

--- a/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
+++ b/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
@@ -83,6 +83,7 @@ class ProcessMessageNotificationsWorker @AssistedInject constructor(
         notificationUtils.updateUserAndMailboxes(mailboxController, TAG)
 
         val mailbox = mailboxController.getMailbox(userId, mailboxId) ?: run {
+            SentryDebug.sendFailedNotification("No Mailbox in Realm", SentryLevel.ERROR, userId, mailboxId, messageUid)
             displayGenericNewMailsNotification()
             // If the Mailbox doesn't exist in Realm, it's either because :
             // - The Mailbox isn't attached to this User anymore.

--- a/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
+++ b/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
@@ -40,6 +40,8 @@ import com.infomaniak.mail.utils.SentryDebug
 import com.infomaniak.mail.workers.BaseProcessMessageNotificationsWorker
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import io.sentry.Sentry
+import io.sentry.SentryLevel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -129,6 +131,8 @@ class ProcessMessageNotificationsWorker @AssistedInject constructor(
 
             @Suppress("MissingPermission")
             notificationManagerCompat.notify(GENERIC_NEW_MAILS_NOTIFICATION_ID, builder.build())
+
+            Sentry.captureMessage("Send a generic notification", SentryLevel.INFO)
         }
     }
 

--- a/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
+++ b/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
@@ -40,7 +40,6 @@ import com.infomaniak.mail.utils.SentryDebug
 import com.infomaniak.mail.workers.BaseProcessMessageNotificationsWorker
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import io.sentry.SentryLevel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -64,17 +63,17 @@ class ProcessMessageNotificationsWorker @AssistedInject constructor(
         SentryLog.i(TAG, "Work started")
 
         val userId = inputData.getIntOrNull(USER_ID_KEY) ?: run {
-            SentryDebug.sendFailedNotification("No userId in Notification", SentryLevel.ERROR)
+            SentryDebug.sendFailedNotification("No userId in Notification")
             displayGenericNewMailsNotification()
             return@withContext Result.success()
         }
         val mailboxId = inputData.getIntOrNull(MAILBOX_ID_KEY) ?: run {
-            SentryDebug.sendFailedNotification("No mailboxId in Notification", SentryLevel.ERROR, userId)
+            SentryDebug.sendFailedNotification("No mailboxId in Notification", userId)
             displayGenericNewMailsNotification()
             return@withContext Result.success()
         }
         val messageUid = inputData.getString(MESSAGE_UID_KEY) ?: run {
-            SentryDebug.sendFailedNotification("No messageUid in Notification", SentryLevel.ERROR, userId, mailboxId)
+            SentryDebug.sendFailedNotification("No messageUid in Notification", userId, mailboxId)
             displayGenericNewMailsNotification()
             return@withContext Result.success()
         }
@@ -83,7 +82,7 @@ class ProcessMessageNotificationsWorker @AssistedInject constructor(
         notificationUtils.updateUserAndMailboxes(mailboxController, TAG)
 
         val mailbox = mailboxController.getMailbox(userId, mailboxId) ?: run {
-            SentryDebug.sendFailedNotification("No Mailbox in Realm", SentryLevel.ERROR, userId, mailboxId, messageUid)
+            SentryDebug.sendFailedNotification("No Mailbox in Realm", userId, mailboxId, messageUid)
             displayGenericNewMailsNotification()
             // If the Mailbox doesn't exist in Realm, it's either because :
             // - The Mailbox isn't attached to this User anymore.

--- a/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
+++ b/app/src/standard/java/com/infomaniak/mail/firebase/ProcessMessageNotificationsWorker.kt
@@ -40,8 +40,6 @@ import com.infomaniak.mail.utils.SentryDebug
 import com.infomaniak.mail.workers.BaseProcessMessageNotificationsWorker
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import io.sentry.Sentry
-import io.sentry.SentryLevel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -84,8 +82,6 @@ class ProcessMessageNotificationsWorker @AssistedInject constructor(
         notificationUtils.updateUserAndMailboxes(mailboxController, TAG)
 
         val mailbox = mailboxController.getMailbox(userId, mailboxId) ?: run {
-            SentryDebug.sendFailedNotification("No Mailbox in Realm", userId, mailboxId, messageUid)
-            displayGenericNewMailsNotification()
             // If the Mailbox doesn't exist in Realm, it's either because :
             // - The Mailbox isn't attached to this User anymore.
             // - The user POSSIBLY recently added this new Mailbox on its account, via the Infomaniak
@@ -99,15 +95,16 @@ class ProcessMessageNotificationsWorker @AssistedInject constructor(
         var hasShownNotification = false
 
         return@withContext runCatching {
+
             MessageController.getMessage(messageUid, mailboxContentRealm)?.let {
                 // If the Message is already in Realm, it means we already fetched it when we received a previous Notification.
                 // So we've already shown it in a previous batch of Notifications.
                 // We can leave safely.
+                hasShownNotification = true
                 return@runCatching Result.success()
             }
 
             hasShownNotification = fetchMessagesManager.execute(scope = this, userId, mailbox, messageUid, mailboxContentRealm)
-
             SentryLog.i(TAG, "Work finished")
             Result.success()
         }.getOrElse {
@@ -132,7 +129,9 @@ class ProcessMessageNotificationsWorker @AssistedInject constructor(
             @Suppress("MissingPermission")
             notificationManagerCompat.notify(GENERIC_NEW_MAILS_NOTIFICATION_ID, builder.build())
 
-            Sentry.captureMessage("Send a generic notification", SentryLevel.INFO)
+            // TODO: If the generic new mails notification still pops up too often, maybe
+            //  put back this log and the breadcrumbs in `sendFailedNotification()`.
+            // Sentry.captureMessage("Send a generic notification", SentryLevel.INFO)
         }
     }
 


### PR DESCRIPTION
Reasons to display the generic new mails notification :
- No userId in Notification
- No mailboxId in Notification
- No messageUid in Notification
- RefreshThreads failed
- No Message in the Thread
- Created Notif: no Mailbox in Realm

Reasons to not display anything :
- Mailbox doesn't exist in Realm
- Message is already in Realm
- User disabled Notifications
- The user never opened this Mailbox
- The user never opened this INBOX
- When we fetched Messages, we didn't find any new Message
- Message has already been seen before receiving the Notification