### PR TITLE
fix: Use the correct wording when modifying the scheduled date of a draft

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -586,6 +586,7 @@ class ThreadFragment : Fragment() {
     private fun setupBackActionHandler() {
         getBackNavigationResult(OPEN_SCHEDULE_DRAFT_DATE_AND_TIME_PICKER) { _: Boolean ->
             dateAndTimeScheduleDialog.show(
+                positiveButtonResId = R.string.buttonModify,
                 onDateSelected = { timestamp ->
                     localSettings.lastSelectedScheduleEpochMillis = timestamp
                     mainViewModel.rescheduleDraft(Date(timestamp))


### PR DESCRIPTION
The wording of the positive button was modified from "confirm" to "modify" when modifying an existing schedule for a snoozed message but the same logic wasn't applied to the scheduled draft. This fixes it