### PR TITLE
fix: Different word for no swipe action and no choice of swipe action

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/SwipeAction.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/SwipeAction.kt
@@ -52,7 +52,7 @@ enum class SwipeAction(
         R.drawable.ic_param_dots,
         "quickActions",
     ),
-    TUTORIAL(R.string.settingsSwipeActionNone, R.color.progressbarTrackColor, null, "tutorial"),
+    TUTORIAL(R.string.settingsSwipeActionToDefine, R.color.progressbarTrackColor, null, "tutorial"),
     NONE(R.string.settingsSwipeActionNone, R.color.swipeNone, null, "none", neverDisplay);
 
     @ColorInt

--- a/app/src/main/res/layout/fragment_swipe_actions_settings.xml
+++ b/app/src/main/res/layout/fragment_swipe_actions_settings.xml
@@ -55,7 +55,7 @@
                     app:itemAction="chevron"
                     app:ripple="false"
                     app:title="@string/settingsSwipeRight"
-                    tools:subtitle="@string/settingsSwipeActionNone" />
+                    tools:subtitle="@string/settingsSwipeActionToDefine" />
 
                 <include
                     android:id="@+id/swipeRightIllustration"
@@ -84,7 +84,7 @@
                     app:itemAction="chevron"
                     app:ripple="false"
                     app:title="@string/settingsSwipeLeft"
-                    tools:subtitle="@string/settingsSwipeActionNone" />
+                    tools:subtitle="@string/settingsSwipeActionToDefine" />
 
                 <include
                     android:id="@+id/swipeLeftIllustration"


### PR DESCRIPTION
There are 2 distinct words to indicate that the swipe action is defined as None and that there is no swipe action defined.