### PR TITLE
feat: Replace deprecated translatedError and use updated translateError()

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -25,7 +25,9 @@ import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.R
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.api.ApiController.ApiMethod.*
+import com.infomaniak.lib.core.api.ApiController.toApiError
 import com.infomaniak.lib.core.api.ApiRepositoryCore
+import com.infomaniak.lib.core.api.InternalTranslatedErrorCode
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.models.ApiResponseStatus
 import com.infomaniak.lib.core.networking.HttpClient
@@ -490,7 +492,7 @@ object ApiRepository : ApiRepositoryCore() {
         return ApiController.json.decodeFromString(response.body?.string() ?: "")
 
     }.getOrElse {
-        return ApiResponse(result = ApiResponseStatus.ERROR, translatedError = R.string.anErrorHasOccurred)
+        return ApiResponse(result = ApiResponseStatus.ERROR, error = InternalTranslatedErrorCode.UnknownError.toApiError())
     }
 
     fun getSwissTransferContainer(containerUuid: String): ApiResponse<SwissTransferContainer> {

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -22,7 +22,6 @@ import com.infomaniak.core.utils.FORMAT_FULL_DATE_WITH_HOUR
 import com.infomaniak.core.utils.FORMAT_ISO_8601_WITH_TIMEZONE_SEPARATOR
 import com.infomaniak.core.utils.format
 import com.infomaniak.lib.core.InfomaniakCore
-import com.infomaniak.lib.core.R
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.api.ApiController.ApiMethod.*
 import com.infomaniak.lib.core.api.ApiController.toApiError

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -504,7 +504,7 @@ class MainViewModel @Inject constructor(
             if (isSuccess()) {
                 forceRefreshThreads()
             } else {
-                snackbarManager.postValue(appContext.getString(translatedError))
+                snackbarManager.postValue(appContext.getString(translateError()))
             }
         }
     }
@@ -654,7 +654,7 @@ class MainViewModel @Inject constructor(
                 else -> appContext.getString(R.string.snackbarMessageMoved, destination)
             }
         } else {
-            appContext.getString(apiResponses.first().translatedError)
+            appContext.getString(apiResponses.first().translateError())
         }
 
         val undoData = if (undoResources.isEmpty()) null else UndoData(undoResources, undoFoldersIds, undoDestinationId)
@@ -692,7 +692,7 @@ class MainViewModel @Inject constructor(
                 if (isSuccess()) {
                     refreshFoldersAsync(currentMailbox.value!!, ImpactedFolders(mutableSetOf(FolderRole.SCHEDULED_DRAFTS)))
                 } else {
-                    snackbarManager.postValue(title = appContext.getString(translatedError))
+                    snackbarManager.postValue(title = appContext.getString(translateError()))
                 }
             }
         } ?: run {
@@ -712,7 +712,7 @@ class MainViewModel @Inject constructor(
             refreshFoldersAsync(mailbox, ImpactedFolders(mutableSetOf(scheduledDraftsFolderId)))
             onSuccess()
         } else {
-            snackbarManager.postValue(title = appContext.getString(apiResponse.translatedError))
+            snackbarManager.postValue(title = appContext.getString(apiResponse.translateError()))
         }
     }
 
