### PR TITLE
refactor: Extract SwipeAction enum to its own file

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
@@ -20,7 +20,9 @@ package com.infomaniak.mail.data
 import android.content.Context
 import android.os.Build
 import android.view.ContextThemeWrapper
-import androidx.annotation.*
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.annotation.StyleRes
 import androidx.appcompat.app.AppCompatDelegate
 import com.google.android.material.color.MaterialColors
 import com.infomaniak.lib.core.networking.AccessTokenUsageInterceptor.ApiCallRecord
@@ -28,14 +30,8 @@ import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.lib.core.utils.SharedValues
 import com.infomaniak.lib.core.utils.sharedValue
 import com.infomaniak.lib.core.utils.transaction
-import com.infomaniak.mail.MatomoMail.ACTION_ARCHIVE_NAME
-import com.infomaniak.mail.MatomoMail.ACTION_DELETE_NAME
-import com.infomaniak.mail.MatomoMail.ACTION_FAVORITE_NAME
-import com.infomaniak.mail.MatomoMail.ACTION_MARK_AS_SEEN_NAME
-import com.infomaniak.mail.MatomoMail.ACTION_MOVE_NAME
-import com.infomaniak.mail.MatomoMail.ACTION_SNOOZE_NAME
-import com.infomaniak.mail.MatomoMail.ACTION_SPAM_NAME
 import com.infomaniak.mail.R
