### PR TITLE
feat: Fake sent emojis locally

### DIFF
--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/EmojiReactions.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/EmojiReactions.kt
@@ -35,7 +35,6 @@ import com.infomaniak.core.compose.margin.Margin
 import com.infomaniak.emojicomponents.data.ReactionState
 import com.infomaniak.emojicomponents.icons.FaceSmileRoundPlus
 import com.infomaniak.emojicomponents.icons.Icons
-import com.infomaniak.emojicomponents.updateWithEmoji
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -78,6 +77,16 @@ object EmojiReactionsDefaults {
 @Composable
 private fun EmojiReactionsPreview() {
     class State(override val count: Int, override val hasReacted: Boolean) : ReactionState
+
+    fun SnapshotStateMap<String, ReactionState>.updateWithEmoji(emoji: String) {
+        if (this[emoji]?.hasReacted == true) return
+
+        val oldCount = this[emoji]?.count ?: 0
+        this[emoji] = object : ReactionState {
+            override val count: Int = oldCount + 1
+            override val hasReacted: Boolean = true
+        }
+    }
 
     val reactions: SnapshotStateMap<String, ReactionState> = remember {
         mutableStateMapOf(

--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -310,7 +310,7 @@ class MainActivity : BaseActivity() {
         WorkerUtils.flushWorkersBefore(context = this@MainActivity, lifecycleOwner = this@MainActivity) {
 
             val treatedWorkInfoUuids = mutableSetOf<UUID>()
-            getCompletedAndFailedInfoLiveData().observe(this@MainActivity) {
+            getCompletedInfoLiveData().observe(this@MainActivity) {
                 it.forEach { workInfo ->
                     if (!treatedWorkInfoUuids.add(workInfo.id)) return@forEach
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/PrintMailFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/PrintMailFragment.kt
@@ -30,9 +30,9 @@ import androidx.navigation.fragment.navArgs
 import com.infomaniak.lib.core.utils.safeBinding
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.LocalSettings
-import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.databinding.FragmentPrintMailBinding
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.ThreadAdapterCallbacks
+import com.infomaniak.mail.ui.main.thread.models.MessageUi
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -84,7 +84,7 @@ class PrintMailFragment : Fragment() {
     private fun startPrintingView() {
         printMailViewModel.startPrintingService(
             activityContext = requireActivity(),
-            subject = (threadAdapter.items.single() as Message).subject,
+            subject = (threadAdapter.items.single() as MessageUi).message.subject,
             webView = getWebViewToPrint(),
             onFinish = findNavController()::popBackStack,
         )

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -174,7 +174,7 @@ class ThreadAdapter(
                 NotifyType.RE_RENDER -> reloadVisibleWebView()
                 NotifyType.FAILED_MESSAGE -> handleFailedMessagePayload(item.message.uid)
                 NotifyType.ONLY_REBIND_CALENDAR_ATTENDANCE -> handleCalendarAttendancePayload(item.message)
-                NotifyType.ONLY_REBIND_EMOJI_REACTIONS -> handleEmojiReactionPayload(item.emojiReactionState)
+                NotifyType.ONLY_REBIND_EMOJI_REACTIONS -> handleEmojiReactionPayload(item.emojiReactionsState)
             }
         }
     }.getOrDefault(Unit)
@@ -195,8 +195,8 @@ class ThreadAdapter(
         calendarEvent.onlyUpdateAttendance(attendees)
     }
 
-    private fun ItemMessageBinding.handleEmojiReactionPayload(emojiReactions: Map<String, ReactionState>) {
-        this.emojiReactions.bindEmojiReactions(emojiReactions)
+    private fun ItemMessageBinding.handleEmojiReactionPayload(emojiReactionsState: Map<String, ReactionState>) {
+        emojiReactions.bindEmojiReactions(emojiReactionsState)
     }
 
     private fun EmojiReactionsView.bindEmojiReactions(emojiReactions: Map<String, ReactionState>) {
@@ -813,7 +813,7 @@ class ThreadAdapter(
     }
 
     private fun MessageViewHolder.bindEmojiReactions(messageUi: MessageUi) = with(binding.emojiReactions) {
-        bindEmojiReactions(messageUi.emojiReactionState)
+        bindEmojiReactions(messageUi.emojiReactionsState)
         setOnAddReactionClickListener { threadAdapterCallbacks?.onAddReaction?.invoke(messageUi.message) }
         setOnEmojiClickListener { emoji ->
             threadAdapterCallbacks?.onAddEmoji?.invoke(emoji, messageUi.message.uid)
@@ -927,7 +927,8 @@ class ThreadAdapter(
 
             // TODO: Handle the case where there are multiple aspects that changed at once
             return when {
-                MessageDiffAspect.AnythingElse.areDifferent(oldItem.message, newItem.message) -> null // null means "bind the whole item again"
+                // null means "bind the whole item again"
+                MessageDiffAspect.AnythingElse.areDifferent(oldItem.message, newItem.message) -> null
                 MessageDiffAspect.EmojiReactions.areDifferent(oldItem, newItem) -> NotifyType.ONLY_REBIND_EMOJI_REACTIONS
                 else -> getCalendarEventPayloadOrNull(oldItem.message, newItem.message)
             }
@@ -967,7 +968,7 @@ class ThreadAdapter(
 
             object MessageDiffAspect {
                 data object EmojiReactions : DiffAspect<MessageUi>({
-                    emojiReactionState.containsTheSameEmojiValuesAs(it.emojiReactionState)
+                    emojiReactionsState.containsTheSameEmojiValuesAs(it.emojiReactionsState)
                 })
 
                 data object Calendar : DiffAspect<Message>({

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -641,10 +641,10 @@ class ThreadFragment : Fragment() {
             runningWorkInfoLiveData.observe(viewLifecycleOwner) {
                 it.forEach { workInfo ->
                     workInfo.progress.let {
-                        val emojiSendResult = it.getSerializable<DraftsActionsWorker.EmojiSendResult>(EMOJI_SENT_STATUS) ?: return@forEach
+                        val emojiSendResult =
+                            it.getSerializable<DraftsActionsWorker.EmojiSendResult>(EMOJI_SENT_STATUS) ?: return@forEach
                         if (emojiSendResult.isSuccess.not()) {
-                            // TODO: Remove the local status of this emoji
-                            threadViewModel
+                            threadViewModel.undoFakeEmojiReply(emojiSendResult.emoji, emojiSendResult.previousMessageUid)
                         }
                         Log.e("gibran", "observeDraftWorkerResults - emojiSendResult: ${emojiSendResult}")
                     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -648,7 +648,7 @@ class ThreadFragment : Fragment() {
                     val emojiSendResult = workInfo.progress
                         .getSerializable<DraftsActionsWorker.EmojiSendResult>(EMOJI_SENT_STATUS) ?: return@forEach
 
-                    undoFakeEmojiReply(emojiSendResult)
+                    undoFakeEmojiReplyIfNeeded(emojiSendResult)
                 }
             }
 
@@ -663,14 +663,14 @@ class ThreadFragment : Fragment() {
                         .getSerializable<DraftsActionsWorker.EmojiSendResults>(ALL_EMOJI_SENT_STATUS) ?: return@forEach
 
                     emojiSendResults.results.forEach { emojiSendResult ->
-                        undoFakeEmojiReply(emojiSendResult)
+                        undoFakeEmojiReplyIfNeeded(emojiSendResult)
                     }
                 }
             }
         }
     }
 
-    private fun undoFakeEmojiReply(emojiSendResult: DraftsActionsWorker.EmojiSendResult) {
+    private fun undoFakeEmojiReplyIfNeeded(emojiSendResult: DraftsActionsWorker.EmojiSendResult) {
         if (emojiSendResult.isSuccess.not()) {
             threadViewModel.undoFakeEmojiReply(emojiSendResult.emoji, emojiSendResult.previousMessageUid)
         }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -631,6 +631,7 @@ class ThreadFragment : Fragment() {
 
     private fun observePickedEmoji() {
         getBackNavigationResult<PickedEmojiPayload>(EmojiPickerBottomSheetDialog.PICKED_EMOJI) { (emoji, messageUid) ->
+            threadViewModel.fakeEmojiReply(emoji, messageUid)
             mainViewModel.sendEmojiReply(emoji, messageUid)
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -655,7 +655,7 @@ class ThreadFragment : Fragment() {
             // Listening to the draft results ensures we will get all of the possible emoji results and not miss any unlike when
             // we listen to the worker's progress.
             val treatedWorkInfoUuids = mutableSetOf<UUID>()
-            draftsActionsWorkerScheduler.getCompletedAndFailedInfoLiveData().observe(viewLifecycleOwner) {
+            draftsActionsWorkerScheduler.getCompletedInfoLiveData().observe(viewLifecycleOwner) {
                 it.forEach { workInfo ->
                     if (!treatedWorkInfoUuids.add(workInfo.id)) return@forEach
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -529,6 +529,9 @@ class ThreadViewModel @Inject constructor(
         viewModelScope.launch {
             val messageId = messageController.getMessage(messageUid)?.messageId ?: return@launch
 
+            // If the value isn't present, there's nothing to remove, so we can exit
+            if (fakeReactions.value[messageId]?.contains(emoji) != true) return@launch
+
             // TODO: Optimize memory consumption
             fakeReactions.value = fakeReactions.value.toMutableMap().apply {
                 set(messageId, getOrDefault(messageId, emptySet()).minus(emoji))

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -622,11 +622,24 @@ private fun <E : Any> List<E>.toUiMessages(fakeReactions: Map<String, Set<String
 }
 
 private fun RealmDictionary<EmojiReactionState?>.toFakedReactions(localReactions: Set<String>): Map<String, ReactionState> {
-    return entries
+    val fakeReactions = mutableMapOf<String, ReactionState>()
+
+    entries
         .filterOutNullStates()
-        .associate { (emoji, state) ->
+        .associateTo(fakeReactions) { (emoji, state) ->
             emoji to fakeEmojiReactionState(emoji, state, localReactions)
         }
+
+    localReactions.forEach { emoji ->
+        if (emoji !in fakeReactions) {
+            fakeReactions[emoji] = object : ReactionState {
+                override val count = 1
+                override val hasReacted = true
+            }
+        }
+    }
+
+    return fakeReactions
 }
 
 private fun <T> Set<Map.Entry<String, T?>>.filterOutNullStates(): List<Map.Entry<String, T>> {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.liveData
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
+import com.infomaniak.emojicomponents.data.ReactionState
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.utils.SingleLiveEvent
 import com.infomaniak.mail.MatomoMail.MatomoName
@@ -45,10 +46,12 @@ import com.infomaniak.mail.data.models.calendar.Attendee.AttendanceState
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
 import com.infomaniak.mail.data.models.isSnoozed
 import com.infomaniak.mail.data.models.mailbox.Mailbox
+import com.infomaniak.mail.data.models.message.EmojiReactionState
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.SuperCollapsedBlock
+import com.infomaniak.mail.ui.main.thread.models.MessageUi
 import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.FeatureAvailability.isSnoozeAvailable
 import com.infomaniak.mail.utils.MessageBodyUtils
@@ -64,6 +67,7 @@ import com.infomaniak.mail.utils.extensions.indexOfFirstOrNull
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.query.RealmResults
+import io.realm.kotlin.types.RealmDictionary
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -72,6 +76,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChangedBy
@@ -139,6 +144,10 @@ class ThreadViewModel @Inject constructor(
         .map { it.obj }
         .asLiveData(ioCoroutineContext)
 
+    // To each message id we associate a set of emojis that are added for fake so we can instantly apply clicked emojis without
+    // having to wait for the api call to return
+    private val fakeReactions = MutableStateFlow<Map<String, Set<String>>>(emptyMap())
+
     @OptIn(ExperimentalCoroutinesApi::class)
     val messagesLive: LiveData<Pair<ThreadAdapterItems, MessagesWithoutHeavyData>> =
         /**
@@ -148,9 +157,19 @@ class ThreadViewModel @Inject constructor(
          * As a workaround, [ThreadState.hasSuperCollapsedBlockBeenClicked] is used solely to retrigger the computation.
          * The [ThreadOpeningMode.getMessages] method will independently determine the appropriate value to use.
          */
-        combine(threadOpeningModeFlow, threadState.hasSuperCollapsedBlockBeenClicked, featureFlagsFlow) { mode, _, featureFlags ->
-            mode to featureFlags
-        }.flatMapLatest { (mode, featureFlags) -> mode.getMessages(featureFlags) }.asLiveData(ioCoroutineContext)
+        combine(
+            threadOpeningModeFlow,
+            threadState.hasSuperCollapsedBlockBeenClicked,
+            featureFlagsFlow,
+            fakeReactions,
+            transform = { mode, _, featureFlags, fakeReactions ->
+                Triple(mode, featureFlags, fakeReactions)
+            },
+        ).flatMapLatest { (mode, featureFlags, fakeReactions) ->
+            mode.getMessages(featureFlags).map { (items, messagesToFetch) ->
+                items.toUiMessages(fakeReactions) to messagesToFetch
+            }
+        }.asLiveData(ioCoroutineContext)
 
     val quickActionBarClicks = SingleLiveEvent<QuickActionBarResult>()
 
@@ -428,8 +447,8 @@ class ThreadViewModel @Inject constructor(
 
     private suspend fun fetchCalendarEvent(item: Any, forceFetch: Boolean): Pair<Message, ApiResponse<CalendarEventResponse>>? {
 
-        if (item !is Message) return null
-        val message: Message = item
+        if (item !is MessageUi) return null
+        val message: Message = item.message
 
         if (!message.isFullyDownloaded()) return null // Only process Messages with Attachments already downloaded
 
@@ -492,6 +511,28 @@ class ThreadViewModel @Inject constructor(
     fun updateCurrentThreadUid(mode: ThreadOpeningMode) {
         viewModelScope.launch {
             _threadOpeningModeFlow.emit(mode)
+        }
+    }
+
+    fun fakeEmojiReply(emoji: String, messageUid: String) {
+        viewModelScope.launch {
+            val messageId = messageController.getMessage(messageUid)?.messageId ?: return@launch
+
+            // TODO: Optimize memory consumption
+            fakeReactions.value = fakeReactions.value.toMutableMap().apply {
+                set(messageId, getOrDefault(messageId, emptySet()).plus(emoji))
+            }
+        }
+    }
+
+    fun undoFakeEmojiReply(emoji: String, messageUid: String) {
+        viewModelScope.launch {
+            val messageId = messageController.getMessage(messageUid)?.messageId ?: return@launch
+
+            // TODO: Optimize memory consumption
+            fakeReactions.value = fakeReactions.value.toMutableMap().apply {
+                set(messageId, getOrDefault(messageId, emptySet()).minus(emoji))
+            }
         }
     }
 
@@ -565,4 +606,38 @@ class ThreadViewModel @Inject constructor(
         private const val SUPER_COLLAPSED_BLOCK_MINIMUM_MESSAGES_LIMIT = 5
         private const val SUPER_COLLAPSED_BLOCK_FIRST_INDEX_LIMIT = 3
     }
+}
+
+private fun <E : Any> List<E>.toUiMessages(fakeReactions: Map<String, Set<String>>): List<Any> = map { item ->
+    if (item is Message) {
+        val localReactions = fakeReactions[item.messageId] ?: emptySet()
+        val reactions = item.emojiReactions.toFakedReactions(localReactions)
+        MessageUi(item, reactions)
+    } else {
+        item
+    }
+}
+
+private fun RealmDictionary<EmojiReactionState?>.toFakedReactions(localReactions: Set<String>): Map<String, ReactionState> {
+    return entries
+        .filterOutNullStates()
+        .associate { (emoji, state) ->
+            emoji to fakeEmojiReactionState(emoji, state, localReactions)
+        }
+}
+
+private fun <T> Set<Map.Entry<String, T?>>.filterOutNullStates(): List<Map.Entry<String, T>> {
+    @Suppress("UNCHECKED_CAST")
+    return filter { (_, state) -> state != null } as List<Map.Entry<String, T>>
+}
+
+private fun fakeEmojiReactionState(emoji: String, state: EmojiReactionState, localReactions: Set<String>): ReactionState {
+    val shouldFake = emoji in localReactions && !state.hasReacted
+
+    val fakedReaction = object : ReactionState {
+        override val count = state.count + if (shouldFake) 1 else 0
+        override val hasReacted = state.hasReacted || shouldFake
+    }
+
+    return fakedReaction
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/MessageUi.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/MessageUi.kt
@@ -15,17 +15,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.infomaniak.emojicomponents
+package com.infomaniak.mail.ui.main.thread.models
 
-import androidx.compose.runtime.snapshots.SnapshotStateMap
 import com.infomaniak.emojicomponents.data.ReactionState
+import com.infomaniak.mail.data.models.message.Message
 
-internal fun SnapshotStateMap<String, ReactionState>.updateWithEmoji(emoji: String) {
-    if (this[emoji]?.hasReacted == true) return
-
-    val oldCount = this[emoji]?.count ?: 0
-    this[emoji] = object : ReactionState {
-        override val count: Int = oldCount + 1
-        override val hasReacted: Boolean = true
-    }
-}
+data class MessageUi(val message: Message, val emojiReactionState: Map<String, ReactionState>)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/MessageUi.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/MessageUi.kt
@@ -20,4 +20,4 @@ package com.infomaniak.mail.ui.main.thread.models
 import com.infomaniak.emojicomponents.data.ReactionState
 import com.infomaniak.mail.data.models.message.Message
 
-data class MessageUi(val message: Message, val emojiReactionState: Map<String, ReactionState>)
+data class MessageUi(val message: Message, val emojiReactionsState: Map<String, ReactionState>)

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -539,7 +539,7 @@ class DraftsActionsWorker @AssistedInject constructor(
             return WorkerUtils.getWorkInfoLiveData(TAG, workManager, listOf(State.RUNNING))
         }
 
-        fun getCompletedWorkInfoLiveData(): LiveData<List<WorkInfo>> {
+        fun getSuccessWorkInfoLiveData(): LiveData<List<WorkInfo>> {
             return WorkerUtils.getWorkInfoLiveData(TAG, workManager, listOf(State.SUCCEEDED))
         }
 
@@ -547,7 +547,7 @@ class DraftsActionsWorker @AssistedInject constructor(
             return WorkerUtils.getWorkInfoLiveData(TAG, workManager, listOf(State.FAILED))
         }
 
-        fun getCompletedAndFailedInfoLiveData(): LiveData<List<WorkInfo>> {
+        fun getCompletedInfoLiveData(): LiveData<List<WorkInfo>> {
             return WorkerUtils.getWorkInfoLiveData(TAG, workManager, listOf(State.SUCCEEDED, State.FAILED))
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -536,7 +536,7 @@ class DraftsActionsWorker @AssistedInject constructor(
     }
 
     @Serializable
-    data class EmojiSendResult(val previousMessageUid: String, val isSuccess: Boolean)
+    data class EmojiSendResult(val previousMessageUid: String, val isSuccess: Boolean, val emoji: String)
 
     companion object {
         private const val TAG = "DraftsActionsWorker"
@@ -557,7 +557,10 @@ class DraftsActionsWorker @AssistedInject constructor(
 
         private suspend fun DraftsActionsWorker.notifyOfEmojiProgress(draft: Draft, draftActionResult: DraftActionResult) {
             val previousMessageUid = draft.inReplyToUid ?: return // inReplyToUid is always set in the case of an emoji reaction
-            val encodedEmojiSendResult = Json.encodeToString(EmojiSendResult(previousMessageUid, draftActionResult.isSuccess))
+            val emoji = draft.emojiReaction ?: return // we always have an emoji in the case of an emoji reaction
+            val encodedEmojiSendResult = Json.encodeToString(
+                EmojiSendResult(previousMessageUid, draftActionResult.isSuccess, emoji)
+            )
             Log.e("gibran", "notifyOfEmojiProgress - encodedEmojiSendResult: ${encodedEmojiSendResult}")
             setProgress(workDataOf(EMOJI_SENT_STATUS to encodedEmojiSendResult))
         }

--- a/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
+++ b/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
@@ -24,6 +24,7 @@ import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse.AttachmentEventMethod
 import com.infomaniak.mail.data.models.message.Body
 import com.infomaniak.mail.data.models.message.Message
+import com.infomaniak.mail.ui.main.thread.models.MessageUi
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.NotifyType
 import io.realm.kotlin.ext.realmListOf
@@ -43,7 +44,7 @@ class CalendarEventResponseTest {
             body = null
             splitBody = null
             latestCalendarEventResponse = response1
-        }
+        }.toMessageUi()
 
         // If nothing changed at all, no change should be detected
         assertTrue(messageDiffCallback.areContentsTheSame(message, message))
@@ -58,7 +59,7 @@ class CalendarEventResponseTest {
             body = filledBody
             splitBody = null
             latestCalendarEventResponse = response1
-        }
+        }.toMessageUi()
         assertFalse(messageDiffCallback.areContentsTheSame(message, otherThingsButAttendeesChanged))
         assertEquals(null, messageDiffCallback.getChangePayload(message, otherThingsButAttendeesChanged))
 
@@ -70,7 +71,7 @@ class CalendarEventResponseTest {
             body = null
             splitBody = null
             latestCalendarEventResponse = response2
-        }
+        }.toMessageUi()
         assertFalse(messageDiffCallback.areContentsTheSame(message, onlyAttendeesChanged))
         assertEquals(
             NotifyType.ONLY_REBIND_CALENDAR_ATTENDANCE,
@@ -83,7 +84,7 @@ class CalendarEventResponseTest {
             body = filledBody
             splitBody = null
             latestCalendarEventResponse = response2
-        }
+        }.toMessageUi()
         assertFalse(messageDiffCallback.areContentsTheSame(message, otherThingsAndAttendeesChanged))
         assertEquals(null, messageDiffCallback.getChangePayload(message, otherThingsAndAttendeesChanged))
     }
@@ -166,3 +167,5 @@ class CalendarEventResponseTest {
         val tomorrow = RealmInstant.from(1_706_792_315L, 0)
     }
 }
+
+private fun Message.toMessageUi(): MessageUi = MessageUi(this, emptyMap())


### PR DESCRIPTION
Fake emojis locally when they are clicked so the UX is quick and responsive. In the meanwhile the code will try to send the emoji for real and only undo the faked reaction if the api call has failed.

This required to introduce a MessageUi model because relying on the database model made it impossible to fake reactions at the UI level. MessageUi mainly wraps the existing Message instance so I don't have to refactor the whole app.

For now reactions are only faked locally but some buttons can be clicked even though they should not. This is handled in later PRs.

Depends on #2432