@@ -788,7 +788,7 @@ class MainViewModel @Inject constructor(
         val destination = destinationFolder.getLocalizedName(appContext)
 
         val snackbarTitle = when {
-            apiResponses.allFailed() -> appContext.getString(apiResponses.first().translatedError)
+            apiResponses.allFailed() -> appContext.getString(apiResponses.first().translateError())
             message == null -> appContext.resources.getQuantityString(R.plurals.snackbarThreadMoved, threads.count(), destination)
             else -> appContext.getString(R.string.snackbarMessageMoved, destination)
         }
@@ -1072,7 +1072,7 @@ class MainViewModel @Inject constructor(
                 if (getActionFolderRole(message.threads, message) != FolderRole.SPAM) toggleMessageSpamStatus(threadUid, message)
                 R.string.snackbarReportPhishingConfirmation
             } else {
-                translatedError
+                translateError()
             }
 
             reportPhishingTrigger.postValue(Unit)
@@ -1113,7 +1113,7 @@ class MainViewModel @Inject constructor(
 
         with(ApiRepository.blockUser(mailboxUuid, message.folderId, message.shortUid)) {
 
-            val snackbarTitle = if (isSuccess()) R.string.snackbarBlockUserConfirmation else translatedError
+            val snackbarTitle = if (isSuccess()) R.string.snackbarBlockUserConfirmation else translateError()
 
             snackbarManager.postValue(appContext.getString(snackbarTitle))
         }
@@ -1264,8 +1264,7 @@ class MainViewModel @Inject constructor(
 
         val snackbarTitle = when {
             failedCall == null -> R.string.snackbarMoveCancelled
-            failedCall.translatedError == 0 -> RCore.string.anErrorHasOccurred
-            else -> failedCall.translatedError
+            else -> failedCall.translateError()
         }
 
         snackbarManager.postValue(appContext.getString(snackbarTitle))
@@ -1356,7 +1355,7 @@ class MainViewModel @Inject constructor(
                 updateUserInfo()
                 R.string.snackbarContactSaved
             } else {
-                translatedError
+                translateError()
             }
 
             snackbarManager.postValue(appContext.getString(snackbarTitle))

--- a/app/src/main/java/com/infomaniak/mail/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/login/LoginActivity.kt
@@ -29,7 +29,7 @@ import com.infomaniak.lib.core.api.InternalTranslatedErrorCode
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.models.ApiResponseStatus
 import com.infomaniak.lib.core.networking.HttpClient
-import com.infomaniak.lib.core.utils.ErrorCode
+import com.infomaniak.lib.core.utils.ErrorCodeTranslated
 import com.infomaniak.lib.core.utils.Utils.lockOrientationForSmallScreens
 import com.infomaniak.lib.login.ApiToken
 import com.infomaniak.lib.login.InfomaniakLogin
@@ -132,7 +132,7 @@ class LoginActivity : AppCompatActivity() {
             }
         }
 
-        private fun getErrorResponse(error: ErrorCode.Translated): ApiResponse<Any> {
+        private fun getErrorResponse(error: ErrorCodeTranslated): ApiResponse<Any> {
             return ApiResponse(result = ApiResponseStatus.ERROR, error = error.toApiError())
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/InvalidPasswordFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/InvalidPasswordFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,6 +27,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import com.infomaniak.lib.core.utils.*
+import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
 import com.infomaniak.mail.MatomoMail.trackInvalidPasswordMailboxEvent
 import com.infomaniak.mail.R
@@ -119,7 +120,7 @@ class InvalidPasswordFragment : Fragment() {
         }
 
         invalidPasswordViewModel.requestPasswordResult.observe(viewLifecycleOwner) { apiResponse ->
-            showSnackbar(if (apiResponse.isSuccess()) R.string.snackbarMailboxPasswordRequested else apiResponse.translatedError)
+            showSnackbar(if (apiResponse.isSuccess()) R.string.snackbarMailboxPasswordRequested else apiResponse.translateError())
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/RestoreEmailsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/RestoreEmailsBottomSheetDialog.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,6 +30,7 @@ import com.infomaniak.core.utils.FORMAT_EVENT_DATE
 import com.infomaniak.core.utils.format
 import com.infomaniak.lib.core.MatomoCore.TrackerAction
 import com.infomaniak.lib.core.utils.*
+import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
 import com.infomaniak.mail.MatomoMail.trackRestoreMailsEvent
 import com.infomaniak.mail.R
@@ -104,7 +105,7 @@ class RestoreEmailsBottomSheetDialog : BottomSheetDialogFragment() {
                     }
                 }
             } else {
-                showSnackbar(apiResponse.translatedError)
+                showSnackbar(apiResponse.translateError())
                 findNavController().popBackStack()
             }
         }
@@ -118,7 +119,7 @@ class RestoreEmailsBottomSheetDialog : BottomSheetDialogFragment() {
         restoreEmailViewModel.restoreEmails(formattedDate).observe(viewLifecycleOwner) { apiResponse ->
             restoreEmailsButtonProgressTimer.cancel()
             binding.restoreMailsButton.hideProgressCatching(R.string.buttonConfirmRestoreEmails)
-            showSnackbar(if (apiResponse.isSuccess()) R.string.snackbarRestorationLaunched else apiResponse.translatedError)
+            showSnackbar(if (apiResponse.isSuccess()) R.string.snackbarRestorationLaunched else apiResponse.translateError())
             findNavController().popBackStack()
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/mailbox/SignatureSettingViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/mailbox/SignatureSettingViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.lib.core.utils.SingleLiveEvent
 import com.infomaniak.mail.data.api.ApiRepository
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
@@ -58,7 +59,7 @@ class SignatureSettingViewModel @Inject constructor(
             if (isSuccess()) {
                 updateSignatures()
             } else {
-                showError.postValue(translatedError)
+                showError.postValue(translateError())
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/user/AttachMailboxFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/user/AttachMailboxFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -120,7 +120,7 @@ class AttachMailboxFragment : Fragment() {
                 else -> {
                     mailInputLayout.error = null
                     passwordInputLayout.error = null
-                    showSnackbar(title = apiResponse.translatedError, anchor = attachMailboxButton)
+                    showSnackbar(title = apiResponse.translateError(), anchor = attachMailboxButton)
                 }
             }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/LoginUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/LoginUtils.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@ import com.infomaniak.lib.core.R
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.models.user.User
 import com.infomaniak.lib.core.networking.HttpClient
+import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.lib.login.ApiToken
 import com.infomaniak.lib.login.InfomaniakLogin
@@ -127,7 +128,7 @@ class LoginUtils @Inject constructor(
     }
 
     private suspend fun Context.apiError(apiResponse: ApiResponse<*>) = withContext(mainDispatcher) {
-        showError(getString(apiResponse.translatedError))
+        showError(getString(apiResponse.translateError()))
     }
 
     private suspend fun Context.otherError() = withContext(mainDispatcher) {

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -20,6 +20,7 @@ package com.infomaniak.mail.utils
 import androidx.fragment.app.Fragment
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.models.ApiResponse
+import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.mail.MatomoMail.trackEvent
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
@@ -200,7 +201,7 @@ class SharedUtils @Inject constructor(
                     if (apiException !is ApiController.NetworkException) {
                         Sentry.captureException(SignatureException(apiException.message, apiException))
                     }
-                    translatedError
+                    translateError()
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/AttachmentExt.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/AttachmentExt.kt
@@ -24,6 +24,7 @@ import android.os.Bundle
 import android.provider.MediaStore.Files.FileColumns
 import androidx.core.content.FileProvider
 import com.infomaniak.core.extensions.goToPlayStore
+import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.lib.core.utils.hasSupportedApplications
 import com.infomaniak.mail.R
@@ -140,7 +141,7 @@ object AttachmentExt {
             }
         } else {
             val baseMessage = "Upload failed for attachment $localUuid"
-            val errorMessage = "error : ${apiResponse?.translatedError}"
+            val errorMessage = "error : ${apiResponse?.translateError()}"
             SentryLog.i(
                 tag = ATTACHMENT_TAG,
                 msg = "$baseMessage - $errorMessage - data : ${apiResponse?.data}",


### PR DESCRIPTION
I bumped core to use the updated translateError() message and took this opportunity to update the usages of `translatedError` inside of mail because they weren't too hard to replace.

Depends on https://github.com/Infomaniak/android-core/pull/340