### PR TITLE
feat: Hide reactions if not available

### DIFF
--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/AddReactionChip.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/AddReactionChip.kt
@@ -17,10 +17,12 @@
  */
 package com.infomaniak.emojicomponents.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -58,8 +60,17 @@ internal fun AddReactionChip(
 @Preview
 @Composable
 private fun AddReactionChipPreview() {
-    AddReactionChip(
-        icon = Icons.FaceSmileRoundPlus,
-        onClick = {},
-    )
+    Surface {
+        Column {
+            AddReactionChip(
+                icon = Icons.FaceSmileRoundPlus,
+                onClick = {},
+            )
+            AddReactionChip(
+                icon = Icons.FaceSmileRoundPlus,
+                onClick = {},
+                enabled = { false }
+            )
+        }
+    }
 }

--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/EmojiReactions.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/EmojiReactions.kt
@@ -44,6 +44,7 @@ fun EmojiReactions(
     onAddReactionClick: () -> Unit,
     modifier: Modifier = Modifier,
     addReactionIcon: ImageVector = EmojiReactionsDefaults.addReactionIcon,
+    isAddReactionEnabled: () -> Boolean = { true },
     colors: ReactionChipColors = ReactionChipDefaults.reactionChipColors(),
     shape: Shape = InputChipDefaults.shape,
 ) {
@@ -65,6 +66,7 @@ fun EmojiReactions(
         AddReactionChip(
             addReactionIcon,
             onClick = onAddReactionClick,
+            enabled = isAddReactionEnabled,
         )
     }
 }

--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/views/EmojiReactionsView.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/views/EmojiReactionsView.kt
@@ -24,7 +24,10 @@ import androidx.annotation.StyleableRes
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.InputChipDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.res.vectorResource
@@ -41,6 +44,8 @@ class EmojiReactionsView @JvmOverloads constructor(
 ) : AbstractComposeView(context, attrs, defStyleAttr) {
 
     private val reactionsState = mutableStateMapOf<String, ReactionState>()
+    private var isAddReactionEnabled by mutableStateOf(true)
+
     private var addReactionClickListener: (() -> Unit)? = null
     private var onEmojiClickListener: ((emoji: String) -> Unit)? = null
 
@@ -74,6 +79,7 @@ class EmojiReactionsView @JvmOverloads constructor(
                 onEmojiClicked = { emoji -> onEmojiClickListener?.invoke(emoji) },
                 shape = chipCornerRadius?.let { RoundedCornerShape(it) } ?: InputChipDefaults.shape,
                 addReactionIcon = addReactionIcon,
+                isAddReactionEnabled = { isAddReactionEnabled },
                 onAddReactionClick = { addReactionClickListener?.invoke() }
             )
         }
@@ -96,6 +102,10 @@ class EmojiReactionsView @JvmOverloads constructor(
     fun setEmojiReactions(emojiReactions: Map<String, ReactionState>) {
         reactionsState.clear()
         reactionsState.putAll(emojiReactions)
+    }
+
+    fun setAddReactionEnabledState(isEnabled: Boolean) {
+        isAddReactionEnabled = isEnabled
     }
 }
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -214,8 +214,7 @@ class Message : RealmObject, Snoozable {
 
     val isReaction get() = emojiReaction != null
 
-    // TODO: Add check to know if the user has already reacted 5 times to an email
-    val isReactionAllowed get() = _emojiReactionNotAllowedReason != null
+    val isValidReactionTarget get() = _emojiReactionNotAllowedReason == null
 
     val threads by backlinks(Thread::messages)
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -200,8 +200,12 @@ class ThreadAdapter(
     }
 
     private fun EmojiReactionsView.bindEmojiReactions(message: MessageUi) {
-        isVisible = message.isReactionsFeatureAvailable && (message.hasEmojis() || message.canBeReactedTo())
+        val canBeReactedTo by lazy { message.canBeReactedTo() }
+
+        isVisible = message.isReactionsFeatureAvailable && (canBeReactedTo || message.hasEmojis())
         setEmojiReactions(message.emojiReactionsState)
+
+        if (message.isReactionsFeatureAvailable) setAddReactionEnabledState(isEnabled = canBeReactedTo)
     }
 
     override fun onBindViewHolder(holder: ThreadAdapterViewHolder, position: Int) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -174,7 +174,7 @@ class ThreadAdapter(
                 NotifyType.RE_RENDER -> reloadVisibleWebView()
                 NotifyType.FAILED_MESSAGE -> handleFailedMessagePayload(item.message.uid)
                 NotifyType.ONLY_REBIND_CALENDAR_ATTENDANCE -> handleCalendarAttendancePayload(item.message)
-                NotifyType.ONLY_REBIND_EMOJI_REACTIONS -> handleEmojiReactionPayload(item.emojiReactionsState)
+                NotifyType.ONLY_REBIND_EMOJI_REACTIONS -> handleEmojiReactionPayload(item)
             }
         }
     }.getOrDefault(Unit)
