### PR TITLE
feat: Hide reaction messages

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.data.cache.mailboxContent
 
 import android.content.Context
+import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import com.infomaniak.mail.data.models.mailbox.Mailbox
@@ -42,14 +43,19 @@ import io.realm.kotlin.query.Sort
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class MessageController @Inject constructor(private val mailboxContentRealm: RealmDatabase.MailboxContent) {
+class MessageController @Inject constructor(
+    private val mailboxContentRealm: RealmDatabase.MailboxContent,
+    private val localSettings: LocalSettings,
+) {
 
     //region Queries
-    private fun getSortedAndNotDeletedMessagesQuery(threadUid: String): RealmQuery<Message>? {
+    private fun getSortedAndNotDeletedMessagesQuery(
+        threadUid: String,
+        featureFlags: Mailbox.FeatureFlagSet?,
+    ): RealmQuery<Message>? {
         return ThreadController.getThread(threadUid, mailboxContentRealm())
-            ?.getDisplayedMessages()
+            ?.getDisplayedMessages(featureFlags, localSettings)
             ?.query("${Message::isDeletedOnApi.name} == false")
-            ?.query("${Message::emojiReaction.name} == $0", null)
             ?.sort(Message::internalDate.name, Sort.ASCENDING)
     }
     //endregion
@@ -59,7 +65,7 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
         return getMessage(uid, mailboxContentRealm())
     }
 
-    fun getLastMessageToExecuteAction(thread: Thread): Message = with(thread) {
+    fun getLastMessageToExecuteAction(thread: Thread, featureFlags: Mailbox.FeatureFlagSet?): Message = with(thread) {
 
         fun RealmQuery<Message>.last(): Message? = sort(Message::internalDate.name, Sort.DESCENDING).first().find()
 
@@ -74,16 +80,17 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
                 " AND \$recipient.${Recipient::email.name} ENDSWITH '${end}'" +
                 ").@count < 1"
 
-        return getDisplayedMessages().query("$isNotDraft AND $isNotScheduledDraft AND $isNotFromRealMe AND $isNotFromPlusMe").last()
-            ?: getDisplayedMessages().query("$isNotDraft AND $isNotScheduledDraft").last()
-            ?: getDisplayedMessages().query(isNotScheduledDraft).last()
-            ?: getDisplayedMessages().last()
+        val messages = getDisplayedMessages(featureFlags, localSettings)
+        return messages.query("$isNotDraft AND $isNotScheduledDraft AND $isNotFromRealMe AND $isNotFromPlusMe").last()
+            ?: messages.query("$isNotDraft AND $isNotScheduledDraft").last()
+            ?: messages.query(isNotScheduledDraft).last()
+            ?: messages.last()
     }
 
-    fun getLastMessageAndItsDuplicatesToExecuteAction(thread: Thread): List<Message> {
+    fun getLastMessageAndItsDuplicatesToExecuteAction(thread: Thread, featureFlags: Mailbox.FeatureFlagSet?): List<Message> {
         return getMessageAndDuplicates(
             thread = thread,
-            message = getLastMessageToExecuteAction(thread),
+            message = getLastMessageToExecuteAction(thread, featureFlags),
         )
     }
 
@@ -105,13 +112,13 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
     }
 
     private fun getMessagesAndTheirDuplicates(thread: Thread, query: String): List<Message> {
-        val messages = thread.getDisplayedMessages().query(query).find()
+        val messages = thread.messages.query(query).find()
         val duplicates = thread.duplicates.query("${Message::messageId.name} IN $0", messages.map { it.messageId }).find()
         return messages + duplicates
     }
 
     private fun getMessagesAndDuplicates(thread: Thread, query: String): List<Message> {
-        val messages = thread.getDisplayedMessages().query(query).find()
+        val messages = thread.messages.query(query).find()
         val duplicates = thread.duplicates.query(query).find()
         return messages + duplicates
     }
@@ -152,16 +159,19 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
         }.find().copyFromRealm()
     }
 
-    fun getSortedAndNotDeletedMessagesAsync(threadUid: String): Flow<ResultsChange<Message>>? {
-        return getSortedAndNotDeletedMessagesQuery(threadUid)?.asFlow()
+    fun getSortedAndNotDeletedMessagesAsync(
+        threadUid: String,
+        featureFlags: Mailbox.FeatureFlagSet?,
+    ): Flow<ResultsChange<Message>>? {
+        return getSortedAndNotDeletedMessagesQuery(threadUid, featureFlags)?.asFlow()
     }
 
     fun getMessageAsync(messageUid: String): Flow<SingleQueryChange<Message>> {
         return getMessagesQuery(messageUid, mailboxContentRealm()).first().asFlow()
     }
 
-    fun getMessagesCountInThread(threadUid: String, realm: Realm): Int? {
-        return ThreadController.getThread(threadUid, realm)?.getDisplayedMessages()?.count()
+    fun getMessagesCountInThread(threadUid: String, featureFlags: Mailbox.FeatureFlagSet?, realm: Realm): Int? {
+        return ThreadController.getThread(threadUid, realm)?.getDisplayedMessages(featureFlags, localSettings)?.count()
     }
     //endregion
 
@@ -198,7 +208,7 @@ class MessageController @Inject constructor(private val mailboxContentRealm: Rea
 
         fun getThreadLastMessageInFolder(threadUid: String, realm: TypedRealm): Message? {
             val thread = ThreadController.getThread(threadUid, realm)
-            return thread?.getDisplayedMessages()?.query("${Message::folderId.name} == $0", thread.folderId)?.find()?.lastOrNull()
+            return thread?.messages?.query("${Message::folderId.name} == $0", thread.folderId)?.find()?.lastOrNull()
         }
         //endregion
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
@@ -65,8 +65,7 @@ class MessageController @Inject constructor(
         return getMessage(uid, mailboxContentRealm())
     }
 
-    fun getLastMessageToExecuteAction(thread: Thread, featureFlags: Mailbox.FeatureFlagSet?): Message = with(thread) {
-
+    fun getLastMessageToExecuteAction(thread: Thread, featureFlags: Mailbox.FeatureFlagSet?): Message {
         fun RealmQuery<Message>.last(): Message? = sort(Message::internalDate.name, Sort.DESCENDING).first().find()
 
         val isNotScheduledDraft = "${Message::isScheduledDraft.name} == false"
@@ -80,7 +79,7 @@ class MessageController @Inject constructor(
                 " AND \$recipient.${Recipient::email.name} ENDSWITH '${end}'" +
                 ").@count < 1"
 
-        val messages = getDisplayedMessages(featureFlags, localSettings)
+        val messages = thread.getDisplayedMessages(featureFlags, localSettings)
         return messages.query("$isNotDraft AND $isNotScheduledDraft AND $isNotFromRealMe AND $isNotFromPlusMe").last()
             ?: messages.query("$isNotDraft AND $isNotScheduledDraft").last()
             ?: messages.query(isNotScheduledDraft).last()

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -29,6 +29,7 @@ import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshMo
 import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshMode.REFRESH_FOLDER
 import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshMode.REFRESH_FOLDER_WITH_ROLE
 import com.infomaniak.mail.data.cache.mailboxContent.refreshStrategies.RefreshStrategy
+import com.infomaniak.mail.data.cache.mailboxContent.refreshStrategies.ThreadRecomputations.recomputeThread
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/DefaultRefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/DefaultRefreshStrategy.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import com.infomaniak.mail.data.cache.mailboxContent.ImpactedFolders
 import com.infomaniak.mail.data.cache.mailboxContent.MessageController
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
+import com.infomaniak.mail.data.cache.mailboxContent.refreshStrategies.ThreadRecomputations.recomputeThread
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/SnoozeRefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/SnoozeRefreshStrategy.kt
@@ -22,6 +22,7 @@ import com.infomaniak.mail.data.cache.mailboxContent.FolderController
 import com.infomaniak.mail.data.cache.mailboxContent.ImpactedFolders
 import com.infomaniak.mail.data.cache.mailboxContent.MessageController
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
+import com.infomaniak.mail.data.cache.mailboxContent.refreshStrategies.ThreadRecomputations.recomputeThread
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/ThreadRecomputations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/ThreadRecomputations.kt
@@ -1,0 +1,174 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.cache.mailboxContent.refreshStrategies
+
+import com.infomaniak.mail.data.models.Snoozable
+import com.infomaniak.mail.data.models.isSnoozed
+import com.infomaniak.mail.data.models.message.Message
+import com.infomaniak.mail.data.models.message.Message.Companion.parseMessagesIds
+import com.infomaniak.mail.data.models.thread.Thread
+import com.infomaniak.mail.data.models.thread.computeReactionsPerMessageId
+import com.infomaniak.mail.data.models.thread.overrideWith
+import io.realm.kotlin.MutableRealm
+import io.realm.kotlin.Realm
+import io.realm.kotlin.ext.copyFromRealm
+import io.realm.kotlin.ext.isManaged
+import io.realm.kotlin.ext.realmListOf
+import io.realm.kotlin.ext.toRealmList
+import io.realm.kotlin.internal.getRealm
+import io.realm.kotlin.types.RealmList
+
+object ThreadRecomputations {
+    fun Thread.recomputeThread(realm: MutableRealm? = null) {
+
+        messages.sortBy { it.internalDate }
+        // All of the following methods should not be inside of Thread to begin with. At least the input list of messages is
+        // extracted once so every other following logic is forced to base its processing on this unique list of messages. We
+        // avoid side effects and unnecessary coupling
+        val allMessages = messages
+
+        val lastCurrentFolderMessage = allMessages.lastOrNull { it.folderId == folderId }
+        val lastMessage = if (isFromSearch) {
+            // In the search, some threads (such as threads from the snooze folder) won't have any messages with the same folderId
+            // as the thread folderId. This is an expected behavior and we don't want to delete it in this case. We just need to
+            // fallback on the last message of the thread.
+            lastCurrentFolderMessage ?: allMessages.lastOrNull()
+        } else {
+            lastCurrentFolderMessage
+        }
+
+        if (lastMessage == null) {
+            // Delete Thread if empty. Do not rely on this deletion code being part of the method's logic, it's a temporary fix. If
+            // threads should be deleted, then they need to be deleted outside this method.
+            if (isManaged()) realm?.delete(this)
+            return
+        }
+
+        resetThread()
+
+        updateThread(lastMessage, allMessages)
+
+        recomputeMessagesWithContent(allMessages)
+
+        // Remove duplicates in Recipients lists
+        val unmanagedFrom = if (from.getRealm<Realm>() == null) from else from.copyFromRealm()
+        val unmanagedTo = if (to.getRealm<Realm>() == null) to else to.copyFromRealm()
+        from = unmanagedFrom.distinct().toRealmList()
+        to = unmanagedTo.distinct().toRealmList()
+    }
+
+    private fun Thread.resetThread() {
+        unseenMessagesCount = 0
+        from = realmListOf()
+        to = realmListOf()
+        hasDrafts = false
+        isFavorite = false
+        isAnswered = false
+        isForwarded = false
+        hasAttachable = false
+        numberOfScheduledDrafts = 0
+        snoozeState = null
+        snoozeEndDate = null
+        snoozeUuid = null
+        isLastInboxMessageSnoozed = false
+    }
+
+    private fun Thread.updateThread(lastMessage: Message, allMessages: RealmList<Message>) {
+
+        fun Thread.updateSnoozeStatesBasedOn(message: Message) {
+            message.snoozeState?.let {
+                snoozeState = it
+                snoozeEndDate = message.snoozeEndDate
+                snoozeUuid = message.snoozeUuid
+            }
+        }
+
+        allMessages.forEach { message ->
+            messagesIds += message.messageIds
+            if (!message.isSeen) unseenMessagesCount++
+            from += message.from
+            to += message.to
+            if (message.isDraft) hasDrafts = true
+            if (message.isFavorite) isFavorite = true
+            if (message.isAnswered) {
+                isAnswered = true
+                isForwarded = false
+            }
+            if (message.isForwarded) {
+                isForwarded = true
+                isAnswered = false
+            }
+            if (message.hasAttachable) hasAttachable = true
+            if (message.isScheduledDraft) numberOfScheduledDrafts++
+
+            updateSnoozeStatesBasedOn(message)
+        }
+
+        duplicates.forEach { message ->
+            if (!message.isSeen) unseenMessagesCount++
+            updateSnoozeStatesBasedOn(message)
+        }
+
+        displayDate = lastMessage.displayDate
+        internalDate = lastMessage.internalDate
+        subject = allMessages.first().subject
+
+        isLastInboxMessageSnoozed = allMessages.isLastInboxMessageSnoozed(folderId)
+    }
+
+    /**
+     * This method determines whether the last inbox message in the list is snoozed. If there are none, it returns false.
+     *
+     * Instead of querying Realm every time to retrieve the inbox folder ID, we rely on the fact that [Snoozable.isSnoozed] only
+     * returns `true` for messages whose [Message.folderId] matches the inbox folder ID.
+     *
+     * To illustrate the reasoning:
+     * | folderId == inbox | isSnoozed() | Comment                        | Result         |
+     * |-------------------|-------------|--------------------------------|----------------|
+     * | false             | false       | isSnoozed always returns false | false          |
+     * | false             | true        | This situation doesn't exist   | doesn't matter |
+     * |-------------------|-------------|--------------------------------|----------------|
+     * | true              | false       |                                | false          |
+     * | true              | true        |                                | true           |
+     *
+     * => Only returns true when the last message of inbox is snoozed
+     */
+    @Suppress("NullableBooleanElvis")
+    private fun List<Message>.isLastInboxMessageSnoozed(threadFolderId: String): Boolean {
+        return lastOrNull { it.folderId == threadFolderId }?.isSnoozed() ?: false
+    }
+
+    fun Thread.recomputeMessagesWithContent(allMessages: List<Message>) {
+        val (reactionsPerMessageId, threadMessageIds) = computeReactionsPerMessageId(allMessages)
+
+        messagesWithContent.clear()
+        allMessages.forEach { message ->
+            reactionsPerMessageId[message.messageId]?.let { reactions ->
+                message.emojiReactions.overrideWith(reactions)
+            }
+
+            val targetMessageIds = message.inReplyTo ?: ""
+            val isHiddenEmojiReaction = message.isReaction && isTargetMessageInThread(targetMessageIds, threadMessageIds)
+            if (isHiddenEmojiReaction.not()) messagesWithContent += message
+        }
+    }
+
+    private fun isTargetMessageInThread(targetMessageIds: String, threadMessageIds: Set<String>): Boolean {
+        return targetMessageIds.parseMessagesIds().any(threadMessageIds::contains)
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/data/models/FeatureFlag.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/FeatureFlag.kt
@@ -24,4 +24,5 @@ enum class FeatureFlag(val apiName: String) {
     ENCRYPTION("mail-compose-encrypted"),
     SCHEDULE_DRAFTS("schedule-send-draft"),
     SNOOZE("mail-snooze"),
+    EMOJI_REACTION("mail-emoji-reaction"),
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/SwipeAction.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/SwipeAction.kt
@@ -25,7 +25,7 @@ import androidx.annotation.StringRes
 import com.infomaniak.mail.MatomoMail.MatomoName
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Folder.FolderRole
-import com.infomaniak.mail.utils.SharedUtils
+import com.infomaniak.mail.utils.FeatureAvailability
 
 enum class SwipeAction(
     @StringRes val nameRes: Int,
@@ -64,5 +64,5 @@ private val alwaysDisplay = SwipeDisplayBehavior { _, _, _ -> true }
 private val neverDisplay = SwipeDisplayBehavior { _, _, _ -> false }
 
 private val snoozeDisplay = SwipeDisplayBehavior { role, featureFlags, localSettings ->
-    (role == FolderRole.INBOX || role == FolderRole.SNOOZED) && SharedUtils.isSnoozeAvailable(featureFlags, localSettings)
+    (role == FolderRole.INBOX || role == FolderRole.SNOOZED) && FeatureAvailability.isSnoozeAvailable(featureFlags, localSettings)
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -34,21 +34,14 @@ import com.infomaniak.mail.data.models.isSnoozed
 import com.infomaniak.mail.data.models.isUnsnoozed
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message
-import com.infomaniak.mail.data.models.message.Message.Companion.parseMessagesIds
 import com.infomaniak.mail.ui.main.folder.ThreadListDateDisplay
 import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.FeatureAvailability
 import com.infomaniak.mail.utils.extensions.toRealmInstant
-import io.realm.kotlin.MutableRealm
-import io.realm.kotlin.Realm
 import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.ext.backlinks
-import io.realm.kotlin.ext.copyFromRealm
-import io.realm.kotlin.ext.isManaged
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.ext.realmSetOf
-import io.realm.kotlin.ext.toRealmList
-import io.realm.kotlin.internal.getRealm
 import io.realm.kotlin.serializers.RealmListKSerializer
 import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmList
@@ -207,125 +200,6 @@ class Thread : RealmObject, Snoozable {
         }
     }
 
-    fun recomputeThread(realm: MutableRealm? = null) {
-
-        messages.sortBy { it.internalDate }
-        // All of the following methods should not be inside of Thread to begin with. At least the input list of messages is
-        // extracted once so every other following logic is forced to base its processing on this unique list of messages. We
-        // avoid side effects and unnecessary coupling
-        val allMessages = messages
-
-        val lastCurrentFolderMessage = allMessages.lastOrNull { it.folderId == folderId }
-        val lastMessage = if (isFromSearch) {
-            // In the search, some threads (such as threads from the snooze folder) won't have any messages with the same folderId
-            // as the thread folderId. This is an expected behavior and we don't want to delete it in this case. We just need to
-            // fallback on the last message of the thread.
-            lastCurrentFolderMessage ?: allMessages.lastOrNull()
-        } else {
-            lastCurrentFolderMessage
-        }
-
-        if (lastMessage == null) {
-            // Delete Thread if empty. Do not rely on this deletion code being part of the method's logic, it's a temporary fix. If
-            // threads should be deleted, then they need to be deleted outside this method.
-            if (isManaged()) realm?.delete(this)
-            return
-        }
-
-        resetThread()
-
-        updateThread(lastMessage, allMessages)
-
-        recomputeMessagesWithContent(allMessages)
-
-        // Remove duplicates in Recipients lists
-        val unmanagedFrom = if (from.getRealm<Realm>() == null) from else from.copyFromRealm()
-        val unmanagedTo = if (to.getRealm<Realm>() == null) to else to.copyFromRealm()
-        from = unmanagedFrom.distinct().toRealmList()
-        to = unmanagedTo.distinct().toRealmList()
-    }
-
-    private fun resetThread() {
-        unseenMessagesCount = 0
-        from = realmListOf()
-        to = realmListOf()
-        hasDrafts = false
-        isFavorite = false
-        isAnswered = false
-        isForwarded = false
-        hasAttachable = false
-        numberOfScheduledDrafts = 0
-        snoozeState = null
-        snoozeEndDate = null
-        snoozeUuid = null
-        isLastInboxMessageSnoozed = false
-    }
-
-    private fun updateThread(lastMessage: Message, allMessages: RealmList<Message>) {
-
-        fun Thread.updateSnoozeStatesBasedOn(message: Message) {
-            message.snoozeState?.let {
-                snoozeState = it
-                snoozeEndDate = message.snoozeEndDate
-                snoozeUuid = message.snoozeUuid
-            }
-        }
-
-        allMessages.forEach { message ->
-            messagesIds += message.messageIds
-            if (!message.isSeen) unseenMessagesCount++
-            from += message.from
-            to += message.to
-            if (message.isDraft) hasDrafts = true
-            if (message.isFavorite) isFavorite = true
-            if (message.isAnswered) {
-                isAnswered = true
-                isForwarded = false
-            }
-            if (message.isForwarded) {
-                isForwarded = true
-                isAnswered = false
-            }
-            if (message.hasAttachable) hasAttachable = true
-            if (message.isScheduledDraft) numberOfScheduledDrafts++
-
-            updateSnoozeStatesBasedOn(message)
-        }
-
-        duplicates.forEach { message ->
-            if (!message.isSeen) unseenMessagesCount++
-            updateSnoozeStatesBasedOn(message)
-        }
-
-        displayDate = lastMessage.displayDate
-        internalDate = lastMessage.internalDate
-        subject = allMessages.first().subject
-
-        isLastInboxMessageSnoozed = allMessages.isLastInboxMessageSnoozed()
-    }
-
-    /**
-     * This method determines whether the last inbox message in the list is snoozed. If there are none, it returns false.
-     *
-     * Instead of querying Realm every time to retrieve the inbox folder ID, we rely on the fact that [Snoozable.isSnoozed] only
-     * returns `true` for messages whose [Message.folderId] matches the inbox folder ID.
-     *
-     * To illustrate the reasoning:
-     * | folderId == inbox | isSnoozed() | Comment                        | Result         |
-     * |-------------------|-------------|--------------------------------|----------------|
-     * | false             | false       | isSnoozed always returns false | false          |
-     * | false             | true        | This situation doesn't exist   | doesn't matter |
-     * |-------------------|-------------|--------------------------------|----------------|
-     * | true              | false       |                                | false          |
-     * | true              | true        |                                | true           |
-     *
-     * => Only returns true when the last message of inbox is snoozed
-     */
-    @Suppress("NullableBooleanElvis")
-    private fun List<Message>.isLastInboxMessageSnoozed(): Boolean {
-        return lastOrNull { it.folderId == folderId }?.isSnoozed() ?: false
-    }
-
     /**
      * Only used for when the api tells us we're trying to automatically unsnooze a thread that's not snoozed
      */
@@ -333,25 +207,6 @@ class Thread : RealmObject, Snoozable {
         super.manuallyUnsnooze()
         messages.forEach(Message::manuallyUnsnooze)
         duplicates.forEach(Message::manuallyUnsnooze)
-    }
-
-    fun recomputeMessagesWithContent(allMessages: List<Message>) {
-        val (reactionsPerMessageId, threadMessageIds) = computeReactionsPerMessageId(allMessages)
-
-        messagesWithContent.clear()
-        allMessages.forEach { message ->
-            reactionsPerMessageId[message.messageId]?.let { reactions ->
-                message.emojiReactions.overrideWith(reactions)
-            }
-
-            val targetMessageIds = message.inReplyTo ?: ""
-            val isHiddenEmojiReaction = message.isReaction && isTargetMessageInThread(targetMessageIds, threadMessageIds)
-            if (isHiddenEmojiReaction.not()) messagesWithContent += message
-        }
-    }
-
-    private fun isTargetMessageInThread(targetMessageIds: String, threadMessageIds: Set<String>): Boolean {
-        return targetMessageIds.parseMessagesIds().any(threadMessageIds::contains)
     }
 
     fun computeAvatarRecipient(): Pair<Recipient?, Bimi?> = runCatching {

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -30,9 +30,9 @@ import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.Snoozable
 import com.infomaniak.mail.data.models.SnoozeState
 import com.infomaniak.mail.data.models.correspondent.Recipient
-import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.isSnoozed
 import com.infomaniak.mail.data.models.isUnsnoozed
+import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.message.Message.Companion.parseMessagesIds
 import com.infomaniak.mail.ui.main.folder.ThreadListDateDisplay
@@ -210,6 +210,9 @@ class Thread : RealmObject, Snoozable {
     fun recomputeThread(realm: MutableRealm? = null) {
 
         messages.sortBy { it.internalDate }
+        // All of the following methods should not be inside of Thread to begin with. At least the input list of messages is
+        // extracted once so every other following logic is forced to base its processing on this unique list of messages. We
+        // avoid side effects and unnecessary coupling
         val allMessages = messages
 
         val lastCurrentFolderMessage = allMessages.lastOrNull { it.folderId == folderId }

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -37,7 +37,7 @@ import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.message.Message.Companion.parseMessagesIds
 import com.infomaniak.mail.ui.main.folder.ThreadListDateDisplay
 import com.infomaniak.mail.utils.AccountUtils
-import com.infomaniak.mail.utils.SharedUtils
+import com.infomaniak.mail.utils.FeatureAvailability
 import com.infomaniak.mail.utils.extensions.toRealmInstant
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
@@ -174,7 +174,7 @@ class Thread : RealmObject, Snoozable {
     val isOnlyOneDraft get() = messages.count() == 1 && hasDrafts
 
     fun getDisplayedMessages(featureFlags: Mailbox.FeatureFlagSet?, localSettings: LocalSettings): RealmList<Message> {
-        return if (SharedUtils.isReactionsAvailable(featureFlags, localSettings)) messagesWithContent else messages
+        return if (FeatureAvailability.isReactionsAvailable(featureFlags, localSettings)) messagesWithContent else messages
     }
 
     fun addMessageWithConditions(newMessage: Message, realm: TypedRealm) {

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -351,12 +351,7 @@ class Thread : RealmObject, Snoozable {
         return targetMessageIds.parseMessagesIds().any(threadMessageIds::contains)
     }
 
-    fun computeAvatarRecipient(
-        featureFlags: Mailbox.FeatureFlagSet?,
-        localSettings: LocalSettings,
-    ): Pair<Recipient?, Bimi?> = runCatching {
-        val messages = getDisplayedMessages(featureFlags, localSettings)
-
+    fun computeAvatarRecipient(): Pair<Recipient?, Bimi?> = runCatching {
         val message = messages.lastOrNull {
             it.folder.role != FolderRole.SENT &&
                     it.folder.role != FolderRole.DRAFT &&

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -965,7 +965,9 @@ class MainViewModel @Inject constructor(
     }
 
     private fun getMessagesToMarkAsUnseen(threads: List<Thread>, message: Message?) = when (message) {
-        null -> threads.flatMap(messageController::getLastMessageAndItsDuplicatesToExecuteAction)
+        null -> threads.flatMap { thread ->
+            messageController.getLastMessageAndItsDuplicatesToExecuteAction(thread, featureFlagsLive.value)
+        }
         else -> messageController.getMessageAndDuplicates(threads.first(), message)
     }
 
@@ -1031,7 +1033,9 @@ class MainViewModel @Inject constructor(
     }
 
     private fun getMessagesToFavorite(threads: List<Thread>, message: Message?) = when (message) {
-        null -> threads.flatMap(messageController::getLastMessageAndItsDuplicatesToExecuteAction)
+        null -> threads.flatMap { thread ->
+            messageController.getLastMessageAndItsDuplicatesToExecuteAction(thread, featureFlagsLive.value)
+        }
         else -> messageController.getMessageAndDuplicates(threads.first(), message)
     }
 
@@ -1489,7 +1493,7 @@ class MainViewModel @Inject constructor(
     }
 
     private fun threadHasOnlyOneMessageLeft(threadUid: String): Boolean {
-        return messageController.getMessagesCountInThread(threadUid, mailboxContentRealm()) == 1
+        return messageController.getMessagesCountInThread(threadUid, featureFlagsLive.value, mailboxContentRealm()) == 1
     }
 
     fun shareThreadUrl(messageUid: String) {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -1154,7 +1154,7 @@ class MainViewModel @Inject constructor(
                 val threads = threadUids.mapNotNull(threadController::getThread)
 
                 val messageUids = threads.mapNotNull { thread ->
-                    thread.messages.lastOrNull { it.folderId == currentFolderId }?.uid
+                    thread.getDisplayedMessages(currentMailbox.featureFlags, localSettings).lastOrNull { it.folderId == currentFolderId }?.uid
                 }
 
                 val responses = ioDispatcher { ApiRepository.snoozeMessages(currentMailbox.uuid, messageUids, date) }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -464,7 +464,7 @@ class ThreadListAdapter @Inject constructor(
     }
 
     private fun CardviewThreadItemBinding.displayAvatar(thread: Thread) {
-        val (recipient, bimi) = thread.computeAvatarRecipient(callbacks?.getFeatureFlags?.invoke(), localSettings)
+        val (recipient, bimi) = thread.computeAvatarRecipient()
         expeditorAvatar.apply {
             loadAvatar(recipient, bimi)
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -271,7 +271,7 @@ class ThreadListAdapter @Inject constructor(
             iconCalendar.isGone = true // TODO: See with API when we should display this icon
             iconFavorite.isVisible = isFavorite
 
-            val messagesCount = messages.count()
+            val messagesCount = getDisplayedMessages(callbacks?.getFeatureFlags?.invoke(), localSettings).count()
             threadCountText.text = "$messagesCount"
             threadCountCard.isVisible = messagesCount > 1
 
@@ -464,7 +464,7 @@ class ThreadListAdapter @Inject constructor(
     }
 
     private fun CardviewThreadItemBinding.displayAvatar(thread: Thread) {
-        val (recipient, bimi) = thread.computeAvatarRecipient()
+        val (recipient, bimi) = thread.computeAvatarRecipient(callbacks?.getFeatureFlags?.invoke(), localSettings)
         expeditorAvatar.apply {
             loadAvatar(recipient, bimi)
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSelectionSettingFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/appearance/swipe/SwipeActionsSelectionSettingFragment.kt
@@ -44,7 +44,7 @@ import com.infomaniak.mail.data.models.SwipeAction.SNOOZE
 import com.infomaniak.mail.data.models.SwipeAction.SPAM
 import com.infomaniak.mail.databinding.FragmentSwipeActionsSelectionSettingBinding
 import com.infomaniak.mail.ui.MainViewModel
-import com.infomaniak.mail.utils.SharedUtils
+import com.infomaniak.mail.utils.FeatureAvailability
 import com.infomaniak.mail.utils.extensions.applySideAndBottomSystemInsets
 import com.infomaniak.mail.utils.extensions.setSystemBarsColors
 import dagger.hilt.android.AndroidEntryPoint
@@ -72,7 +72,7 @@ class SwipeActionsSelectionSettingFragment : Fragment() {
         val actionResId = navigationArgs.titleResId
         root.setTitle(actionResId)
 
-        snooze.isVisible = SharedUtils.isSnoozeAvailable(mainViewModel.featureFlagsLive.value, localSettings)
+        snooze.isVisible = FeatureAvailability.isSnoozeAvailable(mainViewModel.featureFlagsLive.value, localSettings)
 
         radioGroup.apply {
             initBijectionTable(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/SubjectFormatter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/SubjectFormatter.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,7 +58,7 @@ class SubjectFormatter @Inject constructor(private val appContext: Context) {
     ): CharSequence {
         if (!externalMailFlagEnabled) return previousContent
 
-        val (externalRecipientEmail, externalRecipientQuantity) = thread.findExternalRecipients(
+        val (externalRecipientEmail, externalRecipientQuantity) = thread.messages.findExternalRecipients(
             externalData = ExternalData(emailDictionary, aliases, trustedDomains),
         )
         if (externalRecipientQuantity == 0) return previousContent
@@ -105,7 +105,9 @@ class SubjectFormatter @Inject constructor(private val appContext: Context) {
         ellipsizeConfiguration,
     )
 
-    private fun getFolderName(thread: Thread) = if (thread.messages.size > 1) "" else thread.folderName
+    private fun getFolderName(thread: Thread): String {
+        return if (thread.messages.size > 1) "" else thread.folderName
+    }
 
     private fun getEllipsizeConfiguration(tag: String): EllipsizeConfiguration? {
         val paddingsInPixels = (appContext.resources.getDimension(R.dimen.threadHorizontalMargin) * 2).toInt()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -489,7 +489,7 @@ class ThreadFragment : Fragment() {
                 iconTint = ColorStateList.valueOf(color)
             }
 
-            val shouldDisplayScheduledDraftActions = thread.numberOfScheduledDrafts == thread.messages.size
+            val shouldDisplayScheduledDraftActions = thread.numberOfScheduledDrafts == thread.getDisplayedMessages(mainViewModel.featureFlagsLive.value, localSettings).size
             quickActionBar.init(if (shouldDisplayScheduledDraftActions) R.menu.scheduled_draft_menu else R.menu.message_menu)
 
             thread.snoozeEndDate?.let { snoozeEndDate ->

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -489,7 +489,8 @@ class ThreadFragment : Fragment() {
                 iconTint = ColorStateList.valueOf(color)
             }
 
-            val shouldDisplayScheduledDraftActions = thread.numberOfScheduledDrafts == thread.getDisplayedMessages(mainViewModel.featureFlagsLive.value, localSettings).size
+            val messagesCount = thread.getDisplayedMessages(mainViewModel.featureFlagsLive.value, localSettings).size
+            val shouldDisplayScheduledDraftActions = thread.numberOfScheduledDrafts == messagesCount
             quickActionBar.init(if (shouldDisplayScheduledDraftActions) R.menu.scheduled_draft_menu else R.menu.message_menu)
 
             thread.snoozeEndDate?.let { snoozeEndDate ->

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -50,10 +50,10 @@ import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.SuperCollapsedBlock
 import com.infomaniak.mail.utils.AccountUtils
+import com.infomaniak.mail.utils.FeatureAvailability.isSnoozeAvailable
 import com.infomaniak.mail.utils.MessageBodyUtils
 import com.infomaniak.mail.utils.SentryDebug
 import com.infomaniak.mail.utils.SharedUtils
-import com.infomaniak.mail.utils.SharedUtils.Companion.isSnoozeAvailable
 import com.infomaniak.mail.utils.Utils
 import com.infomaniak.mail.utils.Utils.runCatchingRealm
 import com.infomaniak.mail.utils.coroutineContext
@@ -77,6 +77,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -115,6 +115,8 @@ class ThreadViewModel @Inject constructor(
         AccountUtils.currentMailboxId,
     ).mapNotNull { it.obj }
 
+    private val currentMailboxLive = currentMailboxFlow.asLiveData()
+
     private val featureFlagsFlow = currentMailboxFlow.map { it.featureFlags }
 
     val threadState = ThreadState()
@@ -159,7 +161,7 @@ class ThreadViewModel @Inject constructor(
     var reschedulingCurrentlyScheduledEpochMillis: Long? = null
 
     val isThreadSnoozeHeaderVisible: LiveData<ThreadHeaderVisibility> = Utils
-        .waitInitMediator(currentMailboxFlow.asLiveData(), threadLive)
+        .waitInitMediator(currentMailboxLive, threadLive)
         .map { (mailbox, thread) ->
             runCatchingRealm {
                 when {
@@ -355,7 +357,7 @@ class ThreadViewModel @Inject constructor(
                 value = SubjectDataResult(value?.thread, mergedContacts, value?.mailbox)
             }
 
-            addSource(currentMailboxFlow.asLiveData()) { mailbox ->
+            addSource(currentMailboxLive) { mailbox ->
                 value = SubjectDataResult(value?.thread, value?.mergedContacts, mailbox)
             }
         }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.liveData
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.infomaniak.mail.data.cache.mailboxContent.MessageController
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController

--- a/app/src/main/java/com/infomaniak/mail/utils/ExternalUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ExternalUtils.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 package com.infomaniak.mail.utils
 
 import com.infomaniak.mail.data.models.correspondent.Recipient
-import com.infomaniak.mail.data.models.thread.Thread
+import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.utils.extensions.MergedContactDictionary
 
 object ExternalUtils {
@@ -26,11 +26,11 @@ object ExternalUtils {
     /**
      * Only returns a quantity of at most 2, used to differentiate between the singular or plural form of the dialog messages
      */
-    fun Thread.findExternalRecipients(externalData: ExternalData): Pair<String?, Int> {
+    fun List<Message>.findExternalRecipients(externalData: ExternalData): Pair<String?, Int> {
         var externalRecipientEmail: String? = null
         var externalRecipientQuantity = 0
 
-        messages.forEach { message ->
+        forEach { message ->
             val (singleEmail, quantityForThisMessage) = findExternalRecipientInIterables(externalData, message.from)
 
             externalRecipientQuantity += quantityForThisMessage

--- a/app/src/main/java/com/infomaniak/mail/utils/FeatureAvailability.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/FeatureAvailability.kt
@@ -1,0 +1,37 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.utils
+
+import com.infomaniak.mail.data.LocalSettings
+import com.infomaniak.mail.data.LocalSettings.ThreadMode
+import com.infomaniak.mail.data.models.FeatureFlag
+import com.infomaniak.mail.data.models.mailbox.Mailbox
+
+object FeatureAvailability {
+    fun isSnoozeAvailable(featureFlags: Mailbox.FeatureFlagSet?, localSettings: LocalSettings): Boolean {
+        fun hasSnoozeFeatureFlag() = featureFlags?.contains(FeatureFlag.SNOOZE) == true
+        fun isConversationMode() = localSettings.threadMode == ThreadMode.CONVERSATION
+        return hasSnoozeFeatureFlag() && isConversationMode()
+    }
+
+    fun isReactionsAvailable(featureFlags: Mailbox.FeatureFlagSet?, localSettings: LocalSettings): Boolean {
+        fun hasEmojiFeatureFlag() = featureFlags?.contains(FeatureFlag.EMOJI_REACTION) == true
+        fun isConversationMode() = localSettings.threadMode == ThreadMode.CONVERSATION
+        return hasEmojiFeatureFlag() && isConversationMode()
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@ import com.infomaniak.html.cleaner.HtmlSanitizer
 import com.infomaniak.lib.core.api.ApiController.NetworkException
 import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.mail.R
+import com.infomaniak.mail.data.LocalSettings
 import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.cache.mailboxContent.FolderController
 import com.infomaniak.mail.data.cache.mailboxContent.MessageController
@@ -48,6 +49,7 @@ class FetchMessagesManager @Inject constructor(
     private val notificationManagerCompat: NotificationManagerCompat,
     private val notificationUtils: NotificationUtils,
     private val refreshController: RefreshController,
+    private val localSettings: LocalSettings,
 ) {
 
     private lateinit var coroutineScope: CoroutineScope
@@ -185,7 +187,7 @@ class FetchMessagesManager @Inject constructor(
         okHttpClient: OkHttpClient,
     ): Boolean {
 
-        ThreadController.fetchMessagesHeavyData(messages, realm, okHttpClient)
+        ThreadController.fetchMessagesHeavyData(getDisplayedMessages(mailbox.featureFlags, localSettings), realm, okHttpClient)
 
         val message = MessageController.getThreadLastMessageInFolder(uid, realm) ?: run {
             SentryDebug.sendFailedNotification("No Message in the Thread", userId, mailbox.mailboxId, sentryMessageUid, mailbox)

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -23,6 +23,8 @@ import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.cache.mailboxContent.FolderController
 import com.infomaniak.mail.data.cache.mailboxContent.MessageController
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
+import com.infomaniak.mail.data.cache.mailboxContent.refreshStrategies.ThreadRecomputations.recomputeMessagesWithContent
+import com.infomaniak.mail.data.cache.mailboxContent.refreshStrategies.ThreadRecomputations.recomputeThread
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.isSnoozed

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -127,8 +127,7 @@ class SearchUtils @Inject constructor(
     }
 
     private fun Thread.setFolderId(filterFolder: Folder?) {
-        val allMessages = messages
-        this.folderId = if (allMessages.count() == 1) allMessages.single().folderId else filterFolder!!.id
+        this.folderId = if (messages.count() == 1) messages.single().folderId else filterFolder!!.id
     }
 
     private suspend fun Thread.keepOldMessagesData(filterFolder: Folder?, realm: Realm) {

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -127,7 +127,8 @@ class SearchUtils @Inject constructor(
     }
 
     private fun Thread.setFolderId(filterFolder: Folder?) {
-        this.folderId = if (messages.count() == 1) messages.single().folderId else filterFolder!!.id
+        val allMessages = messages
+        this.folderId = if (allMessages.count() == 1) allMessages.single().folderId else filterFolder!!.id
     }
 
     private suspend fun Thread.keepOldMessagesData(filterFolder: Folder?, realm: Realm) {

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -299,6 +299,12 @@ class SharedUtils @Inject constructor(
             return hasSnoozeFeatureFlag() && isConversationMode()
         }
 
+        fun isReactionsAvailable(featureFlags: Mailbox.FeatureFlagSet?, localSettings: LocalSettings): Boolean {
+            fun hasEmojiFeatureFlag() = featureFlags?.contains(FeatureFlag.EMOJI_REACTION) == true
+            fun isConversationMode() = localSettings.threadMode == ThreadMode.CONVERSATION
+            return hasEmojiFeatureFlag() && isConversationMode()
+        }
+
         sealed interface AutomaticUnsnoozeResult {
             data class Success(val impactedFolders: ImpactedFolders) : AutomaticUnsnoozeResult
             data object CannotBeUnsnoozedError : AutomaticUnsnoozeResult

--- a/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SharedUtils.kt
@@ -21,7 +21,6 @@ import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.mail.data.LocalSettings
-import com.infomaniak.mail.data.LocalSettings.ThreadMode
 import com.infomaniak.mail.data.api.ApiRepository
 import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.cache.mailboxContent.ImpactedFolders
@@ -31,7 +30,6 @@ import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshCa
 import com.infomaniak.mail.data.cache.mailboxContent.RefreshController.RefreshMode
 import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
-import com.infomaniak.mail.data.models.FeatureFlag
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.isSnoozed
 import com.infomaniak.mail.data.models.mailbox.Mailbox
@@ -289,20 +287,8 @@ class SharedUtils @Inject constructor(
             localSettings: LocalSettings,
             currentFolderRole: FolderRole?,
         ): Boolean {
-            fun isSnoozeAvailable() = isSnoozeAvailable(mainViewModel.featureFlagsLive.value, localSettings)
+            fun isSnoozeAvailable() = FeatureAvailability.isSnoozeAvailable(mainViewModel.featureFlagsLive.value, localSettings)
             return currentFolderRole == FolderRole.INBOX || currentFolderRole == FolderRole.SNOOZED && isSnoozeAvailable()
-        }
-
-        fun isSnoozeAvailable(featureFlags: Mailbox.FeatureFlagSet?, localSettings: LocalSettings): Boolean {
-            fun hasSnoozeFeatureFlag() = featureFlags?.contains(FeatureFlag.SNOOZE) == true
-            fun isConversationMode() = localSettings.threadMode == ThreadMode.CONVERSATION
-            return hasSnoozeFeatureFlag() && isConversationMode()
-        }
-
-        fun isReactionsAvailable(featureFlags: Mailbox.FeatureFlagSet?, localSettings: LocalSettings): Boolean {
-            fun hasEmojiFeatureFlag() = featureFlags?.contains(FeatureFlag.EMOJI_REACTION) == true
-            fun isConversationMode() = localSettings.threadMode == ThreadMode.CONVERSATION
-            return hasEmojiFeatureFlag() && isConversationMode()
         }
 
         sealed interface AutomaticUnsnoozeResult {

--- a/app/src/test/java/com/infomaniak/mail/dataset/DummyThreads.kt
+++ b/app/src/test/java/com/infomaniak/mail/dataset/DummyThreads.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.mail.dataset
 
+import com.infomaniak.mail.data.cache.mailboxContent.refreshStrategies.ThreadRecomputations.recomputeThread
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.dataset.DummyFolders.FOLDER_DRAFT_ID


### PR DESCRIPTION
When a reaction message targets an existing message, it needs to not display and not be taken into account in some places in the code.

To hide the messages we don't want I replaced accesses to `Thread.messages` that should only consider a subset of messages with the method `getDisplayMessages()` that will adapt and return the correct list of messages everytime it's called.

Depends on https://github.com/Infomaniak/android-kMail/pull/2385