### PR TITLE
feat: Use correct disabled color for add reaction button

### DIFF
--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/AddReactionChip.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/AddReactionChip.kt
@@ -21,7 +21,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -40,7 +42,7 @@ internal fun AddReactionChip(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: () -> Boolean = { true },
-    colors: ReactionChipColors = ReactionChipDefaults.reactionChipColors(),
+    colors: AddReactionColors = AddReactionChipDefaults.addReactionColors(),
 ) {
     IconButton(
         modifier = modifier.size(38.dp),
@@ -53,8 +55,19 @@ internal fun AddReactionChip(
                 modifier = Modifier.size(Margin.Large),
             )
         },
-        colors = IconButtonDefaults.iconButtonColors(contentColor = colors.accentColor),
+        colors = colors.buttonColors,
     )
+}
+
+data class AddReactionColors(val buttonColors: IconButtonColors)
+
+object AddReactionChipDefaults {
+    @Composable
+    fun addReactionColors(
+        iconButtonColors: IconButtonColors = IconButtonDefaults.iconButtonColors(
+            contentColor = MaterialTheme.colorScheme.primary,
+        ),
+    ): AddReactionColors = AddReactionColors(iconButtonColors)
 }
 
 @Preview

--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/EmojiReactions.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/EmojiReactions.kt
@@ -45,7 +45,7 @@ fun EmojiReactions(
     modifier: Modifier = Modifier,
     addReactionIcon: ImageVector = EmojiReactionsDefaults.addReactionIcon,
     isAddReactionEnabled: () -> Boolean = { true },
-    colors: ReactionChipColors = ReactionChipDefaults.reactionChipColors(),
+    colors: EmojiReactionsColors = EmojiReactionsDefaults.colors(),
     shape: Shape = InputChipDefaults.shape,
 ) {
     FlowRow(
@@ -59,7 +59,7 @@ fun EmojiReactions(
                 reactionCount = { state.count },
                 selected = { state.hasReacted },
                 onClick = { onEmojiClicked(emoji) },
-                colors = colors,
+                colors = colors.reactionChip,
                 shape = shape,
             )
         }
@@ -67,12 +67,27 @@ fun EmojiReactions(
             addReactionIcon,
             onClick = onAddReactionClick,
             enabled = isAddReactionEnabled,
+            colors = colors.addReaction,
         )
     }
 }
 
+data class EmojiReactionsColors(
+    val reactionChip: ReactionChipColors,
+    val addReaction: AddReactionColors,
+)
+
 object EmojiReactionsDefaults {
     val addReactionIcon = Icons.FaceSmileRoundPlus
+
+    @Composable
+    fun colors(
+        reactionChipColors: ReactionChipColors = ReactionChipDefaults.reactionChipColors(),
+        addReactionColors: AddReactionColors = AddReactionChipDefaults.addReactionColors(),
+    ): EmojiReactionsColors = EmojiReactionsColors(
+        reactionChipColors,
+        addReactionColors,
+    )
 }
 
 @Preview