@@ -195,13 +195,13 @@ class ThreadAdapter(
         calendarEvent.onlyUpdateAttendance(attendees)
     }
 
-    private fun ItemMessageBinding.handleEmojiReactionPayload(emojiReactionsState: Map<String, ReactionState>) {
-        emojiReactions.bindEmojiReactions(emojiReactionsState)
+    private fun ItemMessageBinding.handleEmojiReactionPayload(message: MessageUi) {
+        emojiReactions.bindEmojiReactions(message)
     }
 
-    private fun EmojiReactionsView.bindEmojiReactions(emojiReactions: Map<String, ReactionState>) {
-        isGone = false // reactions.isEmpty()
-        setEmojiReactions(emojiReactions)
+    private fun EmojiReactionsView.bindEmojiReactions(message: MessageUi) {
+        isVisible = message.isReactionsFeatureAvailable && (message.hasEmojis() || message.canBeReactedTo())
+        setEmojiReactions(message.emojiReactionsState)
     }
 
     override fun onBindViewHolder(holder: ThreadAdapterViewHolder, position: Int) {
@@ -813,7 +813,7 @@ class ThreadAdapter(
     }
 
     private fun MessageViewHolder.bindEmojiReactions(messageUi: MessageUi) = with(binding.emojiReactions) {
-        bindEmojiReactions(messageUi.emojiReactionsState)
+        bindEmojiReactions(messageUi)
         setOnAddReactionClickListener { threadAdapterCallbacks?.onAddReaction?.invoke(messageUi.message) }
         setOnEmojiClickListener { emoji ->
             threadAdapterCallbacks?.onAddEmoji?.invoke(emoji, messageUi.message.uid)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/MessageUi.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/MessageUi.kt
@@ -19,5 +19,13 @@ package com.infomaniak.mail.ui.main.thread.models
 
 import com.infomaniak.emojicomponents.data.ReactionState
 import com.infomaniak.mail.data.models.message.Message
+import com.infomaniak.mail.utils.EmojiReactionUtils.hasAvailableReactionSlot
 
-data class MessageUi(val message: Message, val emojiReactionsState: Map<String, ReactionState>)
+data class MessageUi(
+    val message: Message,
+    val emojiReactionsState: Map<String, ReactionState>,
+    val isReactionsFeatureAvailable: Boolean,
+) {
+    fun hasEmojis(): Boolean = emojiReactionsState.isNotEmpty()
+    fun canBeReactedTo(): Boolean = message.isValidReactionTarget && emojiReactionsState.hasAvailableReactionSlot()
+}

--- a/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
+++ b/app/src/test/java/com/infomaniak/mail/CalendarEventResponseTest.kt
@@ -24,12 +24,14 @@ import com.infomaniak.mail.data.models.calendar.CalendarEventResponse
 import com.infomaniak.mail.data.models.calendar.CalendarEventResponse.AttachmentEventMethod
 import com.infomaniak.mail.data.models.message.Body
 import com.infomaniak.mail.data.models.message.Message
-import com.infomaniak.mail.ui.main.thread.models.MessageUi
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.NotifyType
+import com.infomaniak.mail.ui.main.thread.models.MessageUi
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.types.RealmInstant
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CalendarEventResponseTest {
@@ -168,4 +170,4 @@ class CalendarEventResponseTest {
     }
 }
 
-private fun Message.toMessageUi(): MessageUi = MessageUi(this, emptyMap())
+private fun Message.toMessageUi(): MessageUi = MessageUi(this, emptyMap(), false)


### PR DESCRIPTION
The emoji reactions chips should only be displayed when the feature is available and when the message can be reacted to. This PR hides it otherwise.

Depends on #2434 