### PR TITLE
refactor: Remove code that does not belong to the Correspondent interface

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -191,9 +191,9 @@ object RealmDatabase {
     private object RealmConfig {
 
         //region Configurations versions
-        const val USER_INFO_SCHEMA_VERSION = 3L
+        const val USER_INFO_SCHEMA_VERSION = 4L
         const val MAILBOX_INFO_SCHEMA_VERSION = 9L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 29L
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 30L
         //endregion
 
         //region Configurations names

--- a/app/src/main/java/com/infomaniak/mail/data/models/calendar/Attendee.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/calendar/Attendee.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.data.models.calendar
 
 import android.os.Parcel
+import android.os.Parcelable
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import com.infomaniak.mail.R
@@ -31,7 +32,7 @@ import kotlinx.serialization.Serializable
 
 @Parcelize
 @Serializable
-class Attendee() : EmbeddedRealmObject, Correspondent {
+class Attendee() : EmbeddedRealmObject, Correspondent, Parcelable {
 
     //region Remote data
     @SerialName("address")
@@ -41,9 +42,6 @@ class Attendee() : EmbeddedRealmObject, Correspondent {
     var isOrganizer: Boolean = false
     @SerialName("state")
     private var _state: String = ""
-
-    override var contactedTimes: Int? = null
-    override var other: Boolean = false
     //endregion
 
     val state get() = AttendanceState.entries.firstOrNull { it.apiValue == _state } ?: AttendanceState.NEEDS_ACTION

--- a/app/src/main/java/com/infomaniak/mail/data/models/correspondent/Correspondent.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/correspondent/Correspondent.kt
@@ -18,29 +18,17 @@
 package com.infomaniak.mail.data.models.correspondent
 
 import android.content.Context
-import android.os.Parcelable
 import com.infomaniak.lib.core.utils.firstOrEmpty
 import com.infomaniak.mail.R
 import com.infomaniak.mail.utils.AccountUtils
 import com.infomaniak.mail.utils.extensions.getStartAndEndOfPlusEmail
 import io.sentry.Sentry
 
-interface Correspondent : Parcelable {
-    var email: String
-    var name: String
+interface Correspondent {
+    val email: String
+    val name: String
 
     val initials: String
-
-    var contactedTimes: Int?
-
-    /**
-     * This value represents a contact that is not in the user's contact list,
-     * but with whom the user has communicated in the past. This communication
-     * could be either:
-     *   - The user has replied to a message from this contact.
-     *   - The user has sent a message first to this contact.
-     */
-    var other: Boolean
 
     fun isMe(): Boolean {
         val userEmail = AccountUtils.currentMailboxEmail?.lowercase()

--- a/app/src/main/java/com/infomaniak/mail/data/models/correspondent/MergedContact.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/correspondent/MergedContact.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.mail.data.models.correspondent
 
+import android.os.Parcelable
 import com.infomaniak.mail.data.api.ApiRoutes
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.annotations.Ignore
@@ -25,7 +26,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @Suppress("PROPERTY_WONT_BE_SERIALIZED", "PARCELABLE_PRIMARY_CONSTRUCTOR_IS_EMPTY")
-class MergedContact() : RealmObject, Correspondent {
+class MergedContact() : RealmObject, Correspondent, Parcelable {
     @PrimaryKey
     var id: Long? = null
         private set
@@ -41,8 +42,16 @@ class MergedContact() : RealmObject, Correspondent {
     @delegate:Ignore
     override val initials by lazy { computeInitials() }
 
-    override var contactedTimes: Int? = null
-    override var other: Boolean = false
+    var contactedTimes: Int? = null
+
+    /**
+     * This value represents a contact that is not in the user's contact list,
+     * but with whom the user has communicated in the past. This communication
+     * could be either:
+     *   - The user has replied to a message from this contact.
+     *   - The user has sent a message first to this contact.
+     */
+    var other: Boolean = false
 
     constructor(
         email: String,

--- a/app/src/main/java/com/infomaniak/mail/data/models/correspondent/Recipient.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/correspondent/Recipient.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.data.models.correspondent
 
 import android.os.Parcel
+import android.os.Parcelable
 import com.infomaniak.mail.utils.ExternalUtils.ExternalData
 import com.infomaniak.mail.utils.extensions.isEmail
 import io.realm.kotlin.types.EmbeddedRealmObject
@@ -29,7 +30,7 @@ import kotlinx.serialization.Transient
 
 @Parcelize
 @Serializable
-open class Recipient : EmbeddedRealmObject, Correspondent {
+open class Recipient : EmbeddedRealmObject, Correspondent, Parcelable {
 
     override var email: String = ""
     override var name: String = ""
@@ -48,9 +49,6 @@ open class Recipient : EmbeddedRealmObject, Correspondent {
 
     @delegate:Ignore
     override val initials by lazy { computeInitials() }
-
-    override var contactedTimes: Int? = null
-    override var other: Boolean = false
 
     fun initLocalValues(email: String? = null, name: String? = null): Recipient {
 


### PR DESCRIPTION
Values only needed in MergedContacts were stored inside of the generic Correspondent interface so I placed them in the correct class instead. 

Also Correspondent extended Parcelable which is only required by the three existing child classes but not the parent interface