### PR TITLE
fix: Unsnoozed date display when device's date is in the past

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -347,7 +347,8 @@ class Thread : RealmObject, Snoozable {
 
     fun computeThreadListDateDisplay(folderRole: FolderRole?) = when {
         numberOfScheduledDrafts > 0 && folderRole == FolderRole.SCHEDULED_DRAFTS -> ThreadListDateDisplay.Scheduled
-        isSnoozed() || isUnsnoozed() -> ThreadListDateDisplay.Snoozed
+        isSnoozed() -> ThreadListDateDisplay.Snoozed
+        isUnsnoozed() -> ThreadListDateDisplay.Unsnoozed
         else -> ThreadListDateDisplay.Default
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListDateDisplay.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListDateDisplay.kt
@@ -53,7 +53,16 @@ enum class ThreadListDateDisplay(
         formatThreadDate = { thread ->
             // If the thread is in SnoozeState.Snoozed then we necessarily have a snoozeEndDate
             val date = thread.snoozeEndDate ?: RealmInstant.MIN
-            if (date.isInTheFuture()) relativeFormatting(date) else defaultFormatting(date)
+            relativeFormatting(date)
+        }
+    ),
+    Unsnoozed(
+        iconRes = R.drawable.ic_alarm_clock_thick,
+        iconColorRes = R.color.snoozeColor,
+        formatThreadDate = { thread ->
+            // If the thread is in SnoozeState.Unsnoozed then we necessarily have a snoozeEndDate
+            val date = thread.snoozeEndDate ?: RealmInstant.MIN
+            defaultFormatting(date)
         }
     )
 }


### PR DESCRIPTION
If the device's date was in the past, the unsnoozed date might have been displayed using the relative formatting instead of the default one. This fixes the issue forever.

This occurs if unsnoozed message's date is later than the device's date, which is possible if the device's date is in the past.

Bugged diplayed relative date:
<img width="174" alt="image" src="https://github.com/user-attachments/assets/a0c9fea5-fed6-476a-baac-ad4d012b803c" />

Correct default formatting for dates in the future:
<img width="98" alt="image" src="https://github.com/user-attachments/assets/f640978f-d255-493c-aab0-351b17e8edf6" />

