### PR TITLE
chore: Bump playServices library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility javaVersion
         targetCompatibility javaVersion
     }
@@ -123,6 +124,8 @@ dependencies {
     implementation libs.sentry.android.fragment
 
     implementation libs.coil.svg
+
+    coreLibraryDesugaring libs.desugar.jdk
 
     // Compose
     implementation libs.compose.ui.android

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,8 @@
 [versions]
 androidGradlePlugin = "8.8.2"
 coilSvg = "2.7.0"
-compose = "1.7.8"
+compose = "1.7.8" # Doesn't build when bumped (waiting for Android SDK 35)
+desugarJDK = "2.1.5"
 dotsindicator = "5.1.0"
 dragDropSwipeRecyclerView = "1.0.0"
 firebaseMessagingKtx = "24.1.1"
@@ -18,7 +19,7 @@ leakcanaryAndroid = "2.12"
 lifecycleProcess = "2.8.7"
 lottie = "6.6.6"
 navigation = "2.8.9"
-playServices = "18.6.0"
+playServices = "18.7.0"
 realmKotlin = "3.0.0"
 richHtmlEditor = "0.2.0"
 sentryAndroidFragment = "8.10.0"
@@ -30,6 +31,7 @@ workRuntimeKtx = "2.9.1" # Doesn't build when bumped (waiting for Android SDK 35
 coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coilSvg" }
 compose-ui-android = { group = "androidx.compose.ui", name = "ui-android", version.ref = "compose" }
 dotsindicator = { module = "com.tbuonomo:dotsindicator", version.ref = "dotsindicator" }
+desugar-jdk = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJDK" }
 dragdropswipe-recyclerview = { module = "com.github.infomaniak:DragDropSwipeRecyclerview", version.ref = "dragDropSwipeRecyclerView" }
 firebase-messaging-ktx = { module = "com.google.firebase:firebase-messaging-ktx", version.ref = "firebaseMessagingKtx" }
 flexbox = { module = "com.google.android.flexbox:flexbox", version.ref = "flexbox" }


### PR DESCRIPTION
It required to use desugaring for the updated java api as explained in their patch note