### PR TITLE
feat: Display messages coming from the snooze folder as such in the search

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/NamedFolder.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/NamedFolder.kt
@@ -1,0 +1,39 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.ui.main.search
+
+import android.content.Context
+import com.infomaniak.mail.data.models.Folder
+
+sealed interface NamedFolder {
+    data class Role(val role: Folder.FolderRole) : NamedFolder {
+        override fun getName(context: Context): String = context.getString(role.folderNameRes)
+    }
+
+    data class Custom(val name: String) : NamedFolder {
+        override fun getName(context: Context): String = name
+    }
+
+    fun getName(context: Context): String
+
+    companion object {
+        fun fromFolder(folder: Folder, context: Context): NamedFolder = folder.role.let { role ->
+            if (role != null) Role(role) else Custom(folder.getLocalizedName(context))
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -177,6 +177,7 @@ private fun Thread.setFolderName(cachedNamedFolders: MutableMap<String, NamedFol
             ?.let { NamedFolder.fromFolder(it, context) }
             ?.also { cachedNamedFolders[folderId] = it }
 
+    // If the remote folder id is inbox and the thread is snoozed, instead of using its default name, change it to snooze
     val computedFolderName = cachedNamedFolder?.let {
         if (it is NamedFolder.Role && it.role == FolderRole.INBOX && isSnoozed()) {
             context.getString(FolderRole.SNOOZED.folderNameRes)

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -177,12 +177,16 @@ private fun Thread.setFolderName(cachedNamedFolders: MutableMap<String, NamedFol
             ?.let { NamedFolder.fromFolder(it, context) }
             ?.also { cachedNamedFolders[folderId] = it }
 
-    // If the remote folder id is inbox and the thread is snoozed, instead of using its default name, change it to snooze
-    cachedNamedFolder?.let {
-        folderName = if (it is NamedFolder.Role && it.role == FolderRole.INBOX && isSnoozed()) {
-            context.getString(FolderRole.SNOOZED.folderNameRes)
-        } else {
-            it.getName(context)
-        }
+    cachedNamedFolder?.let { namedFolder ->
+        folderName = namedFolder.computeDisplayedName(thread = this, context)
+    }
+}
+
+// If the remote folder id is inbox and the thread is snoozed, instead of using its default name, change it to snooze
+private fun NamedFolder.computeDisplayedName(thread: Thread, context: Context): String {
+    return if (this is NamedFolder.Role && role == FolderRole.INBOX && thread.isSnoozed()) {
+        context.getString(FolderRole.SNOOZED.folderNameRes)
+    } else {
+        getName(context)
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -178,13 +178,11 @@ private fun Thread.setFolderName(cachedNamedFolders: MutableMap<String, NamedFol
             ?.also { cachedNamedFolders[folderId] = it }
 
     // If the remote folder id is inbox and the thread is snoozed, instead of using its default name, change it to snooze
-    val computedFolderName = cachedNamedFolder?.let {
-        if (it is NamedFolder.Role && it.role == FolderRole.INBOX && isSnoozed()) {
+    cachedNamedFolder?.let {
+        folderName = if (it is NamedFolder.Role && it.role == FolderRole.INBOX && isSnoozed()) {
             context.getString(FolderRole.SNOOZED.folderNameRes)
         } else {
             it.getName(context)
         }
     }
-
-    computedFolderName?.let { folderName = it }
 }


### PR DESCRIPTION
When a search thread has a remote folder id of "inbox" and is snoozed, we need to alter the displayed origin folder name in the search to display "snooze" instead. Snoozed folders are always located inside of inbox, therefore only deriving the displayed origin name from the remote folder id is not enough because of snooze.

Depends on #2347 