### PR TITLE
feat: Snooze swipe action

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/SwipeAction.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/SwipeAction.kt
@@ -41,7 +41,7 @@ enum class SwipeAction(
     ),
     MOVE(R.string.actionMove, R.color.swipeMove, R.drawable.ic_email_action_move, MatomoMail.ACTION_MOVE_NAME),
     FAVORITE(R.string.actionShortStar, R.color.swipeFavorite, R.drawable.ic_star, MatomoMail.ACTION_FAVORITE_NAME),
-    POSTPONE(R.string.actionSnooze, R.color.swipePostpone, R.drawable.ic_alarm_clock, MatomoMail.ACTION_SNOOZE_NAME),
+    SNOOZE(R.string.actionSnooze, R.color.swipeSnooze, R.drawable.ic_alarm_clock, MatomoMail.ACTION_SNOOZE_NAME),
     SPAM(R.string.actionSpam, R.color.swipeSpam, R.drawable.ic_spam, MatomoMail.ACTION_SPAM_NAME),
     QUICKACTIONS_MENU(
         R.string.settingsSwipeActionQuickActionsMenu,

--- a/app/src/main/java/com/infomaniak/mail/data/models/SwipeAction.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/SwipeAction.kt
@@ -24,9 +24,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.infomaniak.mail.MatomoMail
 import com.infomaniak.mail.R
-import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.data.models.Folder.FolderRole
-import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.utils.SharedUtils
 
 enum class SwipeAction(
@@ -34,8 +32,8 @@ enum class SwipeAction(
     @ColorRes val colorRes: Int,
     @DrawableRes val iconRes: Int?,
     val matomoValue: String,
-    val displayBehavior: DisplayBehavior = alwaysDisplay,
-) {
+    private val swipeDisplayBehavior: SwipeDisplayBehavior = alwaysDisplay,
+) : SwipeDisplayBehavior by swipeDisplayBehavior {
     DELETE(R.string.actionDelete, R.color.swipeDelete, R.drawable.ic_bin, MatomoMail.ACTION_DELETE_NAME),
     ARCHIVE(R.string.actionArchive, R.color.swipeArchive, R.drawable.ic_archive_folder, MatomoMail.ACTION_ARCHIVE_NAME),
     READ_UNREAD(
@@ -59,20 +57,12 @@ enum class SwipeAction(
 
     @ColorInt
     fun getBackgroundColor(context: Context): Int = context.getColor(colorRes)
-
-    fun interface DisplayBehavior {
-        fun canDisplay(
-            folderRole: FolderRole?,
-            featureFlags: Mailbox.FeatureFlagSet?,
-            localSettings: LocalSettings,
-        ): Boolean
-    }
 }
 
-private val alwaysDisplay = SwipeAction.DisplayBehavior { _, _, _ -> true }
+private val alwaysDisplay = SwipeDisplayBehavior { _, _, _ -> true }
 
-private val neverDisplay = SwipeAction.DisplayBehavior { _, _, _ -> false }
+private val neverDisplay = SwipeDisplayBehavior { _, _, _ -> false }
 
-private val snoozeDisplay = SwipeAction.DisplayBehavior { role, featureFlags, localSettings ->
+private val snoozeDisplay = SwipeDisplayBehavior { role, featureFlags, localSettings ->
     (role == FolderRole.INBOX || role == FolderRole.SNOOZED) && SharedUtils.isSnoozeAvailable(featureFlags, localSettings)
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/SwipeDisplayBehavior.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/SwipeDisplayBehavior.kt
@@ -1,0 +1,25 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.models
+
+import com.infomaniak.mail.data.LocalSettings
+import com.infomaniak.mail.data.models.mailbox.Mailbox
+
+fun interface SwipeDisplayBehavior {
+    fun canDisplay(folderRole: Folder.FolderRole?, featureFlags: Mailbox.FeatureFlagSet?, localSettings: LocalSettings): Boolean
+}

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -151,6 +151,10 @@ class MainViewModel @Inject constructor(
         it?.let(mailboxController::getMailbox)
     }.asLiveData(ioCoroutineContext)
 
+    val currentMailboxLive = _currentMailboxObjectId.filterNotNull().flatMapLatest { objectId ->
+        mailboxController.getMailboxAsync(objectId).mapNotNull { it.obj }
+    }.asLiveData(ioCoroutineContext)
+
     val defaultFoldersLive = _currentMailboxObjectId.filterNotNull().flatMapLatest {
         folderController.getMenuDrawerDefaultFoldersAsync()
             .map { it.list.flattenFolderChildrenAndRemoveMessages(dismissHiddenChildren = true) }
@@ -197,6 +201,10 @@ class MainViewModel @Inject constructor(
     val currentFolderLive = _currentFolderId.flatMapLatest {
         it?.let(folderController::getFolderAsync) ?: emptyFlow()
     }.asLiveData(ioCoroutineContext)
+
+    val swipeActionImpactingValues = Utils.waitInitMediator(currentMailboxLive, currentFolderLive, isMultiSelectOnLiveData) {
+        Triple((it[0] as Mailbox).featureFlags, (it[1] as Folder).role, it[2] as Boolean)
+    }.distinctUntilChanged()
 
     val currentFilter = SingleLiveEvent(ThreadFilter.ALL)
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -204,7 +204,7 @@ class MainViewModel @Inject constructor(
         it?.let(folderController::getFolderAsync) ?: emptyFlow()
     }.asLiveData(ioCoroutineContext)
 
-    val swipeActionImpactingValues = Utils.waitInitMediator(featureFlagsLive, currentFolderLive) {
+    val swipeActionContext = Utils.waitInitMediator(featureFlagsLive, currentFolderLive) {
         (it[0] as Mailbox.FeatureFlagSet) to (it[1] as Folder).role
     }.distinctUntilChanged()
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -151,9 +151,11 @@ class MainViewModel @Inject constructor(
         it?.let(mailboxController::getMailbox)
     }.asLiveData(ioCoroutineContext)
 
-    val currentMailboxLive = _currentMailboxObjectId.filterNotNull().flatMapLatest { objectId ->
+    private val currentMailboxLive = _currentMailboxObjectId.filterNotNull().flatMapLatest { objectId ->
         mailboxController.getMailboxAsync(objectId).mapNotNull { it.obj }
     }.asLiveData(ioCoroutineContext)
+
+    val featureFlagsLive = currentMailboxLive.map { it.featureFlags }
 
     val defaultFoldersLive = _currentMailboxObjectId.filterNotNull().flatMapLatest {
         folderController.getMenuDrawerDefaultFoldersAsync()
@@ -202,8 +204,8 @@ class MainViewModel @Inject constructor(
         it?.let(folderController::getFolderAsync) ?: emptyFlow()
     }.asLiveData(ioCoroutineContext)
 
-    val swipeActionImpactingValues = Utils.waitInitMediator(currentMailboxLive, currentFolderLive) {
-        (it[0] as Mailbox).featureFlags to (it[1] as Folder).role
+    val swipeActionImpactingValues = Utils.waitInitMediator(featureFlagsLive, currentFolderLive) {
+        (it[0] as Mailbox.FeatureFlagSet) to (it[1] as Folder).role
     }.distinctUntilChanged()
 
     val currentFilter = SingleLiveEvent(ThreadFilter.ALL)

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -202,8 +202,8 @@ class MainViewModel @Inject constructor(
         it?.let(folderController::getFolderAsync) ?: emptyFlow()
     }.asLiveData(ioCoroutineContext)
 
-    val swipeActionImpactingValues = Utils.waitInitMediator(currentMailboxLive, currentFolderLive, isMultiSelectOnLiveData) {
-        Triple((it[0] as Mailbox).featureFlags, (it[1] as Folder).role, it[2] as Boolean)
+    val swipeActionImpactingValues = Utils.waitInitMediator(currentMailboxLive, currentFolderLive) {
+        (it[0] as Mailbox).featureFlags to (it[1] as Folder).role
     }.distinctUntilChanged()
 
     val currentFilter = SingleLiveEvent(ThreadFilter.ALL)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -51,9 +51,9 @@ import com.infomaniak.mail.MatomoMail.trackMultiSelectionEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.data.LocalSettings.ThreadDensity
-import com.infomaniak.mail.data.models.SwipeAction
 import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.models.Folder.FolderRole
+import com.infomaniak.mail.data.models.SwipeAction
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.databinding.CardviewThreadItemBinding

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -553,29 +553,9 @@ class ThreadListAdapter @Inject constructor(
     }
 
     private fun Thread.updateDynamicIcons() {
-
-        fun computeDynamicAction(folderRole: FolderRole, swipeAction: SwipeAction) = SwipeActionUiData(
-            colorRes = if (folder.role == folderRole) R.color.swipeInbox else swipeAction.colorRes,
-            iconRes = if (folder.role == folderRole) R.drawable.ic_drawer_inbox else swipeAction.iconRes,
-        )
-
-        fun getSwipeActionUiData(swipeAction: SwipeAction) = when (swipeAction) {
-            SwipeAction.READ_UNREAD -> SwipeActionUiData(
-                colorRes = swipeAction.colorRes,
-                iconRes = if (isSeen) swipeAction.iconRes else R.drawable.ic_envelope_open,
-            )
-            SwipeAction.FAVORITE -> SwipeActionUiData(
-                colorRes = swipeAction.colorRes,
-                iconRes = if (isFavorite) R.drawable.ic_unstar else swipeAction.iconRes,
-            )
-            SwipeAction.ARCHIVE -> computeDynamicAction(FolderRole.ARCHIVE, swipeAction)
-            SwipeAction.SPAM -> computeDynamicAction(FolderRole.SPAM, swipeAction)
-            else -> null
-        }
+        val featureFlags = callbacks?.getFeatureFlags?.invoke()
 
         (recyclerView as DragDropSwipeRecyclerView).apply {
-            val featureFlags = callbacks?.getFeatureFlags?.invoke()
-
             if (localSettings.swipeLeft.canDisplay(folderRole, featureFlags, localSettings)) {
                 getSwipeActionUiData(localSettings.swipeLeft)?.let { (colorRes, iconRes) ->
                     behindSwipedItemBackgroundColor = context.getColor(colorRes)
@@ -589,6 +569,27 @@ class ThreadListAdapter @Inject constructor(
                     behindSwipedItemIconSecondaryDrawableId = iconRes
                 }
             }
+        }
+    }
+
+    private fun Thread.getSwipeActionUiData(swipeAction: SwipeAction): SwipeActionUiData? {
+        fun computeDynamicAction(folderRole: FolderRole, swipeAction: SwipeAction) = SwipeActionUiData(
+            colorRes = if (folder.role == folderRole) R.color.swipeInbox else swipeAction.colorRes,
+            iconRes = if (folder.role == folderRole) R.drawable.ic_drawer_inbox else swipeAction.iconRes,
+        )
+
+        return when (swipeAction) {
+            SwipeAction.READ_UNREAD -> SwipeActionUiData(
+                colorRes = swipeAction.colorRes,
+                iconRes = if (isSeen) swipeAction.iconRes else R.drawable.ic_envelope_open,
+            )
+            SwipeAction.FAVORITE -> SwipeActionUiData(
+                colorRes = swipeAction.colorRes,
+                iconRes = if (isFavorite) R.drawable.ic_unstar else swipeAction.iconRes,
+            )
+            SwipeAction.ARCHIVE -> computeDynamicAction(FolderRole.ARCHIVE, swipeAction)
+            SwipeAction.SPAM -> computeDynamicAction(FolderRole.SPAM, swipeAction)
+            else -> null
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -574,14 +574,20 @@ class ThreadListAdapter @Inject constructor(
         }
 
         (recyclerView as DragDropSwipeRecyclerView).apply {
-            getSwipeActionUiData(localSettings.swipeLeft)?.let { (colorRes, iconRes) ->
-                behindSwipedItemBackgroundColor = context.getColor(colorRes)
-                behindSwipedItemIconDrawableId = iconRes
+            val featureFlags = callbacks?.getFeatureFlags?.invoke()
+
+            if (localSettings.swipeLeft.displayBehavior.canDisplay(folderRole, featureFlags, localSettings)) {
+                getSwipeActionUiData(localSettings.swipeLeft)?.let { (colorRes, iconRes) ->
+                    behindSwipedItemBackgroundColor = context.getColor(colorRes)
+                    behindSwipedItemIconDrawableId = iconRes
+                }
             }
 
-            getSwipeActionUiData(localSettings.swipeRight)?.let { (colorRes, iconRes) ->
-                behindSwipedItemBackgroundSecondaryColor = context.getColor(colorRes)
-                behindSwipedItemIconSecondaryDrawableId = iconRes
+            if (localSettings.swipeRight.displayBehavior.canDisplay(folderRole, featureFlags, localSettings)) {
+                getSwipeActionUiData(localSettings.swipeRight)?.let { (colorRes, iconRes) ->
+                    behindSwipedItemBackgroundSecondaryColor = context.getColor(colorRes)
+                    behindSwipedItemIconSecondaryDrawableId = iconRes
+                }
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -576,14 +576,14 @@ class ThreadListAdapter @Inject constructor(
         (recyclerView as DragDropSwipeRecyclerView).apply {
             val featureFlags = callbacks?.getFeatureFlags?.invoke()
 
-            if (localSettings.swipeLeft.displayBehavior.canDisplay(folderRole, featureFlags, localSettings)) {
+            if (localSettings.swipeLeft.canDisplay(folderRole, featureFlags, localSettings)) {
                 getSwipeActionUiData(localSettings.swipeLeft)?.let { (colorRes, iconRes) ->
                     behindSwipedItemBackgroundColor = context.getColor(colorRes)
                     behindSwipedItemIconDrawableId = iconRes
                 }
             }
 
-            if (localSettings.swipeRight.displayBehavior.canDisplay(folderRole, featureFlags, localSettings)) {
+            if (localSettings.swipeRight.canDisplay(folderRole, featureFlags, localSettings)) {
                 getSwipeActionUiData(localSettings.swipeRight)?.let { (colorRes, iconRes) ->
                     behindSwipedItemBackgroundSecondaryColor = context.getColor(colorRes)
                     behindSwipedItemIconSecondaryDrawableId = iconRes

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapterCallbacks.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapterCallbacks.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.mail.ui.main.folder
 
+import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.thread.Thread
 
 interface ThreadListAdapterCallbacks {
@@ -26,4 +27,5 @@ interface ThreadListAdapterCallbacks {
     var onLoadMoreClicked: () -> Unit
     var onPositionClickedChanged: (position: Int, previousPosition: Int) -> Unit
     var deleteThreadInRealm: (threadUid: String) -> Unit
+    val getFeatureFlags: () -> Mailbox.FeatureFlagSet?
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -68,6 +68,7 @@ import com.infomaniak.mail.data.LocalSettings.ThreadDensity.COMPACT
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.SwipeAction
+import com.infomaniak.mail.data.models.isSnoozed
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.data.models.thread.Thread.ThreadFilter
 import com.infomaniak.mail.databinding.FragmentThreadListBinding
@@ -78,6 +79,7 @@ import com.infomaniak.mail.ui.main.SnackbarManager
 import com.infomaniak.mail.ui.main.folder.ThreadListViewModel.ContentDisplayMode
 import com.infomaniak.mail.ui.main.settings.appearance.swipe.SwipeActionsSettingsFragment
 import com.infomaniak.mail.ui.main.thread.ThreadFragment
+import com.infomaniak.mail.ui.main.thread.ThreadViewModel.SnoozeScheduleType
 import com.infomaniak.mail.ui.newMessage.NewMessageActivityArgs
 import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.PlayServicesUtils
@@ -514,8 +516,13 @@ class ThreadListFragment : TwoPaneFragment() {
                 toggleThreadSpamStatus(thread.uid)
                 false
             }
-            SwipeAction.POSTPONE -> {
-                notYetImplemented()
+            SwipeAction.SNOOZE -> {
+                val snoozeScheduleType = if (thread.isSnoozed()) {
+                    SnoozeScheduleType.Modify(thread.uid)
+                } else {
+                    SnoozeScheduleType.Snooze(thread.uid)
+                }
+                navigateToSnoozeBottomSheet(snoozeScheduleType, thread.snoozeEndDate)
                 true
             }
             SwipeAction.NONE -> error("Cannot swipe on an action which is not set")

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -170,7 +170,7 @@ class ThreadListFragment : TwoPaneFragment() {
         observeFilter()
         observeCurrentFolder()
         observeCurrentFolderLive()
-        observeSwipeActionImpactingValues()
+        observeSwipeActionContext()
         observeUpdatedAtTriggers()
         observeFlushFolderTrigger()
         observeUpdateInstall()
@@ -692,8 +692,8 @@ class ThreadListFragment : TwoPaneFragment() {
         }
     }
 
-    private fun observeSwipeActionImpactingValues() {
-        mainViewModel.swipeActionImpactingValues.observe(viewLifecycleOwner) { (featureFlags, folderRole) ->
+    private fun observeSwipeActionContext() {
+        mainViewModel.swipeActionContext.observe(viewLifecycleOwner) { (featureFlags, folderRole) ->
             updateDisabledSwipeActionsUi(featureFlags, folderRole)
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -269,7 +269,7 @@ class ThreadListFragment : TwoPaneFragment() {
         // Manually update disabled states in case LocalSettings have changed when coming back from settings
         val featureFlags = mainViewModel.currentMailbox.value?.featureFlags ?: return
         val folderRole = mainViewModel.currentFolderLive.value?.role ?: return
-        updateDisabledSwipeActions(featureFlags, folderRole)
+        updateDisabledSwipeActionsUi(featureFlags, folderRole)
     }
 
     override fun onDestroyView() {
@@ -366,15 +366,15 @@ class ThreadListFragment : TwoPaneFragment() {
         }
     }
 
-    private fun updateDisabledSwipeActions(featureFlags: Mailbox.FeatureFlagSet, folderRole: FolderRole?) {
+    private fun updateDisabledSwipeActionsUi(featureFlags: Mailbox.FeatureFlagSet, folderRole: FolderRole?) {
         val isLeftEnabled = localSettings.swipeLeft.canDisplay(folderRole, featureFlags, localSettings)
         val isRightEnabled = localSettings.swipeRight.canDisplay(folderRole, featureFlags, localSettings)
 
-        setSwipeActionEnabledState(DirectionFlag.LEFT, isLeftEnabled)
-        setSwipeActionEnabledState(DirectionFlag.RIGHT, isRightEnabled)
+        setSwipeActionEnabledUi(DirectionFlag.LEFT, isLeftEnabled)
+        setSwipeActionEnabledUi(DirectionFlag.RIGHT, isRightEnabled)
     }
 
-    private fun setSwipeActionEnabledState(swipeDirection: DirectionFlag, isEnabled: Boolean) = with(binding.threadsList) {
+    private fun setSwipeActionEnabledUi(swipeDirection: DirectionFlag, isEnabled: Boolean) = with(binding.threadsList) {
         fun SwipeAction.getIconRes(): Int? = if (isEnabled) iconRes else R.drawable.ic_close_small
         fun SwipeAction.getBackgroundColor(): Int {
             return if (isEnabled) getBackgroundColor(context) else SwipeAction.NONE.getBackgroundColor(context)
@@ -695,7 +695,7 @@ class ThreadListFragment : TwoPaneFragment() {
 
     private fun observeSwipeActionImpactingValues() {
         mainViewModel.swipeActionImpactingValues.observe(viewLifecycleOwner) { (featureFlags, folderRole) ->
-            updateDisabledSwipeActions(featureFlags, folderRole)
+            updateDisabledSwipeActionsUi(featureFlags, folderRole)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -367,8 +367,8 @@ class ThreadListFragment : TwoPaneFragment() {
     }
 
     private fun updateDisabledSwipeActions(featureFlags: Mailbox.FeatureFlagSet, folderRole: FolderRole?) {
-        val isLeftEnabled = localSettings.swipeLeft.displayBehavior.canDisplay(folderRole, featureFlags, localSettings)
-        val isRightEnabled = localSettings.swipeRight.displayBehavior.canDisplay(folderRole, featureFlags, localSettings)
+        val isLeftEnabled = localSettings.swipeLeft.canDisplay(folderRole, featureFlags, localSettings)
+        val isRightEnabled = localSettings.swipeRight.canDisplay(folderRole, featureFlags, localSettings)
 
         setSwipeActionEnabledState(DirectionFlag.LEFT, isLeftEnabled)
         setSwipeActionEnabledState(DirectionFlag.RIGHT, isRightEnabled)
@@ -473,7 +473,7 @@ class ThreadListFragment : TwoPaneFragment() {
         isPermanentDeleteFolder: Boolean,
     ): Boolean = with(mainViewModel) {
         val folderRole = thread.folder.role
-        if (!swipeAction.displayBehavior.canDisplay(folderRole, currentMailboxLive.value?.featureFlags, localSettings)) {
+        if (!swipeAction.canDisplay(folderRole, currentMailboxLive.value?.featureFlags, localSettings)) {
             snackbarManager.setValue(getString(R.string.snackbarSwipeActionIncompatible))
             return@with true
         }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -267,7 +267,7 @@ class ThreadListFragment : TwoPaneFragment() {
         unlockSwipeActionsIfSet()
 
         // Manually update disabled states in case LocalSettings have changed when coming back from settings
-        val featureFlags = mainViewModel.currentMailbox.value?.featureFlags ?: return
+        val featureFlags = mainViewModel.featureFlagsLive.value ?: return
         val folderRole = mainViewModel.currentFolderLive.value?.role ?: return
         updateDisabledSwipeActionsUi(featureFlags, folderRole)
     }
@@ -341,9 +341,7 @@ class ThreadListFragment : TwoPaneFragment() {
 
                 override var deleteThreadInRealm: (String) -> Unit = { threadUid -> mainViewModel.deleteThreadInRealm(threadUid) }
 
-                override val getFeatureFlags: () -> Mailbox.FeatureFlagSet? = {
-                    mainViewModel.currentMailboxLive.value?.featureFlags
-                }
+                override val getFeatureFlags: () -> Mailbox.FeatureFlagSet? = { mainViewModel.featureFlagsLive.value }
             },
             multiSelection = object : MultiSelectionListener<Thread> {
                 override var isEnabled by mainViewModel::isMultiSelectOn
@@ -473,7 +471,7 @@ class ThreadListFragment : TwoPaneFragment() {
         isPermanentDeleteFolder: Boolean,
     ): Boolean = with(mainViewModel) {
         val folderRole = thread.folder.role
-        if (!swipeAction.canDisplay(folderRole, currentMailboxLive.value?.featureFlags, localSettings)) {
+        if (!swipeAction.canDisplay(folderRole, featureFlagsLive.value, localSettings)) {
             snackbarManager.setValue(getString(R.string.snackbarSwipeActionIncompatible))
             return@with true
         }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -266,10 +266,11 @@ class ThreadListFragment : TwoPaneFragment() {
     private fun updateSwipeActionsAccordingToSettings() {
         unlockSwipeActionsIfSet()
 
-        // Manually update disabled states in case LocalSettings have changed when coming back from settings
-        val featureFlags = mainViewModel.featureFlagsLive.value ?: return
-        val folderRole = mainViewModel.currentFolderLive.value?.role ?: return
-        updateDisabledSwipeActionsUi(featureFlags, folderRole)
+        // Manually update disabled ui in case LocalSettings have changed when coming back from settings
+        updateDisabledSwipeActionsUi(
+            featureFlags = mainViewModel.featureFlagsLive.value,
+            folderRole = mainViewModel.currentFolderLive.value?.role,
+        )
     }
 
     override fun onDestroyView() {
@@ -364,7 +365,7 @@ class ThreadListFragment : TwoPaneFragment() {
         }
     }
 
-    private fun updateDisabledSwipeActionsUi(featureFlags: Mailbox.FeatureFlagSet, folderRole: FolderRole?) {
+    private fun updateDisabledSwipeActionsUi(featureFlags: Mailbox.FeatureFlagSet?, folderRole: FolderRole?) {
         val isLeftEnabled = localSettings.swipeLeft.canDisplay(folderRole, featureFlags, localSettings)
         val isRightEnabled = localSettings.swipeRight.canDisplay(folderRole, featureFlags, localSettings)
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,6 +27,7 @@ import com.infomaniak.mail.data.models.draft.Draft.DraftMode
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.di.IoDispatcher
+import com.infomaniak.mail.ui.main.thread.ThreadViewModel.SnoozeScheduleType
 import com.infomaniak.mail.ui.newMessage.NewMessageActivityArgs
 import com.infomaniak.mail.utils.Utils.runCatchingRealm
 import com.infomaniak.mail.utils.coroutineContext
@@ -49,6 +50,10 @@ class TwoPaneViewModel @Inject constructor(
     inline val isThreadOpen get() = currentThreadUid.value != null
     val rightPaneFolderName = MutableLiveData<String>()
     var previousFolderId: String? = null
+
+    // Remember what type of snooze action the snooze schedule bottom sheet is used for,
+    // so we know what call to execute when a date is chosen
+    var snoozeScheduleType: SnoozeScheduleType? = null
 
     val newMessageArgs = SingleLiveEvent<NewMessageActivityArgs>()
     val navArgs = SingleLiveEvent<NavData>()
@@ -98,6 +103,10 @@ class TwoPaneViewModel @Inject constructor(
                 mailToUri = mailToUri,
             ),
         )
+    }
+
+    fun safelyNavigate(@IdRes resId: Int, args: Bundle) {
+        navArgs.value = NavData(resId, args)
     }
 
     data class NavData(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
@@ -176,9 +176,7 @@ class SearchFragment : TwoPaneFragment() {
 
                 override var deleteThreadInRealm: (String) -> Unit = { threadUid -> mainViewModel.deleteThreadInRealm(threadUid) }
 
-                override val getFeatureFlags: () -> Mailbox.FeatureFlagSet? = {
-                    mainViewModel.currentMailboxLive.value?.featureFlags
-                }
+                override val getFeatureFlags: () -> Mailbox.FeatureFlagSet? = { mainViewModel.featureFlagsLive.value }
             },
         )
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
@@ -48,6 +48,7 @@ import com.infomaniak.mail.MatomoMail.trackSearchEvent
 import com.infomaniak.mail.MatomoMail.trackThreadListEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Folder
+import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.data.models.thread.Thread.ThreadFilter
 import com.infomaniak.mail.databinding.FragmentSearchBinding
@@ -174,6 +175,10 @@ class SearchFragment : TwoPaneFragment() {
                 override var onPositionClickedChanged: (Int, Int) -> Unit = ::updateAutoAdvanceNaturalThread
 
                 override var deleteThreadInRealm: (String) -> Unit = { threadUid -> mainViewModel.deleteThreadInRealm(threadUid) }
+
+                override val getFeatureFlags: () -> Mailbox.FeatureFlagSet? = {
+                    mainViewModel.currentMailboxLive.value?.featureFlags
+                }
             },
         )
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/SettingsFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -244,8 +244,8 @@ class SettingsFragment : Fragment() {
     }
 
     private fun observeFeatureFlag() {
-        mainViewModel.currentMailbox.observeNotNull(viewLifecycleOwner) {
-            binding.settingsAiEngine.isVisible = it.featureFlags.contains(FeatureFlag.AI)
+        mainViewModel.featureFlagsLive.observe(viewLifecycleOwner) {
+            binding.settingsAiEngine.isVisible = it.contains(FeatureFlag.AI)
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSelectionSettingFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSelectionSettingFragment.kt
@@ -63,7 +63,7 @@ class SwipeActionsSelectionSettingFragment : Fragment() {
                 R.id.readUnread to READ_UNREAD,
                 R.id.move to MOVE,
                 R.id.favorite to FAVORITE,
-                R.id.snooze to POSTPONE,
+                R.id.snooze to SNOOZE,
                 R.id.spam to SPAM,
                 R.id.quickActionMenu to QUICKACTIONS_MENU,
                 R.id.none to NONE,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSelectionSettingFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSelectionSettingFragment.kt
@@ -61,7 +61,7 @@ class SwipeActionsSelectionSettingFragment : Fragment() {
         val actionResId = navigationArgs.titleResId
         root.setTitle(actionResId)
 
-        snooze.isVisible = SharedUtils.isSnoozeAvailable(mainViewModel.currentMailboxLive.value?.featureFlags, localSettings)
+        snooze.isVisible = SharedUtils.isSnoozeAvailable(mainViewModel.featureFlagsLive.value, localSettings)
 
         radioGroup.apply {
             initBijectionTable(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSelectionSettingFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSelectionSettingFragment.kt
@@ -21,7 +21,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.infomaniak.lib.core.utils.safeBinding
@@ -32,6 +34,8 @@ import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.data.models.SwipeAction
 import com.infomaniak.mail.data.models.SwipeAction.*
 import com.infomaniak.mail.databinding.FragmentSwipeActionsSelectionSettingBinding
+import com.infomaniak.mail.ui.MainViewModel
+import com.infomaniak.mail.utils.SharedUtils
 import com.infomaniak.mail.utils.extensions.setSystemBarsColors
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -41,6 +45,7 @@ class SwipeActionsSelectionSettingFragment : Fragment() {
 
     private var binding: FragmentSwipeActionsSelectionSettingBinding by safeBinding()
     private val navigationArgs: SwipeActionsSelectionSettingFragmentArgs by navArgs()
+    private val mainViewModel: MainViewModel by activityViewModels()
 
     @Inject
     lateinit var localSettings: LocalSettings
@@ -55,6 +60,8 @@ class SwipeActionsSelectionSettingFragment : Fragment() {
 
         val actionResId = navigationArgs.titleResId
         root.setTitle(actionResId)
+
+        snooze.isVisible = SharedUtils.isSnoozeAvailable(mainViewModel.currentMailboxLive.value?.featureFlags, localSettings)
 
         radioGroup.apply {
             initBijectionTable(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -102,10 +102,6 @@ class ThreadViewModel @Inject constructor(
     // Save the current scheduled date of the draft we're rescheduling to be able to pass it to the schedule bottom sheet
     var reschedulingCurrentlyScheduledEpochMillis: Long? = null
 
-    // Remember what type of snooze action the snooze schedule bottom sheet is used for,
-    // so we know what call to execute when a date is chosen
-    var snoozeScheduleType: SnoozeScheduleType? = null
-
     val isThreadSnoozeHeaderVisible = Utils.waitInitMediator(currentMailboxLive, threadLive).map { (mailbox, thread) ->
         when {
             thread == null || thread.isSnoozed().not() -> ThreadHeaderVisibility.NONE

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageAiManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageAiManager.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,7 +40,6 @@ import com.infomaniak.mail.data.models.FeatureFlag
 import com.infomaniak.mail.data.models.ai.AiPromptOpeningStatus
 import com.infomaniak.mail.databinding.FragmentNewMessageBinding
 import com.infomaniak.mail.utils.UiUtils
-import com.infomaniak.mail.utils.extensions.observeNotNull
 import com.infomaniak.mail.utils.extensions.updateNavigationBarColor
 import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.FragmentScoped
@@ -203,8 +202,8 @@ class NewMessageAiManager @Inject constructor(
     }
 
     fun observeAiFeatureFlagUpdates() {
-        newMessageViewModel.currentMailboxLive.observeNotNull(viewLifecycleOwner) { mailbox ->
-            val isAiEnabled = mailbox.featureFlags.contains(FeatureFlag.AI)
+        newMessageViewModel.featureFlagsLive.observe(viewLifecycleOwner) { featureFlags ->
+            val isAiEnabled = featureFlags.contains(FeatureFlag.AI)
             binding.editorAi.isVisible = isAiEnabled
             if (isAiEnabled) navigateToDiscoveryBottomSheetIfFirstTime()
         }

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -682,8 +682,8 @@ class NewMessageFragment : Fragment() {
     }
 
     private fun observeScheduledDraftsFeatureFlagUpdates() {
-        newMessageViewModel.currentMailboxLive.observeNotNull(viewLifecycleOwner) { mailbox ->
-            val isScheduledDraftsEnabled = mailbox.featureFlags.contains(FeatureFlag.SCHEDULE_DRAFTS)
+        newMessageViewModel.featureFlagsLive.observe(viewLifecycleOwner) { featureFlags ->
+            val isScheduledDraftsEnabled = featureFlags.contains(FeatureFlag.SCHEDULE_DRAFTS)
             binding.scheduleButton.isVisible = isScheduledDraftsEnabled
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -81,7 +81,7 @@ import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import org.jsoup.nodes.Document
 import java.util.Date
 import javax.inject.Inject
@@ -161,10 +161,12 @@ class NewMessageViewModel @Inject constructor(
 
     val currentMailbox by lazy { mailboxController.getMailbox(AccountUtils.currentUserId, AccountUtils.currentMailboxId)!! }
 
-    val currentMailboxLive = mailboxController.getMailboxAsync(
+    private val currentMailboxLive = mailboxController.getMailboxAsync(
         AccountUtils.currentUserId,
         AccountUtils.currentMailboxId,
-    ).map { it.obj }.asLiveData(ioCoroutineContext)
+    ).mapNotNull { it.obj }.asLiveData(ioCoroutineContext)
+
+    val featureFlagsLive = currentMailboxLive.map { it.featureFlags }
 
     val mergedContacts = liveData(ioCoroutineContext) {
         val list = mergedContactController.getSortedMergedContacts().copyFromRealm()

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -276,7 +276,7 @@ class SharedUtils @Inject constructor(
             localSettings: LocalSettings,
             currentFolderRole: FolderRole?,
         ): Boolean {
-            fun isSnoozeAvailable() = isSnoozeAvailable(mainViewModel.currentMailbox.value?.featureFlags, localSettings)
+            fun isSnoozeAvailable() = isSnoozeAvailable(mainViewModel.featureFlagsLive.value, localSettings)
             return currentFolderRole == FolderRole.INBOX || currentFolderRole == FolderRole.SNOOZED && isSnoozeAvailable()
         }
 

--- a/app/src/main/res/drawable/ic_close_small.xml
+++ b/app/src/main/res/drawable/ic_close_small.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2023-2024 Infomaniak Network SA
+  ~ Copyright (C) 2023-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -15,9 +15,11 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
+<!-- Tint is set because the DragDropSwipeRecyclerView doesn't let us specify icon tint otherwise -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="16dp"
     android:height="16dp"
+    android:tint="@color/iconColor"
     android:viewportWidth="16"
     android:viewportHeight="16">
     <path

--- a/app/src/main/res/layout/fragment_swipe_actions_selection_setting.xml
+++ b/app/src/main/res/layout/fragment_swipe_actions_selection_setting.xml
@@ -67,12 +67,10 @@
                     android:layout_height="wrap_content"
                     app:text="@string/actionShortStar" />
 
-                <!-- TODO: Display this when Postpone/Snooze action will be done (v2) -->
                 <com.infomaniak.mail.ui.main.settings.SettingRadioButtonView
                     android:id="@+id/snooze"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="gone"
                     app:text="@string/actionSnooze" />
 
                 <com.infomaniak.mail.ui.main.settings.SettingRadioButtonView

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -572,6 +572,7 @@
         <item quantity="other">Sie erhalten eine Erinnerung an diese Nachrichten %s</item>
     </plurals>
     <string name="snackbarSubjectCopiedToClipboard">Betreff in die Zwischenablage kopiert</string>
+    <string name="snackbarSwipeActionIncompatible">Wischaktion inkompatibel</string>
     <plurals name="snackbarThreadDeletedPermanently">
         <item quantity="one">Konversation gelöscht</item>
         <item quantity="other">Konversationen gelöscht</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -572,6 +572,7 @@
         <item quantity="other">Recibirás un recordatorio de estos mensajes %s</item>
     </plurals>
     <string name="snackbarSubjectCopiedToClipboard">Tema copiado en el portapapeles</string>
+    <string name="snackbarSwipeActionIncompatible">Acción de deslizamiento incompatible</string>
     <plurals name="snackbarThreadDeletedPermanently">
         <item quantity="one">Conversación eliminada</item>
         <item quantity="other">Conversaciones eliminadas</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -582,6 +582,7 @@
         <item quantity="many">Vous recevrez un rappel de ces messages %s</item>
     </plurals>
     <string name="snackbarSubjectCopiedToClipboard">Objet copié dans le presse-papiers</string>
+    <string name="snackbarSwipeActionIncompatible">Action de balayage incompatible</string>
     <plurals name="snackbarThreadDeletedPermanently">
         <item quantity="one">Conversation supprimée</item>
         <item quantity="other">Conversations supprimées</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -572,6 +572,7 @@
         <item quantity="other">Riceverai un promemoria per questi messaggi %s</item>
     </plurals>
     <string name="snackbarSubjectCopiedToClipboard">Soggetto copiato negli appunti</string>
+    <string name="snackbarSwipeActionIncompatible">Azione di scorrimento incompatibile</string>
     <plurals name="snackbarThreadDeletedPermanently">
         <item quantity="one">Conversazione cancellata</item>
         <item quantity="other">Conversazioni cancellate</item>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -102,7 +102,7 @@
     <color name="swipeMove">@color/fougere_dark</color>
     <color name="swipeReadUnread">@color/cobalt_dark</color>
     <color name="swipeFavorite">@color/favoriteYellow</color>
-    <color name="swipePostpone">@color/azur_dark</color>
+    <color name="swipeSnooze">@color/coral_dark</color>
     <color name="swipeSpam">@color/orangeWarning</color>
     <color name="swipeArchive">@color/mauve_dark</color>
     <color name="swipeQuickActionMenu">@color/app_blue_dark</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -208,7 +208,7 @@
     <color name="swipeMove">@color/fougere_light</color>
     <color name="swipeReadUnread">@color/cobalt_light</color>
     <color name="swipeFavorite">@color/favoriteYellow</color>
-    <color name="swipePostpone">@color/azur_light</color>
+    <color name="swipeSnooze">@color/coral_light</color>
     <color name="swipeSpam">@color/orangeWarning</color>
     <color name="swipeArchive">@color/mauve_light</color>
     <color name="swipeQuickActionMenu">@color/app_blue_light</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -578,6 +578,7 @@
         <item quantity="other">You will receive a reminder for these messages %s</item>
     </plurals>
     <string name="snackbarSubjectCopiedToClipboard">Subject copied to the clipboard</string>
+    <string name="snackbarSwipeActionIncompatible">Swipe action incompatible</string>
     <plurals name="snackbarThreadDeletedPermanently">
         <item quantity="one">Conversation deleted</item>
         <item quantity="other">Conversations deleted</item>


### PR DESCRIPTION
Adds the snooze swipe action. The snooze swipe action is only enabled in the inbox and snooze folder, if your message display mode is set to threaded messages and if you have the snooze feature flag enabled. This required me to add a mechanism to easily define what swipe action can be displayed in what circumstances.

When an action is not accessible in a certain situation, it shows as a greyed out action. When swiped all the way an informative snackbar clarifies even more that the action is incompatible.

I'm not certain about some of the namings, if you've got better ideas I'm all ear.

Sonar rightfully detected that the method that performs swipe actions' logic has too much cognitive complexity, but to not make it harder to review, I fixed it here instead: https://github.com/Infomaniak/android-kMail/pull/2333