### PR TITLE
fix: Fix thread ordering

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -187,7 +187,7 @@ object RealmDatabase {
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 3L
         const val MAILBOX_INFO_SCHEMA_VERSION = 9L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 28L
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 29L
         //endregion
 
         //region Configurations names

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmMigrations.kt
@@ -261,7 +261,7 @@ private fun DynamicMutableRealmObject.setIfPropertyExists(propertyName: String, 
 }
 
 /**
- * Tries to get read [fieldName] but if the value is not in the [DynamicRealmObject], instead of crashing, fallback to an
+ * Tries to read [fieldName] but if the value is not in the [DynamicRealmObject], instead of crashing, fallback to an
  * alternative recovery method to get the expected value.
  *
  * Used for when we can be migrating from versions of the model that might never have had [fieldName] initialized.
@@ -277,7 +277,7 @@ private inline fun <reified T : Any> DynamicRealmObject.getNullableValueOrRecove
 }
 
 /**
- * Tries to get read [fieldName] but if the value is not in the [DynamicRealmObject], instead of crashing, fallback to an
+ * Tries to read [fieldName] but if the value is not in the [DynamicRealmObject], instead of crashing, fallback to an
  * alternative recovery method to get the expected value.
  *
  * Used for when we can be migrating from versions of the model that might never have had [fieldName] initialized.

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -179,6 +179,9 @@ class Thread : RealmObject, Snoozable {
     }
 
     fun recomputeThread(realm: MutableRealm? = null) {
+
+        messages.sortBy { it.internalDate }
+
         val lastCurrentFolderMessage = messages.lastOrNull { it.folderId == folderId }
         val lastMessage = if (isFromSearch) {
             // In the search, some threads (such as threads from the snooze folder) won't have any messages with the same folderId
@@ -232,8 +235,6 @@ class Thread : RealmObject, Snoozable {
                 snoozeUuid = message.snoozeUuid
             }
         }
-
-        messages.sortBy { it.internalDate }
 
         messages.forEach { message ->
             messagesIds += message.messageIds


### PR DESCRIPTION
Recomputing a thread would not compute correctly any value that depends on the computed `lastMessage` variable (i.e. `internalDate` and `displayDate`). This PR fixes the issue so future recomputations are correct and we trigger a migration so we can recompute existing threads.