### PR TITLE
fix: Add missing folder name tags in search results

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -79,7 +79,7 @@ class ThreadController @Inject constructor(
     }
 
     /**
-     * Initialize and retrieve the search Threads obtained from the API.
+     * Initialize the search Threads obtained from the API.
      * - Format the remote Threads to make them compatible with the existing logic.
      * - Preserve old Messages data if it already exists locally.
      * - Handle duplicates using the existing logic.

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -43,7 +43,6 @@ import io.realm.kotlin.notifications.SingleQueryChange
 import io.realm.kotlin.query.*
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import javax.inject.Inject
 
@@ -77,32 +76,14 @@ class ThreadController @Inject constructor(
     fun getThreadAsync(uid: String): Flow<SingleQueryChange<Thread>> {
         return getThreadQuery(uid, mailboxContentRealm()).asFlow()
     }
-
-    /**
-     * Initialize the search Threads obtained from the API.
-     * - Format the remote Threads to make them compatible with the existing logic.
-     * - Preserve old Messages data if it already exists locally.
-     * - Handle duplicates using the existing logic.
-     * @param remoteThreads The list of API Threads that need to be processed.
-     * @param filterFolder The selected Folder on which we filter the Search.
-     */
-    suspend fun createSearchThreadsFromRemote(
-        remoteThreads: List<Thread>,
-        filterFolder: Folder?,
-    ): Unit = withContext(ioDispatcher) {
-        val threads = searchUtils.convertRemoteThreadsToSearchThreads(remoteThreads, filterFolder)
-        mailboxContentRealm().write { saveSearchThreads(threads) }
-    }
     //endregion
 
     //region Edit data
     suspend fun saveSearchThreads(searchThreads: List<Thread>) {
-        mailboxContentRealm().write { saveSearchThreads(searchThreads) }
-    }
-
-    private fun MutableRealm.saveSearchThreads(searchThreads: List<Thread>) {
-        FolderController.getOrCreateSearchFolder(realm = this).apply {
-            threads.replaceContent(searchThreads)
+        mailboxContentRealm().write {
+            FolderController.getOrCreateSearchFolder(realm = this).apply {
+                threads.replaceContent(searchThreads)
+            }
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -86,11 +86,11 @@ class ThreadController @Inject constructor(
      * @param remoteThreads The list of API Threads that need to be processed.
      * @param filterFolder The selected Folder on which we filter the Search.
      */
-    suspend fun initSearchFolderThreads(
+    suspend fun createSearchThreadsFromRemote(
         remoteThreads: List<Thread>,
         filterFolder: Folder?,
     ): Unit = withContext(ioDispatcher) {
-        val threads = searchUtils.convertApiThreadsToSearchThreads(remoteThreads, filterFolder)
+        val threads = searchUtils.convertRemoteThreadsToSearchThreads(remoteThreads, filterFolder)
         mailboxContentRealm().write { saveSearchThreads(threads) }
     }
     //endregion

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/ThreadResult.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/ThreadResult.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ThreadResult(
-    val threads: List<Thread>? = null,
+    val threads: List<Thread> = emptyList(),
     @SerialName("resource_previous")
     val resourcePrevious: String?,
     @SerialName("resource_next")

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -218,8 +218,8 @@ class SearchViewModel @Inject constructor(
         if (isFirstPage && isLastPage) searchUtils.deleteRealmSearchData()
 
         if (apiResponse.isSuccess()) {
-            createSearchThreadsFromRemote(apiResponse.data?.threads, folder)
             with(apiResponse) {
+                data?.let { createSearchThreadsFromRemote(it.threads, folder) }
                 resourceNext = data?.resourceNext
                 isFirstPage = data?.resourcePrevious == null
             }
@@ -240,12 +240,10 @@ class SearchViewModel @Inject constructor(
         visibilityMode.postValue(resultsVisibilityMode)
     }
 
-    private suspend fun createSearchThreadsFromRemote(apiThreads: List<Thread>?, folder: Folder?) {
+    private suspend fun createSearchThreadsFromRemote(remoteThreads: List<Thread>, folder: Folder?) {
         runCatching {
-            apiThreads?.let { remoteThreads ->
-                val threads = searchUtils.convertRemoteThreadsToSearchThreads(remoteThreads, folder)
-                threadController.saveSearchThreads(threads)
-            }
+            val searchThreads = searchUtils.convertRemoteThreadsToSearchThreads(remoteThreads, folder)
+            threadController.saveSearchThreads(searchThreads)
         }.getOrElse { exception ->
             exception.printStackTrace()
             Sentry.captureException(exception)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -237,7 +237,9 @@ class SearchViewModel @Inject constructor(
                 isFirstPage = data?.resourcePrevious == null
             }
         } else if (isLastPage) {
-            threadController.saveThreads(searchMessages = messageController.searchMessages(query, newFilters, folderId))
+            val searchMessages = messageController.searchMessages(query, newFilters, folderId)
+            val searchThreads = searchUtils.convertToSearchThreads(searchMessages)
+            threadController.saveSearchThreads(searchThreads)
         }
 
         if (folder != lastExecutedFolder) lastExecutedFolder = folder

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -243,7 +243,8 @@ class SearchViewModel @Inject constructor(
     private suspend fun createSearchThreadsFromRemote(apiThreads: List<Thread>?, folder: Folder?) {
         runCatching {
             apiThreads?.let { remoteThreads ->
-                threadController.createSearchThreadsFromRemote(remoteThreads, folder)
+                val threads = searchUtils.convertRemoteThreadsToSearchThreads(remoteThreads, folder)
+                threadController.saveSearchThreads(threads)
             }
         }.getOrElse { exception ->
             exception.printStackTrace()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -166,7 +166,7 @@ class SearchViewModel @Inject constructor(
         folder: Folder? = filterFolder,
         shouldGetNextPage: Boolean = false,
     ) = withContext(ioCoroutineContext) {
-        searchJob?.cancel()
+        cancelSearch()
         searchJob = launch {
             delay(SEARCH_DEBOUNCE_DURATION)
             ensureActive()
@@ -213,7 +213,7 @@ class SearchViewModel @Inject constructor(
         val searchFilters = searchUtils.searchFilters(query, newFilters, resource)
         val apiResponse = ApiRepository.searchThreads(currentMailbox.uuid, folderId, searchFilters, resource)
 
-        searchJob?.ensureActive()
+        currentCoroutineContext().ensureActive()
 
         if (isFirstPage && isLastPage) searchUtils.deleteRealmSearchData()
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -210,7 +210,7 @@ class SearchViewModel @Inject constructor(
         suspend fun ApiResponse<ThreadResult>.initSearchFolderThreads() {
             runCatching {
                 data?.threads?.let { remoteThreads ->
-                    threadController.initAndGetSearchFolderThreads(remoteThreads, folder)
+                    threadController.initSearchFolderThreads(remoteThreads, folder)
                 }
             }.getOrElse { exception ->
                 exception.printStackTrace()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchViewModel.kt
@@ -238,7 +238,7 @@ class SearchViewModel @Inject constructor(
             }
         } else if (isLastPage) {
             val searchMessages = messageController.searchMessages(query, newFilters, folderId)
-            val searchThreads = searchUtils.convertToSearchThreads(searchMessages)
+            val searchThreads = searchUtils.convertLocalMessagesToSearchThreads(searchMessages)
             threadController.saveSearchThreads(searchThreads)
         }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -28,7 +28,7 @@ import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.data.models.thread.Thread.ThreadFilter
 import com.infomaniak.mail.di.IoDispatcher
 import dagger.hilt.android.qualifiers.ApplicationContext
-import io.realm.kotlin.TypedRealm
+import io.realm.kotlin.Realm
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -104,11 +104,11 @@ class SearchUtils @Inject constructor(
          * Thread processing that applies to both search threads from the api and from realm. Be careful, it relies on
          * [Thread.folderId] being set correctly.
          */
-        fun Thread.sharedThreadProcessing(context: Context, cachedFolderNames: MutableMap<String, String>, realm: TypedRealm) {
+        fun Thread.sharedThreadProcessing(context: Context, cachedFolderNames: MutableMap<String, String>, realm: Realm) {
             setFolderName(cachedFolderNames, realm, context)
         }
 
-        private fun Thread.setFolderName(cachedFolderNames: MutableMap<String, String>, realm: TypedRealm, context: Context) {
+        private fun Thread.setFolderName(cachedFolderNames: MutableMap<String, String>, realm: Realm, context: Context) {
             val computedFolderName = cachedFolderNames[folderId]
                 ?: FolderController.getFolder(folderId, realm)
                     ?.getLocalizedName(context)

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -101,7 +101,7 @@ class SearchUtils @Inject constructor(
         }
     }
 
-    suspend fun convertApiThreadsToSearchThreads(remoteThreads: List<Thread>, filterFolder: Folder?): List<Thread> {
+    suspend fun convertRemoteThreadsToSearchThreads(remoteThreads: List<Thread>, filterFolder: Folder?): List<Thread> {
         val cachedFolderNames = mutableMapOf<String, String>()
         return remoteThreads.map { remoteThread ->
             currentCoroutineContext().ensureActive()

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -101,6 +101,14 @@ class SearchUtils @Inject constructor(
         }
     }
 
+    /**
+     * Initialize the search Threads obtained from the API.
+     * - Format the remote Threads to make them compatible with the existing logic.
+     * - Preserve old Messages data if it already exists locally.
+     * - Handle duplicates using the existing logic.
+     * @param remoteThreads The list of API Threads that need to be processed.
+     * @param filterFolder The selected Folder on which we filter the Search.
+     */
     suspend fun convertRemoteThreadsToSearchThreads(remoteThreads: List<Thread>, filterFolder: Folder?): List<Thread> {
         val cachedFolderNames = mutableMapOf<String, String>()
         return remoteThreads.map { remoteThread ->


### PR DESCRIPTION
Some folder name tags were missing from the search when fetching API threads on some occasions and they were always missing from the local realm search. This PR fixes this issue by introducing some shared Thread processing between the API and Realm searches. The shared processing is only comprised of the folder name computation for now.

To put this processing in common, I had to move around some of the current processing. I managed to regroup all search threads processing in the same SearchUtils file. I also decoupled the place where threads state is processed from the place where threads are saved to Realm as "search results"