### PR TITLE
fix: Remove displayBatchedMessages to fix ThreadAdapter

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -183,7 +183,6 @@ class ThreadFragment : Fragment() {
         observeLightThemeToggle()
         observeThreadLive()
         observeMessagesLive()
-        observeBatchedMessages()
         observeFailedMessages()
         observeQuickActionBarClicks()
         observeSubjectUpdateTriggers()
@@ -508,10 +507,6 @@ class ThreadFragment : Fragment() {
 
             fetchCalendarEvents(items)
         }
-    }
-
-    private fun observeBatchedMessages() {
-        threadViewModel.batchedMessages.observe(viewLifecycleOwner, threadAdapter::submitList)
     }
 
     private fun observeFailedMessages() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -110,8 +110,6 @@ class ThreadViewModel @Inject constructor(
             mode
         }.flatMapLatest { mode -> mode.getMessages() }.asLiveData(ioCoroutineContext)
 
-    val batchedMessages = SingleLiveEvent<List<Any>>()
-
     val quickActionBarClicks = SingleLiveEvent<QuickActionBarResult>()
 
     val failedMessagesUids = SingleLiveEvent<List<String>>()


### PR DESCRIPTION
We can't use the properties of an adapter anymore if we use this batched messages strategy. The diff util doesn't see previous instances of the items past the first item because when the 10th item of a list is updated, we've tried binding the 9 previous items one by one just so the 10th could be updated. At the time we try to bind the 10th item again, we can't compare the item with its previous instance because at the last known bind, there was no 10th item there only was 9.

This prevents us from using any form of payload to optimize subsequent binds and avoid binding webviews again which is required because binding webviews again makes all of the ui blink uncontrollably.

This payload property is especially used a lot for emoji reactions in future PRs. But it still does impact master if we need to update the attendance state of a calendar event (rare) or if we need to fetch the heavy data of messages (very common)