+import com.infomaniak.mail.data.models.SwipeAction
 import com.google.android.material.R as RMaterial
 
 class LocalSettings private constructor(context: Context) : SharedValues {
@@ -160,37 +156,6 @@ class LocalSettings private constructor(context: Context) : SharedValues {
         }
 
         override fun toString() = name.lowercase()
-    }
-
-    enum class SwipeAction(
-        @StringRes val nameRes: Int,
-        @ColorRes val colorRes: Int,
-        @DrawableRes val iconRes: Int?,
-        val matomoValue: String,
-    ) {
-        DELETE(R.string.actionDelete, R.color.swipeDelete, R.drawable.ic_bin, ACTION_DELETE_NAME),
-        ARCHIVE(R.string.actionArchive, R.color.swipeArchive, R.drawable.ic_archive_folder, ACTION_ARCHIVE_NAME),
-        READ_UNREAD(
-            R.string.settingsSwipeActionReadUnread,
-            R.color.swipeReadUnread,
-            R.drawable.ic_envelope,
-            ACTION_MARK_AS_SEEN_NAME,
-        ),
-        MOVE(R.string.actionMove, R.color.swipeMove, R.drawable.ic_email_action_move, ACTION_MOVE_NAME),
-        FAVORITE(R.string.actionShortStar, R.color.swipeFavorite, R.drawable.ic_star, ACTION_FAVORITE_NAME),
-        POSTPONE(R.string.actionSnooze, R.color.swipePostpone, R.drawable.ic_alarm_clock, ACTION_SNOOZE_NAME),
-        SPAM(R.string.actionSpam, R.color.swipeSpam, R.drawable.ic_spam, ACTION_SPAM_NAME),
-        QUICKACTIONS_MENU(
-            R.string.settingsSwipeActionQuickActionsMenu,
-            R.color.swipeQuickActionMenu,
-            R.drawable.ic_param_dots,
-            "quickActions",
-        ),
-        TUTORIAL(R.string.settingsSwipeActionNone, R.color.progressbarTrackColor, null, "tutorial"),
-        NONE(R.string.settingsSwipeActionNone, R.color.swipeNone, null, "none");
-
-        @ColorInt
-        fun getBackgroundColor(context: Context): Int = context.getColor(colorRes)
     }
 
     enum class ThreadMode(@StringRes val localisedNameRes: Int, val matomoValue: String) {

--- a/app/src/main/java/com/infomaniak/mail/data/models/SwipeAction.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/SwipeAction.kt
@@ -1,0 +1,57 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.models
+
+import android.content.Context
+import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.infomaniak.mail.MatomoMail
+import com.infomaniak.mail.R
+
+enum class SwipeAction(
+    @StringRes val nameRes: Int,
+    @ColorRes val colorRes: Int,
+    @DrawableRes val iconRes: Int?,
+    val matomoValue: String,
+) {
+    DELETE(R.string.actionDelete, R.color.swipeDelete, R.drawable.ic_bin, MatomoMail.ACTION_DELETE_NAME),
+    ARCHIVE(R.string.actionArchive, R.color.swipeArchive, R.drawable.ic_archive_folder, MatomoMail.ACTION_ARCHIVE_NAME),
+    READ_UNREAD(
+        R.string.settingsSwipeActionReadUnread,
+        R.color.swipeReadUnread,
+        R.drawable.ic_envelope,
+        MatomoMail.ACTION_MARK_AS_SEEN_NAME,
+    ),
+    MOVE(R.string.actionMove, R.color.swipeMove, R.drawable.ic_email_action_move, MatomoMail.ACTION_MOVE_NAME),
+    FAVORITE(R.string.actionShortStar, R.color.swipeFavorite, R.drawable.ic_star, MatomoMail.ACTION_FAVORITE_NAME),
+    POSTPONE(R.string.actionSnooze, R.color.swipePostpone, R.drawable.ic_alarm_clock, MatomoMail.ACTION_SNOOZE_NAME),
+    SPAM(R.string.actionSpam, R.color.swipeSpam, R.drawable.ic_spam, MatomoMail.ACTION_SPAM_NAME),
+    QUICKACTIONS_MENU(
+        R.string.settingsSwipeActionQuickActionsMenu,
+        R.color.swipeQuickActionMenu,
+        R.drawable.ic_param_dots,
+        "quickActions",
+    ),
+    TUTORIAL(R.string.settingsSwipeActionNone, R.color.progressbarTrackColor, null, "tutorial"),
+    NONE(R.string.settingsSwipeActionNone, R.color.swipeNone, null, "none");
+
+    @ColorInt
+    fun getBackgroundColor(context: Context): Int = context.getColor(colorRes)
+}

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -50,8 +50,8 @@ import com.infomaniak.lib.core.utils.toPx
 import com.infomaniak.mail.MatomoMail.trackMultiSelectionEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
-import com.infomaniak.mail.data.LocalSettings.SwipeAction
 import com.infomaniak.mail.data.LocalSettings.ThreadDensity
+import com.infomaniak.mail.data.models.SwipeAction
 import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.correspondent.Recipient

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -64,8 +64,8 @@ import com.infomaniak.mail.MatomoMail.trackMyKSuiteEvent
 import com.infomaniak.mail.MatomoMail.trackNewMessageEvent
 import com.infomaniak.mail.MatomoMail.trackThreadListEvent
 import com.infomaniak.mail.R
-import com.infomaniak.mail.data.LocalSettings.SwipeAction
 import com.infomaniak.mail.data.LocalSettings.ThreadDensity.COMPACT
+import com.infomaniak.mail.data.models.SwipeAction
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.thread.Thread

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSelectionSettingFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSelectionSettingFragment.kt
@@ -29,8 +29,8 @@ import com.infomaniak.mail.MatomoMail.toFloat
 import com.infomaniak.mail.MatomoMail.trackEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
-import com.infomaniak.mail.data.LocalSettings.SwipeAction
-import com.infomaniak.mail.data.LocalSettings.SwipeAction.*
+import com.infomaniak.mail.data.models.SwipeAction
+import com.infomaniak.mail.data.models.SwipeAction.*
 import com.infomaniak.mail.databinding.FragmentSwipeActionsSelectionSettingBinding
 import com.infomaniak.mail.utils.extensions.setSystemBarsColors
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSettingsFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSettingsFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ import androidx.fragment.app.Fragment
 import com.infomaniak.lib.core.utils.safeBinding
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
-import com.infomaniak.mail.data.LocalSettings.SwipeAction
+import com.infomaniak.mail.data.models.SwipeAction
 import com.infomaniak.mail.databinding.FragmentSwipeActionsSettingsBinding
 import com.infomaniak.mail.utils.UiUtils.saveFocusWhenNavigatingBack
 import com.infomaniak.mail.utils.extensions.animatedNavigation


### PR DESCRIPTION
I'll need to customize this class and to avoid to make it too big I would prefer to move it to its own file outside of LocalSettings. It already does quiet a bunch of things and LocalSettings might already not be the better place to store it.

I made no code modification, I only used the Android Studio extraction feature