### PR TITLE
fix: Add margin for informationBlockView EdgeToEdge

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/settings/privacy/AccountManagementSettingsFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/settings/privacy/AccountManagementSettingsFragment.kt
@@ -23,14 +23,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.infomaniak.lib.core.BuildConfig.AUTOLOG_URL
 import com.infomaniak.lib.core.BuildConfig.TERMINATE_ACCOUNT_URL
+import com.infomaniak.lib.core.R
 import com.infomaniak.lib.core.ui.WebViewActivity
 import com.infomaniak.lib.core.utils.safeBinding
+import com.infomaniak.lib.core.utils.setMargins
 import com.infomaniak.mail.databinding.FragmentAccountManagementSettingsBinding
 import com.infomaniak.mail.utils.AccountUtils
+import com.infomaniak.mail.utils.extensions.safeArea
 import com.infomaniak.mail.utils.extensions.setSystemBarsColors
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -54,6 +59,7 @@ class AccountManagementSettingsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setSystemBarsColors()
+        handleEdgeToEdge()
 
         setUi()
         setDeleteAccountClickListener()
@@ -75,6 +81,17 @@ class AccountManagementSettingsFragment : Fragment() {
                 urlToQuit = URL_REDIRECT_SUCCESSFUL_ACCOUNT_DELETION,
                 activityResultLauncher = resultActivityResultLauncher,
             )
+        }
+    }
+
+    private fun handleEdgeToEdge() = with(binding) {
+        ViewCompat.setOnApplyWindowInsetsListener(informationBlockView) { view, insets ->
+            with(insets.safeArea()) {
+                view.setMargins(
+                    bottom = context?.resources?.getDimension(R.dimen.marginStandard)?.toInt()
+                )
+            }
+            WindowInsetsCompat.CONSUMED
         }
     }
 

--- a/app/src/main/res/layout/fragment_account_management_settings.xml
+++ b/app/src/main/res/layout/fragment_account_management_settings.xml
@@ -80,6 +80,7 @@
                 app:titleColor="@color/redDestructiveAction" />
 
             <com.infomaniak.mail.views.InformationBlockView
+                android:id="@+id/informationBlockView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/marginStandardMedium"


### PR DESCRIPTION
When you go to Account Management (in Settings), the small block at the bottom has no margin when you rotate the phone.