### PR TITLE
fix: Detect more valid email adresses

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/Extensions.kt
@@ -33,7 +33,6 @@ import android.text.Spannable
 import android.text.Spanned
 import android.text.TextUtils
 import android.text.style.ClickableSpan
-import android.util.Patterns
 import android.view.View
 import android.view.Window
 import android.view.inputmethod.EditorInfo
@@ -63,6 +62,7 @@ import com.google.android.material.imageview.ShapeableImageView
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.infomaniak.core.utils.endOfTheWeek
+import com.infomaniak.core.utils.isEmailRfc5321Compliant
 import com.infomaniak.core.utils.startOfTheDay
 import com.infomaniak.core.utils.startOfTheWeek
 import com.infomaniak.dragdropswiperecyclerview.DragDropSwipeRecyclerView
@@ -134,7 +134,7 @@ fun Fragment.notYetImplemented(anchor: View? = null) = showSnackbar(getString(R.
 
 fun Activity.notYetImplemented(anchor: View? = null) = showSnackbar(getString(R.string.workInProgressTitle), anchor)
 
-fun String.isEmail(): Boolean = Patterns.EMAIL_ADDRESS.matcher(this).matches()
+fun String.isEmail(): Boolean = isEmailRfc5321Compliant()
 
 fun String.removeLineBreaksFromHtml(): Document = jsoupParseWithLog(replace("\r", "").replace("\n", ""))
 


### PR DESCRIPTION
Some adresses with special characters such as `'` would not be considered valid on Android but they are indeed valid on web or iOS. Here the code is modified to use the same valid email regex as iOS

Depends on https://github.com/Infomaniak/android-core/pull/365
Depends on https://github.com/Infomaniak/android-kMail/pull/2367