### PR TITLE
feat: Display and translate snooze api errors

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -59,6 +59,7 @@ import com.infomaniak.mail.data.models.snooze.BatchSnoozeUpdateResponse
 import com.infomaniak.mail.data.models.thread.ThreadResult
 import com.infomaniak.mail.ui.newMessage.AiViewModel.Shortcut
 import com.infomaniak.mail.utils.AccountUtils
+import com.infomaniak.mail.utils.SharedUtils
 import com.infomaniak.mail.utils.Utils
 import com.infomaniak.mail.utils.Utils.EML_CONTENT_TYPE
 import io.realm.kotlin.ext.copyFromRealm
@@ -358,6 +359,17 @@ object ApiRepository : ApiRepositoryCore() {
         }
     }
 
+    fun rescheduleSnoozedThread(mailboxUuid: String, snoozeUuid: String, date: Date): ApiResponse<Boolean> {
+        return callApi(
+            url = ApiRoutes.snoozeAction(mailboxUuid, snoozeUuid),
+            method = PUT,
+            body = mapOf("end_date" to date.format(FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR)),
+        )
+    }
+
+    /**
+     * Do not call directly, use the [SharedUtils.rescheduleSnoozedThreads] instead to correctly support api error messages.
+     */
     fun rescheduleSnoozedThreads(
         mailboxUuid: String,
         snoozeUuids: List<String>,
@@ -376,6 +388,9 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.snoozeAction(mailboxUuid, snoozeUuid), DELETE)
     }
 
