### PR TITLE
fix: When fetching more than one search page, add new page to existing threads

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -31,7 +31,6 @@ import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.utils.ErrorCode
 import com.infomaniak.mail.utils.SearchUtils
 import com.infomaniak.mail.utils.SentryDebug
-import com.infomaniak.mail.utils.extensions.replaceContent
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
 import io.realm.kotlin.TypedRealm
@@ -83,7 +82,7 @@ class ThreadController @Inject constructor(
     suspend fun saveSearchThreads(searchThreads: List<Thread>) {
         mailboxContentRealm().write {
             FolderController.getOrCreateSearchFolder(realm = this).apply {
-                threads.replaceContent(searchThreads)
+                threads.addAll(searchThreads)
             }
         }
     }


### PR DESCRIPTION
We were replacing all of the existing threads with the new page instead of merging them together which lead to some threads having no more parent folders. This occurred only for threads that were not already downloaded in the app prior to searching. Other threads would have lost the search folder as a parent folder but they still had their original folder which hid the issue in this case