### PR TITLE
fix: Revert "fix: Clean view holder in ThreadFragment when view is recycled to avoid crashes (#2330)"

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/AttachmentAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/AttachmentAdapter.kt
@@ -76,19 +76,10 @@ class AttachmentAdapter(
 
     override fun getItemCount(): Int = runCatchingRealm { attachments.count() }.getOrDefault(0)
 
-    override fun onViewRecycled(holder: AttachmentViewHolder) {
-        super.onViewRecycled(holder)
-        holder.onViewRecycled()
-    }
-
     fun submitList(newList: List<Attachable>) = runCatchingRealm {
         attachments.clear()
         attachments.addAll(newList)
         notifyDataSetChanged()
-    }
-
-    fun clear() {
-        attachments.clear()
     }
 
     private fun ItemAttachmentBinding.toggleEndIconVisibility(shouldDisplayCloseButton: Boolean) {
@@ -96,10 +87,5 @@ class AttachmentAdapter(
         moreButton.isVisible = !shouldDisplayCloseButton
     }
 
-    class AttachmentViewHolder(val binding: ItemAttachmentBinding) : ViewHolder(binding.root) {
-
-        fun onViewRecycled() {
-            binding.attachmentDetails.cleanUp()
-        }
-    }
+    class AttachmentViewHolder(val binding: ItemAttachmentBinding) : ViewHolder(binding.root)
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/DetailedRecipientAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/DetailedRecipientAdapter.kt
@@ -59,10 +59,5 @@ class DetailedRecipientAdapter(
         bimi = newBimi
     }
 
-    fun clear() {
-        recipients = emptyList()
-        bimi = null
-    }
-
     class DetailedRecipientViewHolder(val binding: ItemDetailedContactBinding) : ViewHolder(binding.root)
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -257,11 +257,6 @@ class ThreadAdapter(
         }
     }
 
-    override fun onViewRecycled(holder: ThreadAdapterViewHolder) {
-        super.onViewRecycled(holder)
-        if (holder is MessageViewHolder) holder.onViewRecycled()
-    }
-
     private fun initMapForNewMessage(message: Message, position: Int) = with(threadAdapterState) {
         if (isExpandedMap[message.uid] == null) {
             isExpandedMap[message.uid] = message.shouldBeExpanded(position, items.lastIndex)
@@ -980,27 +975,6 @@ class ThreadAdapter(
                     onWebViewFinishedLoading = onWebViewFinishedLoading,
                 )
             }
-        }
-
-        fun onViewRecycled() {
-            binding.bodyWebView.clearWebView()
-            _bodyWebViewClient = null
-
-            binding.fullMessageWebView.clearWebView()
-            _fullMessageWebViewClient = null
-
-            fromAdapter.clear()
-            toAdapter.clear()
-            ccAdapter.clear()
-            bccAdapter.clear()
-            attachmentAdapter.clear()
-        }
-
-        private fun WebView.clearWebView() {
-            stopLoading()
-            clearHistory()
-            loadUrl("about:blank")
-            destroy()
         }
 
         private fun ItemMessageBinding.promptUserForDistantImages() {

--- a/app/src/main/java/com/infomaniak/mail/views/AttachmentDetailsView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/AttachmentDetailsView.kt
@@ -23,7 +23,6 @@ import android.view.LayoutInflater
 import android.widget.LinearLayout
 import androidx.annotation.DimenRes
 import androidx.annotation.StyleRes
-import coil.dispose
 import coil.load
 import com.infomaniak.core.FormatterFileSize.formatShortFileSize
 import com.infomaniak.lib.core.utils.getAttributes
@@ -68,10 +67,6 @@ class AttachmentDetailsView @JvmOverloads constructor(
         fileName.text = attachment.name
         fileSize.text = context.formatShortFileSize(attachment.size)
         icon.load(attachment.getFileTypeFromMimeType().icon)
-    }
-
-    fun cleanUp() {
-        binding.icon.dispose()
     }
 
     private enum class DisplayStyle(


### PR DESCRIPTION
This reverts commit 2b3c45ec5ad897f2c9605999a48be84d7dc8baf7, reversing changes made to a5388aa3bd69f03db870790241f73dd86d416680.

When you have a long thread with multiple messages in it (mine had 8), when you expand all messages, some of them do not display their content anymore since the fix introduced in PR #2330.

There isn't much info on what that fix was supposed to fix but it broke something even more important maybe.