--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/ReactionChip.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/components/ReactionChip.kt
@@ -64,14 +64,17 @@ data class ReactionChipColors(
 
 object ReactionChipDefaults {
     @Composable
-    fun reactionChipColors(): ReactionChipColors = ReactionChipColors(
-        InputChipDefaults.inputChipColors(
+    fun reactionChipColors(
+        inputChipColors: SelectableChipColors = InputChipDefaults.inputChipColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer,
             labelColor = MaterialTheme.colorScheme.onSurface,
             selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
             selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
         ),
-        accentColor = MaterialTheme.colorScheme.primary,
+        accentColor: Color = MaterialTheme.colorScheme.primary,
+    ): ReactionChipColors = ReactionChipColors(
+        inputChipColors,
+        accentColor,
     )
 }
 

--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/views/EmojiReactionsView.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/views/EmojiReactionsView.kt
@@ -20,19 +20,24 @@ package com.infomaniak.emojicomponents.views
 import android.content.Context
 import android.content.res.TypedArray
 import android.util.AttributeSet
+import androidx.annotation.ColorInt
 import androidx.annotation.StyleableRes
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.res.vectorResource
 import com.infomaniak.core.compose.materialthemefromxml.MaterialThemeFromXml
 import com.infomaniak.emojicomponents.R
+import com.infomaniak.emojicomponents.components.AddReactionChipDefaults
 import com.infomaniak.emojicomponents.components.EmojiReactions
 import com.infomaniak.emojicomponents.components.EmojiReactionsDefaults
 import com.infomaniak.emojicomponents.data.ReactionState
@@ -51,21 +56,29 @@ class EmojiReactionsView @JvmOverloads constructor(
 
     private var chipCornerRadius: Float? = null
     private var addReactionIconRes: Int? = null
+    @ColorInt
+    private var addReactionDisabledColor: Int? = null
 
     init {
         context.obtainStyledAttributes(attrs, R.styleable.EmojiReactionsView, defStyleAttr, 0).apply {
             chipCornerRadius = getDimensionOrNull(R.styleable.EmojiReactionsView_chipCornerRadius)
             addReactionIconRes = getResourceIdOrNull(R.styleable.EmojiReactionsView_addReactionIcon)
+            addReactionDisabledColor = getColorOrNull(R.styleable.EmojiReactionsView_addReactionDisabledColor)
             recycle()
         }
+    }
+
+    private fun TypedArray.getDimensionOrNull(@StyleableRes index: Int): Float? {
+        return if (hasValue(index)) getDimension(index, -1f) else null
     }
 
     private fun TypedArray.getResourceIdOrNull(@StyleableRes index: Int): Int? {
         return if (hasValue(index)) getResourceId(index, -1) else null
     }
 
-    private fun TypedArray.getDimensionOrNull(@StyleableRes index: Int): Float? {
-        return if (hasValue(index)) getDimension(index, -1f) else null
+    @ColorInt
+    private fun TypedArray.getColorOrNull(@StyleableRes index: Int): Int? {
+        return if (hasValue(index)) getColor(index, -1) else null
     }
 
     @Composable
@@ -74,13 +87,17 @@ class EmojiReactionsView @JvmOverloads constructor(
             val addReactionIcon = addReactionIconRes?.let { ImageVector.vectorResource(it) }
                 ?: EmojiReactionsDefaults.addReactionIcon
 
+            val emojiReactionsColors = addReactionDisabledColor?.let { createEmojiReactionsColors(it) }
+                ?: EmojiReactionsDefaults.colors()
+
             EmojiReactions(
                 reactions = { reactionsState },
                 onEmojiClicked = { emoji -> onEmojiClickListener?.invoke(emoji) },
                 shape = chipCornerRadius?.let { RoundedCornerShape(it) } ?: InputChipDefaults.shape,
                 addReactionIcon = addReactionIcon,
                 isAddReactionEnabled = { isAddReactionEnabled },
-                onAddReactionClick = { addReactionClickListener?.invoke() }
+                colors = emojiReactionsColors,
+                onAddReactionClick = { addReactionClickListener?.invoke() },
             )
         }
     }
@@ -107,6 +124,16 @@ class EmojiReactionsView @JvmOverloads constructor(
     fun setAddReactionEnabledState(isEnabled: Boolean) {
         isAddReactionEnabled = isEnabled
     }
+
+    @Composable
+    private fun createEmojiReactionsColors(disabledContentColor: Int) = EmojiReactionsDefaults.colors(
+        addReactionColors = AddReactionChipDefaults.addReactionColors(
+            IconButtonDefaults.iconButtonColors(
+                contentColor = MaterialTheme.colorScheme.primary,
+                disabledContentColor = Color(disabledContentColor),
+            )
+        )
+    )
 }
 
 @RequiresOptIn(

--- a/EmojiComponents/src/main/res/values/attrs.xml
+++ b/EmojiComponents/src/main/res/values/attrs.xml
@@ -20,6 +20,7 @@
     <declare-styleable name="EmojiReactionsView">
         <attr name="chipCornerRadius" format="dimension" />
         <attr name="addReactionIcon" format="reference" />
+        <attr name="addReactionDisabledColor" format="color" />
     </declare-styleable>
 
 </resources>

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -595,6 +595,7 @@
             android:layout_height="wrap_content"
             android:paddingHorizontal="@dimen/marginStandardMedium"
             android:visibility="gone"
+            app:addReactionDisabledColor="@color/disabledIconColor"
             app:chipCornerRadius="@dimen/chipCornerRadius"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
We needed to be able to give the app's disabled color to the composable component but the code wasn't customizable enough.

This required to correctly rethink the color theming of the composable methods we have. Before that it was kind of using a shortcut to avoid defining everything but we couldn't customize colors correctly. Now I refactored the colors correctly to be able to easily customize anything