### PR TITLE
refactor: Remove "reassign" methods and use single centralized flows to handle message logic

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/PrintMailFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/PrintMailFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -62,7 +62,7 @@ class PrintMailFragment : Fragment() {
             threadAdapter.submitList(items)
         }
 
-        threadViewModel.reassignMessagesLiveWithoutSuperCollapsedBlock(navigationArgs.messageUid)
+        threadViewModel.updateCurrentThreadUid(threadViewModel.SingleMessage(navigationArgs.messageUid))
     }
 
     private fun setupAdapter() = with(threadViewModel) {
@@ -72,7 +72,6 @@ class PrintMailFragment : Fragment() {
             threadAdapterState = object : ThreadAdapterState {
                 override val isExpandedMap by threadState::isExpandedMap
                 override val isThemeTheSameMap by threadState::isThemeTheSameMap
-                override val hasSuperCollapsedBlockBeenClicked by threadState::hasSuperCollapsedBlockBeenClicked
                 override val verticalScroll by threadState::verticalScroll
                 override val isCalendarEventExpandedMap by threadState::isCalendarEventExpandedMap
             },

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -805,7 +805,7 @@ class ThreadFragment : Fragment() {
     }
 
     private fun expandSuperCollapsedBlock() {
-        threadViewModel.threadState.hasSuperCollapsedBlockBeenClicked.value = true
+        threadViewModel.threadState.clickSuperCollapsedBlock()
     }
 
     private fun navigateToAttendees(attendees: List<Attendee>) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -280,7 +280,6 @@ class ThreadFragment : Fragment() {
             threadAdapterState = object : ThreadAdapterState {
                 override val isExpandedMap by threadState::isExpandedMap
                 override val isThemeTheSameMap by threadState::isThemeTheSameMap
-                override val hasSuperCollapsedBlockBeenClicked by threadState::hasSuperCollapsedBlockBeenClicked
                 override val verticalScroll by threadState::verticalScroll
                 override val isCalendarEventExpandedMap by threadState::isCalendarEventExpandedMap
             },
@@ -412,23 +411,20 @@ class ThreadFragment : Fragment() {
         phoneContextualMenuAlertDialog.initValues(snackbarManager)
     }
 
-    private fun observeThreadOpening() = with(threadViewModel) {
-
+    private fun observeThreadOpening() {
         twoPaneViewModel.currentThreadUid.distinctUntilChanged().observeNotNull(viewLifecycleOwner) { threadUid ->
-
             displayThreadView()
+            threadViewModel.updateCurrentThreadUid(threadViewModel.AllMessages(threadUid))
+        }
 
-            openThread(threadUid).observe(viewLifecycleOwner) { thread ->
-
+        lifecycleScope.launch {
+            threadViewModel.threadFlow.collect { thread ->
                 if (thread == null) {
                     twoPaneViewModel.closeThread()
-                    return@observe
+                    return@collect
                 }
 
-                initUi(threadUid, folderRole = mainViewModel.getActionFolderRole(thread))
-
-                reassignThreadLive(threadUid)
-                reassignMessagesLive(threadUid)
+                initUi(thread.uid, folderRole = mainViewModel.getActionFolderRole(thread))
             }
         }
     }
@@ -488,7 +484,7 @@ class ThreadFragment : Fragment() {
                 return@observe
             }
 
-            if (threadState.hasSuperCollapsedBlockBeenClicked) {
+            if (threadState.hasSuperCollapsedBlockBeenClicked.value) {
                 displayBatchedMessages(items)
             } else {
                 threadAdapter.submitList(items)
@@ -808,9 +804,8 @@ class ThreadFragment : Fragment() {
         binding.messagesListNestedScrollView.scrollY = scrollY
     }
 
-    private fun expandSuperCollapsedBlock() = with(threadViewModel) {
-        threadState.hasSuperCollapsedBlockBeenClicked = true
-        reassignMessagesLive(twoPaneViewModel.currentThreadUid.value!!)
+    private fun expandSuperCollapsedBlock() {
+        threadViewModel.threadState.hasSuperCollapsedBlockBeenClicked.value = true
     }
 
     private fun navigateToAttendees(attendees: List<Attendee>) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadState.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadState.kt
@@ -19,11 +19,11 @@ package com.infomaniak.mail.ui.main.thread
 
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.SuperCollapsedBlock
 import com.infomaniak.mail.utils.MessageBodyUtils.SplitBody
+import kotlinx.coroutines.flow.MutableStateFlow
 
 interface ThreadAdapterState {
     val isExpandedMap: MutableMap<String, Boolean>
     val isThemeTheSameMap: MutableMap<String, Boolean>
-    val hasSuperCollapsedBlockBeenClicked: Boolean
     val verticalScroll: Int?
     val isCalendarEventExpandedMap: MutableMap<String, Boolean>
 }
@@ -32,7 +32,7 @@ class ThreadState {
 
     val isExpandedMap: MutableMap<String, Boolean> = mutableMapOf()
     val isThemeTheSameMap: MutableMap<String, Boolean> = mutableMapOf()
-    var hasSuperCollapsedBlockBeenClicked: Boolean = false
+    var hasSuperCollapsedBlockBeenClicked: MutableStateFlow<Boolean> = MutableStateFlow(false)
     var verticalScroll: Int? = null
     val isCalendarEventExpandedMap: MutableMap<String, Boolean> = mutableMapOf()
     val treatedMessagesForCalendarEvent: MutableSet<String> = mutableSetOf()
@@ -43,7 +43,7 @@ class ThreadState {
     fun reset() {
         isExpandedMap.clear()
         isThemeTheSameMap.clear()
-        hasSuperCollapsedBlockBeenClicked = false
+        hasSuperCollapsedBlockBeenClicked.value = false
         verticalScroll = null
         isCalendarEventExpandedMap.clear()
         treatedMessagesForCalendarEvent.clear()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadState.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadState.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +20,8 @@ package com.infomaniak.mail.ui.main.thread
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.SuperCollapsedBlock
 import com.infomaniak.mail.utils.MessageBodyUtils.SplitBody
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 interface ThreadAdapterState {
     val isExpandedMap: MutableMap<String, Boolean>
@@ -32,7 +34,8 @@ class ThreadState {
 
     val isExpandedMap: MutableMap<String, Boolean> = mutableMapOf()
     val isThemeTheSameMap: MutableMap<String, Boolean> = mutableMapOf()
-    var hasSuperCollapsedBlockBeenClicked: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    private val _hasSuperCollapsedBlockBeenClicked: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val hasSuperCollapsedBlockBeenClicked: StateFlow<Boolean> = _hasSuperCollapsedBlockBeenClicked.asStateFlow()
     var verticalScroll: Int? = null
     val isCalendarEventExpandedMap: MutableMap<String, Boolean> = mutableMapOf()
     val treatedMessagesForCalendarEvent: MutableSet<String> = mutableSetOf()
@@ -43,12 +46,16 @@ class ThreadState {
     fun reset() {
         isExpandedMap.clear()
         isThemeTheSameMap.clear()
-        hasSuperCollapsedBlockBeenClicked.value = false
+        _hasSuperCollapsedBlockBeenClicked.value = false
         verticalScroll = null
         isCalendarEventExpandedMap.clear()
         treatedMessagesForCalendarEvent.clear()
         cachedSplitBodies.clear()
         isFirstOpening = true
         superCollapsedBlock = null
+    }
+
+    fun clickSuperCollapsedBlock() {
+        _hasSuperCollapsedBlockBeenClicked.value = true
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -85,6 +85,8 @@ class ThreadViewModel @Inject constructor(
 
     val threadFlow: Flow<Thread?> = threadOpeningModeFlow
         .map { mode -> mode.threadUid?.let(threadController::getThread) }
+        // replay = 1 is needed because the UI relies on this flow to set click listeners. If there's a config change but no
+        // replay value, the click listeners won't ever be set
         .shareIn(viewModelScope, SharingStarted.Lazily, replay = 1)
 
     // Could this directly collect threadOpeningModeFlow instead of collecting threadFlow?

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -54,7 +54,6 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import kotlin.collections.set
 
 typealias ThreadAdapterItems = List<Any>
 typealias MessagesWithoutHeavyData = List<Message>
@@ -80,7 +79,7 @@ class ThreadViewModel @Inject constructor(
     val threadState = ThreadState()
 
     private val threadOpeningModeFlow: MutableSharedFlow<ThreadOpeningMode> = MutableSharedFlow(replay = 1)
-    val threadFlow: Flow<Thread?> = threadOpeningModeFlow.map { mode -> mode.threadUid?.let { threadController.getThread(it) } }
+    val threadFlow: Flow<Thread?> = threadOpeningModeFlow.map { mode -> mode.threadUid?.let(threadController::getThread) }
 
     // Could this directly collect threadOpeningModeFlow instead of collecting threadFlow?
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -290,30 +290,6 @@ class ThreadViewModel @Inject constructor(
         sendBatchesRecursively(input = items, output = mutableListOf(), batchSize = 2)
     }
 
-    fun openThread(threadUid: String) = liveData(ioCoroutineContext) {
-
-        val thread = threadController.getThread(threadUid) ?: run {
-            emit(null)
-            return@liveData
-        }
-
-        // These 2 will always be empty or not all together at the same time.
-        if (threadState.isExpandedMap.isEmpty() || threadState.isThemeTheSameMap.isEmpty()) {
-            thread.messages.forEachIndexed { index, message ->
-                threadState.isExpandedMap[message.uid] = message.shouldBeExpanded(index, thread.messages.lastIndex)
-                threadState.isThemeTheSameMap[message.uid] = true
-            }
-        }
-
-        if (threadState.isFirstOpening) {
-            threadState.isFirstOpening = false
-            sendMatomoAndSentryAboutThreadMessagesCount(thread)
-            if (thread.isSeen.not()) markThreadAsSeen(thread)
-        }
-
-        emit(thread)
-    }
-
     private fun markThreadAsSeen(thread: Thread) = viewModelScope.launch(ioCoroutineContext) {
         sharedUtils.markAsSeen(mailbox, listOf(thread))
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -78,7 +78,7 @@ class ThreadViewModel @Inject constructor(
 
     val threadState = ThreadState()
 
-    private val threadOpeningModeFlow: MutableSharedFlow<ThreadOpeningMode> = MutableSharedFlow(replay = 1)
+    private val threadOpeningModeFlow: MutableSharedFlow<ThreadOpeningMode> = MutableSharedFlow()
     val threadFlow: Flow<Thread?> = threadOpeningModeFlow.map { mode -> mode.threadUid?.let(threadController::getThread) }
 
     // Could this directly collect threadOpeningModeFlow instead of collecting threadFlow?

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -81,11 +81,11 @@ class ThreadViewModel @Inject constructor(
     @DoNotReadDirectly
     private val _threadOpeningModeFlow: MutableSharedFlow<ThreadOpeningMode> = MutableSharedFlow(replay = 1)
     @OptIn(DoNotReadDirectly::class)
-    private val threadOpeningModeFlow = _threadOpeningModeFlow.distinctUntilChanged()
+    private val threadOpeningModeFlow = _threadOpeningModeFlow.distinctUntilChangedBy { it.threadUid }
 
     val threadFlow: Flow<Thread?> = threadOpeningModeFlow
         .map { mode -> mode.threadUid?.let(threadController::getThread) }
-        .shareIn(viewModelScope, SharingStarted.Lazily)
+        .shareIn(viewModelScope, SharingStarted.Lazily, 1)
 
     // Could this directly collect threadOpeningModeFlow instead of collecting threadFlow?
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -79,7 +79,9 @@ class ThreadViewModel @Inject constructor(
     val threadState = ThreadState()
 
     private val threadOpeningModeFlow: MutableSharedFlow<ThreadOpeningMode> = MutableSharedFlow()
-    val threadFlow: Flow<Thread?> = threadOpeningModeFlow.map { mode -> mode.threadUid?.let(threadController::getThread) }
+    val threadFlow: Flow<Thread?> = threadOpeningModeFlow
+        .map { mode -> mode.threadUid?.let(threadController::getThread) }
+        .shareIn(viewModelScope, SharingStarted.Lazily)
 
     // Could this directly collect threadOpeningModeFlow instead of collecting threadFlow?
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
This logic was too highly coupled which made it very hard to make the changes I needed for the reaction feature. This refactor removes the `reassignMessagesLive` and `reassignThreadLive` and replaces them with flows for each value