### PR TITLE
feat: Translate emoji reaction errors

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionNotAllowedReason.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionNotAllowedReason.kt
@@ -1,0 +1,51 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.data.models.message
+
+import com.infomaniak.core.utils.ApiEnum
+import com.infomaniak.lib.core.utils.ErrorCodeTranslated
+import com.infomaniak.mail.R
+
+enum class EmojiReactionNotAllowedReason(
+    override val apiValue: String,
+    override val translateRes: Int,
+) : ApiEnum, ErrorCodeTranslated {
+    EmojiReactionFolderNotAllowedDraft("folder_not_allowed_draft", R.string.errorEmojiReactionFolderNotAllowedDraft),
+    EmojiReactionFolderNotAllowedScheduledDraft(
+        "folder_not_allowed_scheduled_draft",
+        R.string.errorEmojiReactionFolderNotAllowedScheduledDraft
+    ),
+    EmojiReactionFolderNotAllowedSpam("folder_not_allowed_spam", R.string.errorEmojiReactionFolderNotAllowedSpam),
+    EmojiReactionFolderNotAllowedTrash("folder_not_allowed_trash", R.string.errorEmojiReactionFolderNotAllowedTrash),
+    EmojiReactionMessageInReplyToNotAllowed(
+        "message_in_reply_to_not_allowed",
+        R.string.errorEmojiReactionMessageInReplyToNotAllowed
+    ),
+    EmojiReactionMessageInReplyToNotValid(
+        "message_in_reply_to_not_valid",
+        R.string.errorEmojiReactionMessageInReplyToNotValid
+    ),
+    EmojiReactionMessageInReplyToEncrypted(
+        "message_in_reply_to_not_valid",
+        R.string.errorEmojiReactionMessageInReplyEncrypted
+    ),
+    EmojiReactionMaxRecipient("max_recipient", R.string.errorEmojiReactionMaxRecipient),
+    EmojiReactionRecipientNotAllowed("recipient_not_allowed", R.string.errorEmojiReactionRecipientNotAllowed);
+
+    override val code: String = "emoji_reaction__$apiValue"
+}

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -19,11 +19,8 @@
 
 package com.infomaniak.mail.data.models.message
 
-import com.infomaniak.core.utils.ApiEnum
 import com.infomaniak.core.utils.apiEnum
-import com.infomaniak.lib.core.utils.ErrorCodeTranslated
 import com.infomaniak.lib.core.utils.Utils.enumValueOfOrNull
-import com.infomaniak.mail.R
 import com.infomaniak.mail.data.api.RealmInstantSerializer
 import com.infomaniak.mail.data.api.UnwrappingJsonListSerializer
 import com.infomaniak.mail.data.cache.mailboxContent.FolderController
