### PR TITLE
feat: Remove the snooze status of an "unsnoozed" thread when reading it from any folder

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
@@ -90,24 +90,27 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
     }
 
     fun getFavoriteMessages(thread: Thread): List<Message> {
-        return getMessagesAndDuplicates(thread, "${Message::isFavorite.name} == true")
+        return getMessagesAndTheirDuplicates(thread, "${Message::isFavorite.name} == true")
     }
 
     fun getMovableMessages(thread: Thread): List<Message> {
         val byFolderId = "${Message::folderId.name} == '${thread.folderId}'"
-        return getMessagesAndDuplicates(thread, "$byFolderId AND $isNotScheduledMessage")
+        return getMessagesAndTheirDuplicates(thread, "$byFolderId AND $isNotScheduledMessage")
     }
 
     fun getUnscheduledMessages(thread: Thread): List<Message> {
-        return getMessagesAndDuplicates(thread, isNotScheduledMessage)
+        return getMessagesAndTheirDuplicates(thread, isNotScheduledMessage)
+    }
+
+    private fun getMessagesAndTheirDuplicates(thread: Thread, query: String): List<Message> {
+        val messages = thread.messages.query(query).find()
+        val duplicates = thread.duplicates.query("${Message::messageId.name} IN $0", messages.map { it.messageId }).find()
+        return messages + duplicates
     }
 
     private fun getMessagesAndDuplicates(thread: Thread, query: String): List<Message> {
-
         val messages = thread.messages.query(query).find()
-
-        val duplicates = thread.duplicates.query("${Message::messageId.name} IN $0", messages.map { it.messageId }).find()
-
+        val duplicates = thread.duplicates.query(query).find()
         return messages + duplicates
     }
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -498,7 +498,7 @@ class RefreshController @Inject constructor(
 
             val message = currentFolderRefreshStrategy.getMessageFromShortUid(shortUid, folderId, realm = this) ?: return@forEach
             threads += message.threads
-            if (currentFolderRefreshStrategy.alsoRecomputeDuplicatedThreads()) threads += message.threadsDuplicatedIn
+            threads += message.threadsDuplicatedIn
 
             currentFolderRefreshStrategy.processDeletedMessage(scope, message, appContext, mailbox, realm = this)
         }
@@ -536,7 +536,7 @@ class RefreshController @Inject constructor(
                     is SnoozeMessageFlags -> message.updateSnoozeFlags(flags)
                 }
                 threads += message.threads
-                if (refreshStrategy.alsoRecomputeDuplicatedThreads()) threads += message.threadsDuplicatedIn
+                threads += message.threadsDuplicatedIn
             }
         }
 
@@ -571,10 +571,8 @@ class RefreshController @Inject constructor(
             addedMessagesUids.add(remoteMessage.shortUid)
             refreshStrategy.handleAddedMessage(scope, remoteMessage, isConversationMode, impactedThreadsManaged, realm = this)
 
-            if (refreshStrategy.alsoRecomputeDuplicatedThreads()) {
-                MessageController.getMessage(remoteMessage.uid, realm = this)?.let { localMessage ->
-                    impactedThreadsManaged.addAll(localMessage.threadsDuplicatedIn)
-                }
+            MessageController.getMessage(remoteMessage.uid, realm = this)?.let { localMessage ->
+                impactedThreadsManaged.addAll(localMessage.threadsDuplicatedIn)
             }
         }
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/DefaultRefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/DefaultRefreshStrategy.kt
@@ -43,8 +43,6 @@ interface DefaultRefreshStrategy : RefreshStrategy {
 
     override fun shouldHideEmptyFolder(): Boolean = false
 
-    override fun alsoRecomputeDuplicatedThreads(): Boolean = false
-
     override fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message? {
         return MessageController.getMessage(shortUid.toLongUid(folderId), realm)
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/RefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/RefreshStrategy.kt
@@ -40,12 +40,6 @@ interface RefreshStrategy {
 
     fun shouldHideEmptyFolder(): Boolean
 
-    /**
-     * When a [Message] is added, updated or deleted, we recompute threads that are impacted by this change. If this method
-     * returns true, the impacted threads will also consider threads where the processed [Message] appears as a duplicate.
-     */
-    fun alsoRecomputeDuplicatedThreads(): Boolean
-
     fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message?
 
     fun processDeletedMessage(

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/SnoozeRefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/SnoozeRefreshStrategy.kt
@@ -39,8 +39,6 @@ val snoozeRefreshStrategy = object : DefaultRefreshStrategy {
 
     override fun shouldHideEmptyFolder(): Boolean = true
 
-    override fun alsoRecomputeDuplicatedThreads(): Boolean = true
-
     override fun getMessageFromShortUid(shortUid: String, folderId: String, realm: TypedRealm): Message? {
         val inboxId = FolderController.getFolder(FolderRole.INBOX, realm)?.id ?: return null
         return super.getMessageFromShortUid(shortUid, inboxId, realm)

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -23,7 +23,6 @@ import com.infomaniak.core.utils.apiEnum
 import com.infomaniak.mail.MatomoMail.SEARCH_FOLDER_FILTER_NAME
 import com.infomaniak.mail.data.api.RealmInstantSerializer
 import com.infomaniak.mail.data.cache.mailboxContent.FolderController
-import com.infomaniak.mail.data.cache.mailboxContent.refreshStrategies.RefreshStrategy
 import com.infomaniak.mail.data.models.*
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.correspondent.Recipient
@@ -257,11 +256,10 @@ class Thread : RealmObject, Snoozable {
             updateSnoozeStatesBasedOn(message)
         }
 
-        /**
-         * Only needed for snooze because they rely on duplicates to compute the correct state of every thread. Tightly linked
-         * with [RefreshStrategy.alsoRecomputeDuplicatedThreads].
-         */
-        duplicates.forEach(::updateSnoozeStatesBasedOn)
+        duplicates.forEach { message ->
+            if (!message.isSeen) unseenMessagesCount++
+            updateSnoozeStatesBasedOn(message)
+        }
 
         displayDate = lastMessage.displayDate
         internalDate = lastMessage.internalDate


### PR DESCRIPTION
To do this, we need to compute the `isSeen` status of a thread by taking into account the duplicates as well. This will also make this `isSeen` computation behavior ISO with the webmail and threads returned directly by the API through the search.

When opening an unread thread, we need to read any message or duplicate that's unread. Not just messages and their associated duplicates.

Snooze folder used to be the only folder that would recompute threads where duplicated messages appeared but now that recomputing a thread requires to look at duplicated messages to compute the thread's `isSeen` property, it is always required for any folder to always recompute threads where duplicated messages appear.