+    /**
+     * Do not call directly, use the [SharedUtils.unsnoozeThreads] instead to correctly support api error messages.
+     */
     fun unsnoozeThreads(mailboxUuid: String, snoozeUuids: List<String>): List<ApiResponse<BatchSnoozeCancelResponse>> {
         return batchOver(snoozeUuids, limit = Utils.MAX_UUIDS_PER_CALL_SNOOZE) {
             callApi(ApiRoutes.snooze(mailboxUuid), DELETE, mapOf("uuids" to it))

--- a/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeResponse.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/snooze/BatchSnoozeResponse.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.data.models.snooze
 
 import com.infomaniak.lib.core.models.ApiResponse
+import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.mail.data.cache.mailboxContent.ImpactedFolders
 import com.infomaniak.mail.utils.extensions.getFirstTranslatedError
 
@@ -34,6 +35,13 @@ interface BatchSnoozeResponse {
                 BatchSnoozeResult.Success(impactedFolderIds)
             }
             else -> BatchSnoozeResult.Error.NoneSucceeded
+        }
+
+        fun ApiResponse<Boolean>.computeSnoozeResult(impactedFolderIds: ImpactedFolders): BatchSnoozeResult {
+            return when {
+                isSuccess() -> BatchSnoozeResult.Success(impactedFolderIds)
+                else -> BatchSnoozeResult.Error.ApiError(translateError())
+            }
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -46,7 +46,6 @@ import com.infomaniak.mail.data.models.isSnoozed
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.mailbox.SendersRestrictions
 import com.infomaniak.mail.data.models.message.Message
-import com.infomaniak.mail.data.models.snooze.BatchSnoozeResponse.Companion.computeSnoozeResult
 import com.infomaniak.mail.data.models.snooze.BatchSnoozeResult
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.data.models.thread.Thread.ThreadFilter
@@ -1187,8 +1186,12 @@ class MainViewModel @Inject constructor(
     }
 
     private fun rescheduleSnoozedThreads(currentMailbox: Mailbox, snoozeUuids: List<String>, date: Date): BatchSnoozeResult {
-        val responses = ApiRepository.rescheduleSnoozedThreads(currentMailbox.uuid, snoozeUuids, date)
-        return responses.computeSnoozeResult(ImpactedFolders(mutableSetOf(FolderRole.SNOOZED)))
+        return SharedUtils.rescheduleSnoozedThreads(
+            mailboxUuid = currentMailbox.uuid,
+            snoozeUuids = snoozeUuids,
+            newDate = date,
+            impactedFolders = ImpactedFolders(mutableSetOf(FolderRole.SNOOZED)),
+        )
     }
 
     private fun getRescheduleSnoozedErrorMessage(errorResult: BatchSnoozeResult.Error): String {

--- a/app/src/main/java/com/infomaniak/mail/utils/ErrorCode.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ErrorCode.kt
@@ -96,6 +96,9 @@ object ErrorCode {
 
     //region Snooze
     const val MAIL_MESSAGE_NOT_SNOOZED = "mail__message_not_snoozed"
+    const val MAIL_MESSAGE_SNOOZE_ALREADY_SCHEDULED = "mail__message_snooze_already_scheduled"
+    const val MAIL_MESSAGE_MAX_NUMBER_OF_SCHEDULED_SNOOZE_REACHED = "mail__message_max_number_of_scheduled_snooze_reached"
+    const val MAIL_MESSAGE_CANNOT_BE_SNOOZE = "mail__message_cannot_be_snooze"
     //endregion
 
     val apiErrorCodes = listOf(
@@ -136,6 +139,12 @@ object ErrorCode {
 
         // Action
         ApiErrorCode(MOVE_DESTINATION_NOT_FOUND, R.string.errorMoveDestinationNotFound),
+
+        // Snooze
+        ApiErrorCode(MAIL_MESSAGE_NOT_SNOOZED, R.string.errorMessageNotSnoozed),
+        ApiErrorCode(MAIL_MESSAGE_SNOOZE_ALREADY_SCHEDULED, R.string.errorMessageSnoozeAlreadyScheduled),
+        ApiErrorCode(MAIL_MESSAGE_MAX_NUMBER_OF_SCHEDULED_SNOOZE_REACHED, R.string.errorMaxNumberOfScheduledSnoozeReached),
+        ApiErrorCode(MAIL_MESSAGE_CANNOT_BE_SNOOZE, R.string.errorMessageCannotBeSnoozed),
     )
 
     private val ignoredErrorCodesForDrafts = setOf(

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -20,7 +20,6 @@ package com.infomaniak.mail.utils
 import androidx.fragment.app.Fragment
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.models.ApiResponse
-import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.mail.MatomoMail.trackEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
@@ -224,11 +223,8 @@ class SharedUtils @Inject constructor(
             impactedFolders: ImpactedFolders,
         ): BatchSnoozeResult {
             return if (snoozeUuids.count() == 1) {
-                val apiResponse = ApiRepository.rescheduleSnoozedThread(mailboxUuid, snoozeUuids.single(), newDate)
-                when {
-                    apiResponse.isSuccess() -> BatchSnoozeResult.Success(impactedFolders)
-                    else -> BatchSnoozeResult.Error.ApiError(apiResponse.translateError())
-                }
+                val snoozeUuid = snoozeUuids.single()
+                ApiRepository.rescheduleSnoozedThread(mailboxUuid, snoozeUuid, newDate).computeSnoozeResult(impactedFolders)
             } else {
                 ApiRepository.rescheduleSnoozedThreads(mailboxUuid, snoozeUuids, newDate).computeSnoozeResult(impactedFolders)
             }
@@ -240,11 +236,7 @@ class SharedUtils @Inject constructor(
          */
         fun unsnoozeThreads(mailboxUuid: String, snoozeUuids: List<String>, impactedFolders: ImpactedFolders): BatchSnoozeResult {
             return if (snoozeUuids.count() == 1) {
-                val apiResponse = ApiRepository.unsnoozeThread(mailboxUuid, snoozeUuids.single())
-                when {
-                    apiResponse.isSuccess() -> BatchSnoozeResult.Success(impactedFolders)
-                    else -> BatchSnoozeResult.Error.ApiError(apiResponse.translateError())
-                }
+                ApiRepository.unsnoozeThread(mailboxUuid, snoozeUuids.single()).computeSnoozeResult(impactedFolders)
             } else {
                 ApiRepository.unsnoozeThreads(mailboxUuid, snoozeUuids).computeSnoozeResult(impactedFolders)
             }

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -68,6 +68,7 @@ import com.infomaniak.core.utils.startOfTheWeek
 import com.infomaniak.dragdropswiperecyclerview.DragDropSwipeRecyclerView
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.models.ApiResponse
+import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
 import com.infomaniak.lib.core.utils.hideKeyboard
 import com.infomaniak.lib.core.utils.removeAccents
@@ -294,7 +295,7 @@ inline fun <reified T> ApiResponse<T>.getApiException(): Exception {
 
 fun List<ApiResponse<*>>.atLeastOneSucceeded(): Boolean = any { it.isSuccess() }
 
-fun List<ApiResponse<*>>.getFirstTranslatedError(): Int? = firstOrNull { it.isSuccess().not() }?.translatedError
+fun List<ApiResponse<*>>.getFirstTranslatedError(): Int? = firstOrNull { it.isSuccess().not() }?.translateError()
 
 fun List<ApiResponse<*>>.allFailed(): Boolean = none { it.isSuccess() }
 //endregion

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -293,6 +293,10 @@
     <string name="errorLoginTitle">Login-Fehler</string>
     <string name="errorMailboxLocked">Diese Mailbox ist gesperrt</string>
     <string name="errorMailboxPasswordLength">Das Passwort muss zwischen 6 und 80 Zeichen lang sein</string>
+    <string name="errorMaxNumberOfScheduledSnoozeReached">Sie haben die maximale Anzahl geplanter Schlummerzeiten erreicht</string>
+    <string name="errorMessageCannotBeSnoozed">Diese Nachricht kann nicht in den Schlummermodus versetzt werden</string>
+    <string name="errorMessageNotSnoozed">Diese Nachricht ist derzeit nicht im Schlummermodus</string>
+    <string name="errorMessageSnoozeAlreadyScheduled">Für diese Nachricht ist bereits ein Schlummern geplant</string>
     <string name="errorMoveDestinationNotFound">Der Zielordner besteht nicht</string>
     <string name="errorNewFolderAlreadyExists">Der Ordner besteht bereits</string>
     <string name="errorNewFolderInvalidCharacter">Der Ordnername enthält ungültige Zeichen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -293,6 +293,10 @@
     <string name="errorLoginTitle">Error de inicio de sesión</string>
     <string name="errorMailboxLocked">Esta dirección de correo electrónico está bloqueada</string>
     <string name="errorMailboxPasswordLength">La contraseña debe tener entre 6 y 80 caracteres</string>
+    <string name="errorMaxNumberOfScheduledSnoozeReached">Has alcanzado el número máximo de aplazamientos programados</string>
+    <string name="errorMessageCannotBeSnoozed">Este mensaje no se puede aplazar</string>
+    <string name="errorMessageNotSnoozed">Este mensaje no está aplazado actualmente</string>
+    <string name="errorMessageSnoozeAlreadyScheduled">Este mensaje ya tiene un aplazamiento programado</string>
     <string name="errorMoveDestinationNotFound">La carpeta de destino no existe</string>
     <string name="errorNewFolderAlreadyExists">La carpeta ya existe</string>
     <string name="errorNewFolderInvalidCharacter">El nombre de la carpeta contiene caracteres no válidos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -295,6 +295,10 @@
     <string name="errorLoginTitle">Erreur de connexion</string>
     <string name="errorMailboxLocked">Cette adresse est bloquée</string>
     <string name="errorMailboxPasswordLength">Le mot de passe doit comporter entre 6 et 80 caractères</string>
+    <string name="errorMaxNumberOfScheduledSnoozeReached">Vous avez atteint le nombre maximal de mises en attente programmées</string>
+    <string name="errorMessageCannotBeSnoozed">Ce message ne peut pas être mis en attente</string>
+    <string name="errorMessageNotSnoozed">Ce message n’est pas mis en attente</string>
+    <string name="errorMessageSnoozeAlreadyScheduled">Une mise en attente est déjà programmée pour ce message</string>
     <string name="errorMoveDestinationNotFound">Le dossier de destination n’existe pas</string>
     <string name="errorNewFolderAlreadyExists">Le dossier existe déjà</string>
     <string name="errorNewFolderInvalidCharacter">Le nom du dossier comporte des caractères invalides</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -293,6 +293,10 @@
     <string name="errorLoginTitle">Errore di accesso</string>
     <string name="errorMailboxLocked">Questo indirizzo e-mail è bloccato</string>
     <string name="errorMailboxPasswordLength">La password deve essere compresa tra 6 e 80 caratteri</string>
+    <string name="errorMaxNumberOfScheduledSnoozeReached">Hai raggiunto il numero massimo di posticipi programmati</string>
+    <string name="errorMessageCannotBeSnoozed">Questo messaggio non può essere posticipato</string>
+    <string name="errorMessageNotSnoozed">Questo messaggio non è stato posticipato</string>
+    <string name="errorMessageSnoozeAlreadyScheduled">Questo messaggio ha già un posticipo programmato</string>
     <string name="errorMoveDestinationNotFound">La cartella di destinazione è inesistente</string>
     <string name="errorNewFolderAlreadyExists">La cartella è già esistente</string>
     <string name="errorNewFolderInvalidCharacter">Il nome della cartella contiene caratteri non validi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,6 +299,10 @@
     <string name="errorLoginTitle">Login error</string>
     <string name="errorMailboxLocked">This mailbox is locked</string>
     <string name="errorMailboxPasswordLength">The password must be between 6 and 80 characters</string>
+    <string name="errorMaxNumberOfScheduledSnoozeReached">You’ve reached the maximum number of scheduled snoozes</string>
+    <string name="errorMessageCannotBeSnoozed">This message cannot be snoozed</string>
+    <string name="errorMessageNotSnoozed">This message is not currently snoozed</string>
+    <string name="errorMessageSnoozeAlreadyScheduled">A snooze is already scheduled for this message</string>
     <string name="errorMoveDestinationNotFound">The destination folder does not exist</string>
     <string name="errorNewFolderAlreadyExists">The folder already exists</string>
     <string name="errorNewFolderInvalidCharacter">The folder name contains invalid characters</string>


### PR DESCRIPTION
Make it so calling reschedule of snooze or unsnooze api calls for a single snooze calls the single item route instead. Calling the single item route is the only way to receive api errors from the api to be able to display them to the user.

Also translates new errors introduced with the snooze feature