@@ -317,35 +314,6 @@ class Message : RealmObject, Snoozable {
         NONE,
         PENDING,
         ACKNOWLEDGED,
-    }
-
-    enum class EmojiReactionNotAllowedReason(
-        override val apiValue: String,
-        override val translateRes: Int,
-    ) : ApiEnum, ErrorCodeTranslated {
-        EmojiReactionFolderNotAllowedDraft("folder_not_allowed_draft", R.string.errorEmojiReactionFolderNotAllowedDraft),
-        EmojiReactionFolderNotAllowedScheduledDraft(
-            "folder_not_allowed_scheduled_draft",
-            R.string.errorEmojiReactionFolderNotAllowedScheduledDraft
-        ),
-        EmojiReactionFolderNotAllowedSpam("folder_not_allowed_spam", R.string.errorEmojiReactionFolderNotAllowedSpam),
-        EmojiReactionFolderNotAllowedTrash("folder_not_allowed_trash", R.string.errorEmojiReactionFolderNotAllowedTrash),
-        EmojiReactionMessageInReplyToNotAllowed(
-            "message_in_reply_to_not_allowed",
-            R.string.errorEmojiReactionMessageInReplyToNotAllowed
-        ),
-        EmojiReactionMessageInReplyToNotValid(
-            "message_in_reply_to_not_valid",
-            R.string.errorEmojiReactionMessageInReplyToNotValid
-        ),
-        EmojiReactionMessageInReplyToEncrypted(
-            "message_in_reply_to_not_valid",
-            R.string.errorEmojiReactionMessageInReplyEncrypted
-        ),
-        EmojiReactionMaxRecipient("max_recipient", R.string.errorEmojiReactionMaxRecipient),
-        EmojiReactionRecipientNotAllowed("recipient_not_allowed", R.string.errorEmojiReactionRecipientNotAllowed);
-
-        override val code: String = "emoji_reaction__$apiValue"
     }
 
     fun keepLocalValues(localMessage: Message) {

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -21,7 +21,9 @@ package com.infomaniak.mail.data.models.message
 
 import com.infomaniak.core.utils.ApiEnum
 import com.infomaniak.core.utils.apiEnum
+import com.infomaniak.lib.core.utils.ErrorCodeTranslated
 import com.infomaniak.lib.core.utils.Utils.enumValueOfOrNull
+import com.infomaniak.mail.R
 import com.infomaniak.mail.data.api.RealmInstantSerializer
 import com.infomaniak.mail.data.api.UnwrappingJsonListSerializer
 import com.infomaniak.mail.data.cache.mailboxContent.FolderController
@@ -317,15 +319,33 @@ class Message : RealmObject, Snoozable {
         ACKNOWLEDGED,
     }
 
-    enum class EmojiReactionNotAllowedReason(override val apiValue: String) : ApiEnum {
-        EmojiReactionFolderNotAllowedDraft("folder_not_allowed_draft"),
-        EmojiReactionFolderNotAllowedScheduledDraft("folder_not_allowed_scheduled_draft"),
-        EmojiReactionFolderNotAllowedSpam("folder_not_allowed_spam"),
-        EmojiReactionFolderNotAllowedTrash("folder_not_allowed_trash"),
-        EmojiReactionMessageInReplyToNotAllowed("message_in_reply_to_not_allowed"),
-        EmojiReactionMessageInReplyToNotValid("message_in_reply_to_not_valid"),
-        EmojiReactionMaxRecipient("max_recipient"),
-        EmojiReactionRecipientNotAllowed("recipient_not_allowed"),
+    enum class EmojiReactionNotAllowedReason(
+        override val apiValue: String,
+        override val translateRes: Int,
+    ) : ApiEnum, ErrorCodeTranslated {
+        EmojiReactionFolderNotAllowedDraft("folder_not_allowed_draft", R.string.errorEmojiReactionFolderNotAllowedDraft),
+        EmojiReactionFolderNotAllowedScheduledDraft(
+            "folder_not_allowed_scheduled_draft",
+            R.string.errorEmojiReactionFolderNotAllowedScheduledDraft
+        ),
+        EmojiReactionFolderNotAllowedSpam("folder_not_allowed_spam", R.string.errorEmojiReactionFolderNotAllowedSpam),
+        EmojiReactionFolderNotAllowedTrash("folder_not_allowed_trash", R.string.errorEmojiReactionFolderNotAllowedTrash),
+        EmojiReactionMessageInReplyToNotAllowed(
+            "message_in_reply_to_not_allowed",
+            R.string.errorEmojiReactionMessageInReplyToNotAllowed
+        ),
+        EmojiReactionMessageInReplyToNotValid(
+            "message_in_reply_to_not_valid",
+            R.string.errorEmojiReactionMessageInReplyToNotValid
+        ),
+        EmojiReactionMessageInReplyToEncrypted(
+            "message_in_reply_to_not_valid",
+            R.string.errorEmojiReactionMessageInReplyEncrypted
+        ),
+        EmojiReactionMaxRecipient("max_recipient", R.string.errorEmojiReactionMaxRecipient),
+        EmojiReactionRecipientNotAllowed("recipient_not_allowed", R.string.errorEmojiReactionRecipientNotAllowed);
+
+        override val code: String = "emoji_reaction__$apiValue"
     }
 
     fun keepLocalValues(localMessage: Message) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/emojiPicker/EmojiPickerBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/emojiPicker/EmojiPickerBottomSheetDialog.kt
@@ -17,11 +17,14 @@
  */
 package com.infomaniak.mail.ui.main.emojiPicker
 
+import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.navArgs
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.infomaniak.lib.core.utils.safeBinding
 import com.infomaniak.lib.core.utils.setBackNavigationResult
@@ -33,6 +36,16 @@ class EmojiPickerBottomSheetDialog : BottomSheetDialogFragment() {
 
     private var binding: FragmentEmojiPickerBinding by safeBinding()
     private val navigationArgs: EmojiPickerBottomSheetDialogArgs by navArgs()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+
+        val behavior = (dialog as BottomSheetDialog).behavior
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        behavior.skipCollapsed = true
+
+        return dialog
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return FragmentEmojiPickerBinding.inflate(inflater, container, false).also { binding = it }.root

--- a/app/src/main/java/com/infomaniak/mail/utils/ErrorCode.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ErrorCode.kt
@@ -19,6 +19,7 @@ package com.infomaniak.mail.utils
 
 import com.infomaniak.lib.core.utils.ApiErrorCode
 import com.infomaniak.mail.R
+import com.infomaniak.mail.data.models.message.Message.EmojiReactionNotAllowedReason
 import com.infomaniak.lib.core.R as RCore
 
 @Suppress("MemberVisibilityCanBePrivate")
@@ -100,6 +101,12 @@ object ErrorCode {
     const val MAIL_MESSAGE_MAX_NUMBER_OF_SCHEDULED_SNOOZE_REACHED = "mail__message_max_number_of_scheduled_snooze_reached"
     const val MAIL_MESSAGE_CANNOT_BE_SNOOZE = "mail__message_cannot_be_snooze"
     //endregion
+    //endregion
+
+    //region Emoji reactions
+    const val EMOJI_REACTION_MAX_REACTION_REACHED = "emoji_reaction__max_reaction_reached"
+    const val EMOJI_REACTION_ALREADY_USED = "emoji_reaction__already_used"
+    //endregion
 
     //region Encryption
     const val ENCRYPTION_PASSWORD_IS_REQUIRED = "encryption_password_is_required"
@@ -151,7 +158,20 @@ object ErrorCode {
         ApiErrorCode(MAIL_MESSAGE_CANNOT_BE_SNOOZE, R.string.errorMessageCannotBeSnoozed),
 
         //Encryption
-        ApiErrorCode(ENCRYPTION_PASSWORD_IS_REQUIRED, R.string.encryptedStatePanelIncomplete)
+        ApiErrorCode(ENCRYPTION_PASSWORD_IS_REQUIRED, R.string.encryptedStatePanelIncomplete),
+
+        // Emoji reactions
+        EmojiReactionNotAllowedReason.EmojiReactionFolderNotAllowedDraft,
+        EmojiReactionNotAllowedReason.EmojiReactionFolderNotAllowedScheduledDraft,
+        EmojiReactionNotAllowedReason.EmojiReactionFolderNotAllowedSpam,
+        EmojiReactionNotAllowedReason.EmojiReactionFolderNotAllowedTrash,
+        EmojiReactionNotAllowedReason.EmojiReactionMessageInReplyToNotAllowed,
+        EmojiReactionNotAllowedReason.EmojiReactionMessageInReplyToNotValid,
+        EmojiReactionNotAllowedReason.EmojiReactionMessageInReplyToEncrypted,
+        EmojiReactionNotAllowedReason.EmojiReactionMaxRecipient,
+        EmojiReactionNotAllowedReason.EmojiReactionRecipientNotAllowed,
+        ApiErrorCode(EMOJI_REACTION_MAX_REACTION_REACHED, R.string.errorEmojiReactionMaxReactionReached),
+        ApiErrorCode(EMOJI_REACTION_ALREADY_USED, R.string.errorEmojiReactionAlreadyUsed),
     )
 
     private val ignoredErrorCodesForDrafts = setOf(

--- a/app/src/main/java/com/infomaniak/mail/utils/ErrorCode.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ErrorCode.kt
@@ -19,7 +19,7 @@ package com.infomaniak.mail.utils
 
 import com.infomaniak.lib.core.utils.ApiErrorCode
 import com.infomaniak.mail.R
-import com.infomaniak.mail.data.models.message.Message.EmojiReactionNotAllowedReason
+import com.infomaniak.mail.data.models.message.EmojiReactionNotAllowedReason
 import com.infomaniak.lib.core.R as RCore
 
 @Suppress("MemberVisibilityCanBePrivate")

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -310,6 +310,17 @@
     <string name="errorCorruptAttachment">Der Entwurf konnte nicht bearbeitet werden, ein Anhang ist beschädigt</string>
     <string name="errorDraftNotFound">Entwurf unauffindbar</string>
     <string name="errorEditScheduledMessage">Geplante oder versendete Nachrichten können nicht geändert werden</string>
+    <string name="errorEmojiReactionAlreadyUsed">Sie haben bereits mit dieser Reaktion reagiert</string>
+    <string name="errorEmojiReactionFolderNotAllowedDraft">Sie können nicht auf einen Entwurf reagieren</string>
+    <string name="errorEmojiReactionFolderNotAllowedScheduledDraft">Sie können nicht auf eine geplante E-Mail antworten</string>
+    <string name="errorEmojiReactionFolderNotAllowedSpam">Sie können nicht auf eine als Spam markierte E-Mail reagieren</string>
+    <string name="errorEmojiReactionFolderNotAllowedTrash">Sie können nicht auf eine E-Mail im Papierkorb reagieren</string>
+    <string name="errorEmojiReactionMaxReactionReached">Sie haben die maximale Anzahl an Reaktionen für diese E-Mail erreicht</string>
+    <string name="errorEmojiReactionMaxRecipient">Sie können nicht auf eine E-Mail mit mehr als 20 Empfängern reagieren</string>
+    <string name="errorEmojiReactionMessageInReplyEncrypted">Sie können nicht auf eine verschlüsselte E-Mail reagieren</string>
+    <string name="errorEmojiReactionMessageInReplyToNotAllowed">Sie können nicht auf diese Art von E-Mail reagieren</string>
+    <string name="errorEmojiReactionMessageInReplyToNotValid">Sie können nicht auf diese E-Mail reagieren</string>
+    <string name="errorEmojiReactionRecipientNotAllowed">Nur Empfänger und Absender können auf diese E-Mail reagieren</string>
     <string name="errorFileNameTooLong">Dateiname zu lang</string>
     <string name="errorFolderDoesNotExist">Der Ordner besteht nicht</string>
     <string name="errorGetCredentials">Konnte keine Anmeldeinformationen erhalten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -310,6 +310,17 @@
     <string name="errorCorruptAttachment">No se ha podido gestionar el borrador, un archivo adjunto está dañado</string>
     <string name="errorDraftNotFound">No se puede encontrar el borrador</string>
     <string name="errorEditScheduledMessage">Imposible modificar un mensaje programado o enviado</string>
+    <string name="errorEmojiReactionAlreadyUsed">Ya has reaccionado con esta reacción</string>
+    <string name="errorEmojiReactionFolderNotAllowedDraft">No puedes reaccionar a un borrador</string>
+    <string name="errorEmojiReactionFolderNotAllowedScheduledDraft">No puedes responder a un correo electrónico programado</string>
+    <string name="errorEmojiReactionFolderNotAllowedSpam">No puedes reaccionar a un correo marcado como spam</string>
+    <string name="errorEmojiReactionFolderNotAllowedTrash">No puedes reaccionar a un correo en la papelera</string>
+    <string name="errorEmojiReactionMaxReactionReached">Has alcanzado el número máximo de reacciones para este correo</string>
+    <string name="errorEmojiReactionMaxRecipient">No puedes reaccionar a un correo con más de 20 destinatarios</string>
+    <string name="errorEmojiReactionMessageInReplyEncrypted">No puedes reaccionar a un correo cifrado</string>
+    <string name="errorEmojiReactionMessageInReplyToNotAllowed">No puedes reaccionar a este tipo de correo</string>
+    <string name="errorEmojiReactionMessageInReplyToNotValid">No puedes reaccionar a este correo</string>
+    <string name="errorEmojiReactionRecipientNotAllowed">Solo los destinatarios y remitentes pueden reaccionar a este correo</string>
     <string name="errorFileNameTooLong">Nombre de archivo demasiado largo</string>
     <string name="errorFolderDoesNotExist">La carpeta no existe</string>
     <string name="errorGetCredentials">No se han podido obtener las credenciales</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -312,6 +312,17 @@
     <string name="errorCorruptAttachment">Échec du traitement du brouillon, une pièce jointe est corrompue</string>
     <string name="errorDraftNotFound">Brouillon introuvable</string>
     <string name="errorEditScheduledMessage">Impossible de modifier un message planifié ou envoyé</string>
+    <string name="errorEmojiReactionAlreadyUsed">Vous avez déjà réagi avec cette réaction</string>
+    <string name="errorEmojiReactionFolderNotAllowedDraft">Vous ne pouvez pas réagir à un brouillon</string>
+    <string name="errorEmojiReactionFolderNotAllowedScheduledDraft">Vous ne pouvez pas réagir à un e-mail programmé</string>
+    <string name="errorEmojiReactionFolderNotAllowedSpam">Vous ne pouvez pas réagir à un e-mail marqué comme spam</string>
+    <string name="errorEmojiReactionFolderNotAllowedTrash">Vous ne pouvez pas réagir à un e-mail dans la corbeille</string>
+    <string name="errorEmojiReactionMaxReactionReached">Vous avez atteint le nombre maximum de réactions pour cet e-mail</string>
+    <string name="errorEmojiReactionMaxRecipient">Vous ne pouvez pas réagir à un e-mail avec plus de 20 destinataires</string>
+    <string name="errorEmojiReactionMessageInReplyEncrypted">Vous ne pouvez pas réagir à un e-mail chiffré</string>
+    <string name="errorEmojiReactionMessageInReplyToNotAllowed">Vous ne pouvez pas réagir à ce type d’e-mail</string>
+    <string name="errorEmojiReactionMessageInReplyToNotValid">Vous ne pouvez pas réagir à cet e-mail</string>
+    <string name="errorEmojiReactionRecipientNotAllowed">Seuls les destinataires et expéditeurs peuvent réagir à cet e-mail</string>
     <string name="errorFileNameTooLong">Nom de fichier trop long</string>
     <string name="errorFolderDoesNotExist">Le dossier n’existe pas</string>
     <string name="errorGetCredentials">Impossible d’obtenir les informations d’identification</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -310,6 +310,17 @@
     <string name="errorCorruptAttachment">Impossibile gestire la bozza, un allegato è danneggiato</string>
     <string name="errorDraftNotFound">Bozza non trovata</string>
     <string name="errorEditScheduledMessage">Impossibile modificare un messaggio pianificato o inviato</string>
+    <string name="errorEmojiReactionAlreadyUsed">Hai già reagito con questa reazione</string>
+    <string name="errorEmojiReactionFolderNotAllowedDraft">Non puoi reagire a una bozza</string>
+    <string name="errorEmojiReactionFolderNotAllowedScheduledDraft">Non puoi reagire a un email programmato</string>
+    <string name="errorEmojiReactionFolderNotAllowedSpam">Non puoi reagire a un’email contrassegnata come spam</string>
+    <string name="errorEmojiReactionFolderNotAllowedTrash">Non puoi reagire a un’email nel cestino</string>
+    <string name="errorEmojiReactionMaxReactionReached">Hai raggiunto il numero massimo di reazioni per questa email</string>
+    <string name="errorEmojiReactionMaxRecipient">Non puoi reagire a un’email con più di 20 destinatari</string>
+    <string name="errorEmojiReactionMessageInReplyEncrypted">Non puoi reagire a un’email criptata</string>
+    <string name="errorEmojiReactionMessageInReplyToNotAllowed">Non puoi reagire a questo tipo di email</string>
+    <string name="errorEmojiReactionMessageInReplyToNotValid">Non puoi reagire a questa email</string>
+    <string name="errorEmojiReactionRecipientNotAllowed">Solo i destinatari e i mittenti possono reagire a questa email</string>
     <string name="errorFileNameTooLong">Nome del file troppo lungo</string>
     <string name="errorFolderDoesNotExist">La cartella è inesistente</string>
     <string name="errorGetCredentials">Non è stato possibile ottenere le credenziali</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -316,6 +316,17 @@
     <string name="errorCorruptAttachment">Failed to handle draft, an attachment is corrupted</string>
     <string name="errorDraftNotFound">Draft cannot be found</string>
     <string name="errorEditScheduledMessage">Scheduled or sent messages cannot be edited</string>
+    <string name="errorEmojiReactionAlreadyUsed">You have already reacted with this reaction</string>
+    <string name="errorEmojiReactionFolderNotAllowedDraft">You cannot react to a draft</string>
+    <string name="errorEmojiReactionFolderNotAllowedScheduledDraft">You cannot react to a scheduled email</string>
+    <string name="errorEmojiReactionFolderNotAllowedSpam">You cannot react to an email marked as spam</string>
+    <string name="errorEmojiReactionFolderNotAllowedTrash">You cannot react to an email in the trash</string>
+    <string name="errorEmojiReactionMaxReactionReached">You have reached the maximum number of reactions for this email</string>
+    <string name="errorEmojiReactionMaxRecipient">You cannot react to an email with more than 20 recipients</string>
+    <string name="errorEmojiReactionMessageInReplyEncrypted">You cannot react to an encrypted email</string>
+    <string name="errorEmojiReactionMessageInReplyToNotAllowed">You cannot react to this type of email</string>
+    <string name="errorEmojiReactionMessageInReplyToNotValid">You cannot react to this email</string>
+    <string name="errorEmojiReactionRecipientNotAllowed">Only recipients and senders can react to this email</string>
     <string name="errorFileNameTooLong">File name too long</string>
     <string name="errorFolderDoesNotExist">The folder does not exist</string>
     <string name="errorGetCredentials">Couldn’t get credentials</string>


### PR DESCRIPTION
Add the different strings translated by iOS to the emoji reactions errors and define them inside `InfomaniakCore.apiErrorCodes`

Depends on #2395