### PR TITLE
feat: Adapt text between confirm/modify depending on the type of snooze action

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeDialog.kt
@@ -38,8 +38,8 @@ import com.infomaniak.lib.core.R as RCore
 
 abstract class SelectDateAndTimeDialog(private val activityContext: Context) : BaseAlertDialog(activityContext) {
 
-    @get:StringRes
-    abstract val defaultPositiveButtonResId: Int
+    @StringRes
+    open val defaultPositiveButtonResId: Int = R.string.buttonConfirm
 
     abstract fun defineCalendarConstraint(): CalendarConstraints.Builder
 

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeDialog.kt
@@ -39,7 +39,7 @@ import com.infomaniak.lib.core.R as RCore
 abstract class SelectDateAndTimeDialog(private val activityContext: Context) : BaseAlertDialog(activityContext) {
 
     @get:StringRes
-    abstract val positiveButtonText: Int
+    abstract val defaultPositiveButtonResId: Int
 
     abstract fun defineCalendarConstraint(): CalendarConstraints.Builder
 
@@ -76,7 +76,7 @@ abstract class SelectDateAndTimeDialog(private val activityContext: Context) : B
         alertDialog.show()
 
         selectDate(Date().roundUpToNextTenMinutes())
-        positiveButton.setText(positiveButtonResId ?: positiveButtonText)
+        positiveButton.setText(positiveButtonResId ?: defaultPositiveButtonResId)
     }
 
     private fun setupListeners(onDateSelected: (Long) -> Unit, onAbort: (() -> Unit)?) = with(alertDialog) {

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeDialog.kt
@@ -67,16 +67,16 @@ abstract class SelectDateAndTimeDialog(private val activityContext: Context) : B
         onAbort = null
     }
 
-    fun show(onDateSelected: (Long) -> Unit, onAbort: (() -> Unit)? = null) {
-        showDialogWithBasicInfo()
+    fun show(positiveButtonResId: Int? = null, onDateSelected: (Long) -> Unit, onAbort: (() -> Unit)? = null) {
+        showDialogWithBasicInfo(positiveButtonResId)
         setupListeners(onDateSelected, onAbort)
     }
 
-    private fun showDialogWithBasicInfo() {
+    private fun showDialogWithBasicInfo(positiveButtonResId: Int?) {
         alertDialog.show()
 
         selectDate(Date().roundUpToNextTenMinutes())
-        positiveButton.setText(positiveButtonText)
+        positiveButton.setText(positiveButtonResId ?: positiveButtonText)
     }
 
     private fun setupListeners(onDateSelected: (Long) -> Unit, onAbort: (() -> Unit)?) = with(alertDialog) {

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
@@ -34,8 +34,6 @@ open class SelectDateAndTimeForScheduledDraftDialog @Inject constructor(
     @ActivityContext private val activityContext: Context,
 ) : SelectDateAndTimeDialog(activityContext) {
 
-    override val defaultPositiveButtonResId: Int = R.string.buttonConfirm
-
     override fun defineCalendarConstraint(): CalendarConstraints.Builder {
         val dateValidators = listOf(
             DateValidatorPointForward.now(),

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForScheduledDraftDialog.kt
@@ -34,7 +34,7 @@ open class SelectDateAndTimeForScheduledDraftDialog @Inject constructor(
     @ActivityContext private val activityContext: Context,
 ) : SelectDateAndTimeDialog(activityContext) {
 
-    override val positiveButtonText: Int = R.string.buttonConfirm
+    override val defaultPositiveButtonResId: Int = R.string.buttonConfirm
 
     override fun defineCalendarConstraint(): CalendarConstraints.Builder {
         val dateValidators = listOf(

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForSnoozeDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForSnoozeDialog.kt
@@ -34,8 +34,6 @@ open class SelectDateAndTimeForSnoozeDialog @Inject constructor(
     @ActivityContext private val activityContext: Context,
 ) : SelectDateAndTimeDialog(activityContext) {
 
-    override val defaultPositiveButtonResId: Int = R.string.buttonConfirm
-
     override fun defineCalendarConstraint(): CalendarConstraints.Builder {
         val dateValidators = listOf(
             DateValidatorPointForward.now(),

--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForSnoozeDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/SelectDateAndTimeForSnoozeDialog.kt
@@ -34,7 +34,7 @@ open class SelectDateAndTimeForSnoozeDialog @Inject constructor(
     @ActivityContext private val activityContext: Context,
 ) : SelectDateAndTimeDialog(activityContext) {
 
-    override val positiveButtonText: Int = R.string.buttonConfirm
+    override val defaultPositiveButtonResId: Int = R.string.buttonConfirm
 
     override fun defineCalendarConstraint(): CalendarConstraints.Builder {
         val dateValidators = listOf(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -86,7 +86,8 @@ import com.infomaniak.mail.ui.main.folder.TwoPaneViewModel.NavData
 import com.infomaniak.mail.ui.main.thread.SubjectFormatter.SubjectData
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.ContextMenuType
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.ThreadAdapterCallbacks
-import com.infomaniak.mail.ui.main.thread.ThreadViewModel.*
+import com.infomaniak.mail.ui.main.thread.ThreadViewModel.SnoozeScheduleType
+import com.infomaniak.mail.ui.main.thread.ThreadViewModel.ThreadHeaderVisibility
 import com.infomaniak.mail.ui.main.thread.actions.*
 import com.infomaniak.mail.ui.main.thread.actions.ThreadActionsBottomSheetDialog.Companion.OPEN_SNOOZE_BOTTOM_SHEET
 import com.infomaniak.mail.ui.main.thread.calendar.AttendeesBottomSheetDialogArgs
@@ -604,6 +605,7 @@ class ThreadFragment : Fragment() {
 
         getBackNavigationResult(OPEN_SNOOZE_DATE_AND_TIME_PICKER) { _: Boolean ->
             dateAndTimeSnoozeDialog.show(
+                positiveButtonResId = threadViewModel.snoozeScheduleType?.positiveButtonResId,
                 onDateSelected = { timestamp ->
                     localSettings.lastSelectedSnoozeEpochMillis = timestamp
                     executeSavedSnoozeScheduleType(timestamp)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -19,10 +19,12 @@ package com.infomaniak.mail.ui.main.thread
 
 import android.app.Application
 import android.os.Parcelable
+import androidx.annotation.StringRes
 import androidx.lifecycle.*
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.utils.SingleLiveEvent
 import com.infomaniak.mail.MatomoMail.trackUserInfo
+import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.data.LocalSettings.ThreadMode
 import com.infomaniak.mail.data.api.ApiRepository
@@ -495,16 +497,16 @@ class ThreadViewModel @Inject constructor(
         DISPLAYED, COLLAPSED, FIRST_AFTER_BLOCK,
     }
 
-    sealed interface SnoozeScheduleType : Parcelable {
-        val threadUids: List<String>
+    sealed class SnoozeScheduleType(@StringRes val positiveButtonResId: Int) : Parcelable {
+        abstract val threadUids: List<String>
 
         @Parcelize
-        data class Snooze(override val threadUids: List<String>) : SnoozeScheduleType {
+        data class Snooze(override val threadUids: List<String>) : SnoozeScheduleType(R.string.buttonConfirm) {
             constructor(threadUid: String) : this(listOf(threadUid))
         }
 
         @Parcelize
-        data class Modify(override val threadUids: List<String>) : SnoozeScheduleType {
+        data class Modify(override val threadUids: List<String>) : SnoozeScheduleType(R.string.buttonModify) {
             constructor(threadUid: String) : this(listOf(threadUid))
         }
     }


### PR DESCRIPTION
According to the specs, the button's text should adapt between "confirm" and "modify" depending on if we're snoozing a thread for the first time or if we're modifying an already existing thread. This PR makes the modification to follow the spec