### PR TITLE
feat: Prevent sending emojis when not allowed

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -75,6 +75,7 @@ import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.ContactUtils.getPhoneContacts
 import com.infomaniak.mail.utils.ContactUtils.mergeApiContactsIntoPhoneContacts
 import com.infomaniak.mail.utils.DraftInitManager
+import com.infomaniak.mail.utils.EmojiReactionUtils.hasAvailableReactionSlot
 import com.infomaniak.mail.utils.ErrorCode
 import com.infomaniak.mail.utils.FolderRoleUtils
 import com.infomaniak.mail.utils.MyKSuiteDataUtils
@@ -1306,10 +1307,9 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    private fun Map<String, ReactionState?>.getEmojiSendStatus(emoji: String): EmojiSendStatus = when {
+    private fun Map<String, ReactionState>.getEmojiSendStatus(emoji: String): EmojiSendStatus = when {
         this[emoji]?.hasReacted == true -> EmojiSendStatus.NotAllowed.AlreadyUsed
-        // TODO: Centralize logic with future branch
-        count { it.value?.hasReacted == true } >= 5 -> EmojiSendStatus.NotAllowed.MaxReactionReached
+        hasAvailableReactionSlot().not() -> EmojiSendStatus.NotAllowed.MaxReactionReached
         hasNetwork.not() -> EmojiSendStatus.NotAllowed.NoInternet
         else -> EmojiSendStatus.Allowed
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -1310,6 +1310,7 @@ class MainViewModel @Inject constructor(
         this[emoji]?.hasReacted == true -> EmojiSendStatus.NotAllowed.AlreadyUsed
         // TODO: Centralize logic with future branch
         count { it.value?.hasReacted == true } >= 5 -> EmojiSendStatus.NotAllowed.MaxReactionReached
+        hasNetwork.not() -> EmojiSendStatus.NotAllowed.NoInternet
         else -> EmojiSendStatus.Allowed
     }
 
@@ -1356,6 +1357,7 @@ class MainViewModel @Inject constructor(
         sealed class NotAllowed(@StringRes val errorMessageRes: Int) : EmojiSendStatus {
             data object AlreadyUsed : NotAllowed(ErrorCode.EmojiReactions.alreadyUsed.translateRes)
             data object MaxReactionReached : NotAllowed(ErrorCode.EmojiReactions.maxReactionReached.translateRes)
+            data object NoInternet : NotAllowed(RCore.string.noConnection)
         }
     }
     //endregion

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -404,6 +404,10 @@ class ThreadFragment : Fragment() {
                 onAddReaction = { navigateToEmojiPicker(it.uid) },
                 onAddEmoji = { emoji, messageUid ->
                     val reactions = threadViewModel.getLocalEmojiReactionsFor(messageUid) ?: return@ThreadAdapterCallbacks
+
+                    // No need to display a snackbar to the user if he clicks on an already used reaction
+                    if (reactions[emoji]?.hasReacted == true) return@ThreadAdapterCallbacks
+
                     mainViewModel.trySendEmojiReply(emoji, messageUid, reactions, onAllowed = {
                         threadViewModel.fakeEmojiReply(emoji, messageUid)
                     })

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -403,8 +403,10 @@ class ThreadFragment : Fragment() {
                 onEncryptionSeeConcernedRecipients = ::navigateToUnencryptableRecipients,
                 onAddReaction = { navigateToEmojiPicker(it.uid) },
                 onAddEmoji = { emoji, messageUid ->
-                    threadViewModel.fakeEmojiReply(emoji, messageUid)
-                    mainViewModel.sendEmojiReply(emoji, messageUid)
+                    val reactions = threadViewModel.getLocalEmojiReactionsFor(messageUid) ?: return@ThreadAdapterCallbacks
+                    mainViewModel.trySendEmojiReply(emoji, messageUid, reactions, onAllowed = {
+                        threadViewModel.fakeEmojiReply(emoji, messageUid)
+                    })
                 },
             ),
         )
@@ -631,8 +633,10 @@ class ThreadFragment : Fragment() {
 
     private fun observePickedEmoji() {
         getBackNavigationResult<PickedEmojiPayload>(EmojiPickerBottomSheetDialog.PICKED_EMOJI) { (emoji, messageUid) ->
-            threadViewModel.fakeEmojiReply(emoji, messageUid)
-            mainViewModel.sendEmojiReply(emoji, messageUid)
+            val reactions = threadViewModel.getLocalEmojiReactionsFor(messageUid) ?: return@getBackNavigationResult
+            mainViewModel.trySendEmojiReply(emoji, messageUid, reactions, onAllowed = {
+                threadViewModel.fakeEmojiReply(emoji, messageUid)
+            })
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -539,6 +539,11 @@ class ThreadViewModel @Inject constructor(
         }
     }
 
+    fun getLocalEmojiReactionsFor(messageUid: String) = (messagesLive.value
+        ?.first
+        ?.firstOrNull { it is MessageUi && it.message.uid == messageUid } as? MessageUi)
+        ?.emojiReactionsState
+
     data class SubjectDataResult(
         val thread: Thread?,
         val mergedContacts: MergedContactDictionary?,

--- a/app/src/main/java/com/infomaniak/mail/utils/EmojiReactionUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/EmojiReactionUtils.kt
@@ -1,0 +1,32 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.utils
+
+import com.infomaniak.emojicomponents.data.ReactionState
+
+object EmojiReactionUtils {
+    private const val MAX_REACTION_PER_USER = 5
+
+    fun Map<String, ReactionState>.hasAvailableReactionSlot(): Boolean {
+        var usedReactionSlots = 0
+        forEach { (_, state) ->
+            if (state.hasReacted && ++usedReactionSlots == MAX_REACTION_PER_USER) return false
+        }
+        return true
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/utils/ErrorCode.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ErrorCode.kt
@@ -170,9 +170,14 @@ object ErrorCode {
         EmojiReactionNotAllowedReason.EmojiReactionMessageInReplyToEncrypted,
         EmojiReactionNotAllowedReason.EmojiReactionMaxRecipient,
         EmojiReactionNotAllowedReason.EmojiReactionRecipientNotAllowed,
-        ApiErrorCode(EMOJI_REACTION_MAX_REACTION_REACHED, R.string.errorEmojiReactionMaxReactionReached),
-        ApiErrorCode(EMOJI_REACTION_ALREADY_USED, R.string.errorEmojiReactionAlreadyUsed),
+        EmojiReactions.maxReactionReached,
+        EmojiReactions.alreadyUsed,
     )
+
+    object EmojiReactions {
+        val maxReactionReached = ApiErrorCode(EMOJI_REACTION_MAX_REACTION_REACHED, R.string.errorEmojiReactionMaxReactionReached)
+        val alreadyUsed = ApiErrorCode(EMOJI_REACTION_ALREADY_USED, R.string.errorEmojiReactionAlreadyUsed)
+    }
 
     private val ignoredErrorCodesForDrafts = setOf(
         DRAFT_ALREADY_SCHEDULED_OR_SENT,


### PR DESCRIPTION
We locally detect that the user has already sent an emoji, that he has already reacted 5 times or that he has no internet connection to reply with an emoji to block his action. This lets us avoid making useless api calls.

Depends on #2433 