### PR TITLE
perf: Do not call recomputeTwinFoldersThreadsDependantProperties when nothing has changed

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -535,6 +535,7 @@ class RefreshController @Inject constructor(
         folderId: String,
         currentFolderRefreshStrategy: RefreshStrategy,
     ): ImpactedFolders {
+        if (shortUids.isEmpty()) return ImpactedFolders()
 
         val threads = mutableSetOf<Thread>()
         shortUids.forEach { shortUid ->


### PR DESCRIPTION
Was previously called for no reason even when no uids were deleted