### PR TITLE
refactor: Remove unreachable condition and avoid main view model dependence

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -151,6 +151,9 @@ class Thread : RealmObject, Snoozable {
             return@getOrElse _folders.firstOrNull { uid.contains(it.id) } ?: _folders.first()
         }
 
+
+    val folderRole: FolderRole? get() = folder.role
+
     val isOnlyOneDraft get() = messages.count() == 1 && hasDrafts
 
     fun addMessageWithConditions(newMessage: Message, realm: TypedRealm) {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -1322,14 +1322,6 @@ class MainViewModel @Inject constructor(
         isDownloadingChanges.postValue(false)
     }
 
-    fun getActionFolderRole(thread: Thread?): FolderRole? {
-        return getActionFolderRole(thread?.let(::listOf))
-    }
-
-    fun getActionFolderRole(message: Message): FolderRole? {
-        return getActionFolderRole(message.threads, message)
-    }
-
 // TODO: Handle this correctly if MultiSelect feature is added in the Search.
     /**
      * Get the FolderRole of a Message or a list of Threads.
@@ -1339,15 +1331,8 @@ class MainViewModel @Inject constructor(
      */
     private fun getActionFolderRole(threads: List<Thread>?, message: Message? = null): FolderRole? {
         return when {
-            message != null -> {
-                message.folder.role
-            }
-            threads?.firstOrNull()?.folderId == FolderController.SEARCH_FOLDER_ID -> {
-                folderController.getFolder(threads.first().folderId)?.role
-            }
-            else -> {
-                threads?.firstOrNull()?.folder?.role
-            }
+            message != null -> message.folder.role
+            else -> threads?.firstOrNull()?.folderRole
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -95,7 +95,7 @@ class ThreadListAdapter @Inject constructor(
     private var swipingIsAuthorized: Boolean = true
     private var isLoadMoreDisplayed = false
 
-    private var folderRole: FolderRole? = null
+    private var currentFolderRole: FolderRole? = null
     private var multiSelection: MultiSelectionListener<Thread>? = null
     private var isFolderNameVisible: Boolean = false
     private var callbacks: ThreadListAdapterCallbacks? = null
@@ -109,7 +109,7 @@ class ThreadListAdapter @Inject constructor(
         private set
     //endregion
 
-    private val isMultiselectDisabledInThisFolder: Boolean get() = folderRole == FolderRole.SCHEDULED_DRAFTS
+    private val isMultiselectDisabledInThisFolder: Boolean get() = currentFolderRole == FolderRole.SCHEDULED_DRAFTS
 
     init {
         setHasStableIds(true)
@@ -121,7 +121,7 @@ class ThreadListAdapter @Inject constructor(
         multiSelection: MultiSelectionListener<Thread>? = null,
         isFolderNameVisible: Boolean = false,
     ) {
-        this.folderRole = folderRole
+        this.currentFolderRole = folderRole
         this.multiSelection = multiSelection
         this.isFolderNameVisible = isFolderNameVisible
         this.callbacks = callbacks
@@ -235,7 +235,7 @@ class ThreadListAdapter @Inject constructor(
             mailSubject.text = context.formatSubject(subject)
             mailBodyPreview.text = computePreview().ifBlank { context.getString(R.string.noBodyTitle) }
 
-            val dateDisplay = computeThreadListDateDisplay(folderRole)
+            val dateDisplay = computeThreadListDateDisplay(currentFolderRole)
             mailDate.text = dateDisplay.formatThreadDate(context, this)
             mailDateIcon.apply {
                 isVisible = dateDisplay.iconRes != null
@@ -281,7 +281,7 @@ class ThreadListAdapter @Inject constructor(
     }
 
     private fun CardviewThreadItemBinding.displaySpamSpecificUi(thread: Thread) {
-        val (mailAddressText, isVisible) = if (folderRole == FolderRole.SPAM) {
+        val (mailAddressText, isVisible) = if (currentFolderRole == FolderRole.SPAM) {
             thread.from.first().quotedEmail() to true
         } else {
             "" to false
@@ -556,14 +556,14 @@ class ThreadListAdapter @Inject constructor(
         val featureFlags = callbacks?.getFeatureFlags?.invoke()
 
         (recyclerView as DragDropSwipeRecyclerView).apply {
-            if (localSettings.swipeLeft.canDisplay(folderRole, featureFlags, localSettings)) {
+            if (localSettings.swipeLeft.canDisplay(currentFolderRole, featureFlags, localSettings)) {
                 getSwipeActionUiData(localSettings.swipeLeft)?.let { (colorRes, iconRes) ->
                     behindSwipedItemBackgroundColor = context.getColor(colorRes)
                     behindSwipedItemIconDrawableId = iconRes
                 }
             }
 
-            if (localSettings.swipeRight.canDisplay(folderRole, featureFlags, localSettings)) {
+            if (localSettings.swipeRight.canDisplay(currentFolderRole, featureFlags, localSettings)) {
                 getSwipeActionUiData(localSettings.swipeRight)?.let { (colorRes, iconRes) ->
                     behindSwipedItemBackgroundSecondaryColor = context.getColor(colorRes)
                     behindSwipedItemIconSecondaryDrawableId = iconRes
@@ -661,7 +661,7 @@ class ThreadListAdapter @Inject constructor(
         formatListJob = lifecycleScope.launch {
 
             val formattedList = runCatchingRealm {
-                formatList(itemList, recyclerView.context, folderRole, localSettings.threadDensity, scope = this)
+                formatList(itemList, recyclerView.context, currentFolderRole, localSettings.threadDensity, scope = this)
             }.getOrDefault(emptyList())
 
             Dispatchers.Main {
@@ -731,7 +731,7 @@ class ThreadListAdapter @Inject constructor(
     }
 
     fun updateFolderRole(newRole: FolderRole?) {
-        folderRole = newRole
+        currentFolderRole = newRole
     }
 
     fun updateSelection() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListMultiSelection.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListMultiSelection.kt
@@ -81,7 +81,7 @@ class ThreadListMultiSelection {
                 }
                 R.id.quickActionArchive -> {
                     threadListFragment.descriptionDialog.archiveWithConfirmationPopup(
-                        folderRole = getActionFolderRole(thread = selectedThreads.firstOrNull()),
+                        folderRole = selectedThreads.firstOrNull()?.folderRole,
                         count = selectedThreadsCount,
                     ) {
                         threadListFragment.trackMultiSelectActionEvent(ACTION_ARCHIVE_NAME, selectedThreadsCount)
@@ -96,7 +96,7 @@ class ThreadListMultiSelection {
                 }
                 R.id.quickActionDelete -> threadListFragment.apply {
                     threadListFragment.descriptionDialog.deleteWithConfirmationPopup(
-                        folderRole = getActionFolderRole(selectedThreads.firstOrNull()),
+                        folderRole = selectedThreads.firstOrNull()?.folderRole,
                         count = selectedThreadsCount,
                     ) {
                         trackMultiSelectActionEvent(ACTION_DELETE_NAME, selectedThreadsCount)
@@ -206,7 +206,7 @@ class ThreadListMultiSelection {
             changeIcon(FAVORITE_INDEX, favoriteIcon)
 
             val isSelectionEmpty = selectedThreads.isEmpty()
-            val isFromArchive = mainViewModel.getActionFolderRole(selectedThreads.firstOrNull()) == FolderRole.ARCHIVE
+            val isFromArchive = selectedThreads.firstOrNull()?.folderRole == FolderRole.ARCHIVE
             for (index in 0 until getButtonCount()) {
                 val shouldDisable = isSelectionEmpty || (isFromArchive && index == ARCHIVE_INDEX)
                 if (shouldDisable) disable(index) else enable(index)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -438,7 +438,7 @@ class ThreadFragment : Fragment() {
                     return@collect
                 }
 
-                initUi(thread.uid, folderRole = mainViewModel.getActionFolderRole(thread))
+                initUi(thread.uid, folderRole = thread.folderRole)
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MessageActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MessageActionsBottomSheetDialog.kt
@@ -67,7 +67,7 @@ class MessageActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
 
         mainViewModel.getMessage(messageUid).observe(viewLifecycleOwner) { message ->
 
-            folderRole = mainViewModel.getActionFolderRole(message)
+            folderRole = message.folder.role
 
             setMarkAsReadUi(message.isSeen)
             setArchiveUi(isFromArchive = folderRole == FolderRole.ARCHIVE)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MultiSelectBottomSheetDialog.kt
@@ -93,7 +93,7 @@ class MultiSelectBottomSheetDialog : ActionsBottomSheetDialog() {
                 R.id.actionMove -> {
                     val navController = findNavController()
                     descriptionDialog.moveWithConfirmationPopup(
-                        folderRole = getActionFolderRole(threads.firstOrNull()),
+                        folderRole = threads.firstOrNull()?.folderRole,
                         count = threadsCount,
                     ) {
                         trackMultiSelectActionEvent(ACTION_MOVE_NAME, threadsCount, isFromBottomSheet = true)
@@ -111,7 +111,7 @@ class MultiSelectBottomSheetDialog : ActionsBottomSheetDialog() {
                 }
                 R.id.actionArchive -> {
                     descriptionDialog.archiveWithConfirmationPopup(
-                        folderRole = getActionFolderRole(threads.firstOrNull()),
+                        folderRole = threads.firstOrNull()?.folderRole,
                         count = threadsCount,
                     ) {
                         trackMultiSelectActionEvent(ACTION_ARCHIVE_NAME, threadsCount, isFromBottomSheet = true)
@@ -120,7 +120,7 @@ class MultiSelectBottomSheetDialog : ActionsBottomSheetDialog() {
                 }
                 R.id.actionDelete -> {
                     descriptionDialog.deleteWithConfirmationPopup(
-                        folderRole = getActionFolderRole(threads.firstOrNull()),
+                        folderRole = threads.firstOrNull()?.folderRole,
                         count = threadsCount,
                     ) {
                         trackMultiSelectActionEvent(ACTION_DELETE_NAME, threadsCount, isFromBottomSheet = true)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsBottomSheetDialog.kt
@@ -81,7 +81,7 @@ class ThreadActionsBottomSheetDialog : MailActionsBottomSheetDialog() {
 
         threadLive.observe(viewLifecycleOwner) { thread ->
 
-            folderRole = mainViewModel.getActionFolderRole(thread)
+            folderRole = thread.folderRole
             isFromArchive = folderRole == FolderRole.ARCHIVE
             isFromSpam = folderRole == FolderRole.SPAM
 


### PR DESCRIPTION
Inside the main view model's `getActionFolderRole()` method, the condition `threads?.firstOrNull()?.folderId == FolderController.SEARCH_FOLDER_ID` can never be met because `folderId` comes from the API and therefore cannot ever be equal to our local `FolderController.SEARCH_FOLDER_ID`. I removed the check, which renders the logic of the method pretty straight forward.

The new logic is so straight forward that, in a lot of cases, there's no need to depend on the view model for this logic. It even introduces unnecessary cognitive complexity to be able to make sense of what is really computed. I kept all the calls centralized in a unique point by introducing the `Thread.folderRole` property.

I had to rename the existing `folderRole` inside the ThreadListAdapter to not clash with the `Thread.folderRole` when we have a Thread as receiver in a scope