### PR TITLE
fix: Avoid realm migration crash when setting originalDate or reading snoozeAction

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
@@ -119,7 +119,7 @@ private fun MigrationContext.initializeInternalDateAsDateAfterTwentySecondMigrat
                 set(propertyName = "internalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
 
                 // Initialize new property with old property value
-                setSafe(propertyName = "originalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
+                setIfPropertyExists(propertyName = "originalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
             }
         }
 
@@ -129,7 +129,7 @@ private fun MigrationContext.initializeInternalDateAsDateAfterTwentySecondMigrat
                 set(propertyName = "internalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
 
                 // Initialize new property with old property value
-                setSafe(propertyName = "originalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
+                setIfPropertyExists(propertyName = "originalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
             }
         }
     }
@@ -243,7 +243,7 @@ private fun MigrationContext.initIsLastInboxMessageSnoozedAfterTwentySeventhMigr
  * If the property we're trying to set doesn't exist anymore in our model at the latest schema version, instead of crashing skip
  * this property value.
  */
-private fun DynamicMutableRealmObject.setSafe(propertyName: String, value: Any?) {
+private fun DynamicMutableRealmObject.setIfPropertyExists(propertyName: String, value: Any?) {
     runCatching {
         set(propertyName, value)
     }.onFailure {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.mail.data.cache
 
+import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.mail.data.models.SnoozeState
 import com.infomaniak.mail.utils.SentryDebug
 import io.realm.kotlin.dynamic.DynamicMutableRealmObject
@@ -26,6 +27,8 @@ import io.realm.kotlin.dynamic.getValue
 import io.realm.kotlin.migration.AutomaticSchemaMigration
 import io.realm.kotlin.migration.AutomaticSchemaMigration.MigrationContext
 import io.realm.kotlin.types.RealmInstant
+
+private const val TAG = "RealmMigrations"
 
 val USER_INFO_MIGRATION = AutomaticSchemaMigration { migrationContext ->
     SentryDebug.addMigrationBreadcrumb(migrationContext)
@@ -116,7 +119,7 @@ private fun MigrationContext.initializeInternalDateAsDateAfterTwentySecondMigrat
                 set(propertyName = "internalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
 
                 // Initialize new property with old property value
-                set(propertyName = "originalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
+                setSafe(propertyName = "originalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
             }
         }
 
@@ -126,7 +129,7 @@ private fun MigrationContext.initializeInternalDateAsDateAfterTwentySecondMigrat
                 set(propertyName = "internalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
 
                 // Initialize new property with old property value
-                set(propertyName = "originalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
+                setSafe(propertyName = "originalDate", value = oldObject.getValue<RealmInstant>(fieldName = "date"))
             }
         }
     }
@@ -140,8 +143,14 @@ private fun MigrationContext.replaceOriginalDateWithDisplayDateAfterTwentyFourth
         enumerate(className = "Message") { oldObject: DynamicRealmObject, newObject: DynamicMutableRealmObject? ->
             newObject?.apply {
                 // Initialize new property with old property value
-                val displayDate = oldObject.getNullableValue<RealmInstant>(fieldName = "originalDate")
-                    ?: oldObject.getValue<RealmInstant>(fieldName = "internalDate")
+
+                // If migrating from a version a bit too old, "originalDate" might not have existed in the old object
+                val originalDate = oldObject.getNullableValueOrRecover(
+                    fieldName = "originalDate",
+                    recover = { oldObject.getValue<RealmInstant>(fieldName = "date") },
+                )
+
+                val displayDate = originalDate ?: oldObject.getValue<RealmInstant>(fieldName = "internalDate")
 
                 set(propertyName = "displayDate", value = displayDate)
             }
@@ -150,8 +159,14 @@ private fun MigrationContext.replaceOriginalDateWithDisplayDateAfterTwentyFourth
         enumerate(className = "Thread") { oldObject: DynamicRealmObject, newObject: DynamicMutableRealmObject? ->
             newObject?.apply {
                 // Initialize new property with old property value
-                val displayDate = oldObject.getNullableValue<RealmInstant>(fieldName = "originalDate")
-                    ?: oldObject.getValue<RealmInstant>(fieldName = "internalDate")
+
+                // If migrating from a version a bit too old, "originalDate" might not have existed in the old object
+                val originalDate = oldObject.getNullableValueOrRecover(
+                    fieldName = "originalDate",
+                    recover = { oldObject.getValue<RealmInstant>(fieldName = "date") },
+                )
+
+                val displayDate = originalDate ?: oldObject.getValue<RealmInstant>(fieldName = "internalDate")
 
                 set(propertyName = "displayDate", value = displayDate)
             }
@@ -219,3 +234,31 @@ private fun MigrationContext.initIsLastInboxMessageSnoozedAfterTwentySeventhMigr
     }
 }
 //endregion
+
+/**
+ * If the property we're trying to set doesn't exist anymore in our model at the latest schema version, instead of crashing skip
+ * this property value.
+ */
+private fun DynamicMutableRealmObject.setSafe(propertyName: String, value: Any?) {
+    runCatching {
+        set(propertyName, value)
+    }.onFailure {
+        if (it !is IllegalArgumentException) SentryLog.e(TAG, "Unexpected exception thrown during realm migration", it)
+    }
+}
+
+/**
+ * Tries to get read [fieldName] but if the value is not in the [DynamicRealmObject], instead of crashing, fallback to an
+ * alternative recovery method to get the expected value.
+ *
+ * Used for when we can be migrating from versions of the model that might never have had [fieldName] initialized.
+ */
+private inline fun <reified T : Any> DynamicRealmObject.getNullableValueOrRecover(fieldName: String, recover: () -> T?): T? {
+    return runCatching {
+        getNullableValue<T>(fieldName)
+    }.getOrElse {
+        if (it !is IllegalArgumentException) SentryLog.e(TAG, "Unexpected exception thrown during realm migration", it)
+
+        recover()
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
@@ -147,7 +147,7 @@ private fun MigrationContext.replaceOriginalDateWithDisplayDateAfterTwentyFourth
                 // If migrating from a version a bit too old, "originalDate" might not have existed in the old object
                 val originalDate = oldObject.getNullableValueOrRecover(
                     fieldName = "originalDate",
-                    recover = { oldObject.getValue<RealmInstant>(fieldName = "date") },
+                    recovery = { oldObject.getValue<RealmInstant>(fieldName = "date") },
                 )
 
                 val displayDate = originalDate ?: oldObject.getValue<RealmInstant>(fieldName = "internalDate")
@@ -163,7 +163,7 @@ private fun MigrationContext.replaceOriginalDateWithDisplayDateAfterTwentyFourth
                 // If migrating from a version a bit too old, "originalDate" might not have existed in the old object
                 val originalDate = oldObject.getNullableValueOrRecover(
                     fieldName = "originalDate",
-                    recover = { oldObject.getValue<RealmInstant>(fieldName = "date") },
+                    recovery = { oldObject.getValue<RealmInstant>(fieldName = "date") },
                 )
 
                 val displayDate = originalDate ?: oldObject.getValue<RealmInstant>(fieldName = "internalDate")
@@ -184,7 +184,7 @@ private fun MigrationContext.deserializeSnoozeUuidDirectlyAfterTwentyFifthMigrat
                 // Initialize new property with old property value
 
                 // If snoozeAction was never initialized, default to null the same way the code used to set its default value
-                val snoozeAction = oldObject.getNullableValueOrRecover<String>(fieldName = "snoozeAction", recover = { null })
+                val snoozeAction = oldObject.getNullableValueOrRecover<String>(fieldName = "snoozeAction", recovery = { null })
                 val snoozeUuid = snoozeAction?.lastUuidOrNull()
                 set(propertyName = "snoozeUuid", value = snoozeUuid)
             }
@@ -195,7 +195,7 @@ private fun MigrationContext.deserializeSnoozeUuidDirectlyAfterTwentyFifthMigrat
                 // Initialize new property with old property value
 
                 // If snoozeAction was never initialized, default to null the same way the code used to set its default value
-                val snoozeAction = oldObject.getNullableValueOrRecover<String>(fieldName = "snoozeAction", recover = { null })
+                val snoozeAction = oldObject.getNullableValueOrRecover<String>(fieldName = "snoozeAction", recovery = { null })
                 val snoozeUuid = snoozeAction?.lastUuidOrNull()
                 set(propertyName = "snoozeUuid", value = snoozeUuid)
             }
@@ -257,12 +257,12 @@ private fun DynamicMutableRealmObject.setSafe(propertyName: String, value: Any?)
  *
  * Used for when we can be migrating from versions of the model that might never have had [fieldName] initialized.
  */
-private inline fun <reified T : Any> DynamicRealmObject.getNullableValueOrRecover(fieldName: String, recover: () -> T?): T? {
+private inline fun <reified T : Any> DynamicRealmObject.getNullableValueOrRecover(fieldName: String, recovery: () -> T?): T? {
     return runCatching {
         getNullableValue<T>(fieldName)
     }.getOrElse {
         if (it !is IllegalArgumentException) SentryLog.e(TAG, "Unexpected exception thrown during realm migration", it)
 
-        recover()
+        recovery()
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
@@ -182,7 +182,9 @@ private fun MigrationContext.deserializeSnoozeUuidDirectlyAfterTwentyFifthMigrat
         enumerate(className = "Message") { oldObject: DynamicRealmObject, newObject: DynamicMutableRealmObject? ->
             newObject?.apply {
                 // Initialize new property with old property value
-                val snoozeAction = oldObject.getNullableValue<String>(fieldName = "snoozeAction")
+
+                // If snoozeAction was never initialized, default to null the same way the code used to set its default value
+                val snoozeAction = oldObject.getNullableValueOrRecover<String>(fieldName = "snoozeAction", recover = { null })
                 val snoozeUuid = snoozeAction?.lastUuidOrNull()
                 set(propertyName = "snoozeUuid", value = snoozeUuid)
             }
@@ -191,7 +193,9 @@ private fun MigrationContext.deserializeSnoozeUuidDirectlyAfterTwentyFifthMigrat
         enumerate(className = "Thread") { oldObject: DynamicRealmObject, newObject: DynamicMutableRealmObject? ->
             newObject?.apply {
                 // Initialize new property with old property value
-                val snoozeAction = oldObject.getNullableValue<String>(fieldName = "snoozeAction")
+
+                // If snoozeAction was never initialized, default to null the same way the code used to set its default value
+                val snoozeAction = oldObject.getNullableValueOrRecover<String>(fieldName = "snoozeAction", recover = { null })
                 val snoozeUuid = snoozeAction?.lastUuidOrNull()
                 set(propertyName = "snoozeUuid", value = snoozeUuid)
             }


### PR DESCRIPTION
When migrating with a schema version inferior or equal to 22, during the 22th migration, the field `originalDate` of the new object is set but this field doesn't exist in the latest version of the model's schema anymore as of today. Trying to `set()` this non existing field crashes. Another crash occurs when trying to read `snoozeAction` that never was initialized.

There is no efficient and generic solution with a low memory footprint that can provide a permanent safeguard against this issue, while remaining transparent during migration writing.

Instead, the fix safeguards this very specific case of the error that's been raised and observed in production.