### PR TITLE
feat(Encryption-09): Clean encryption lock button view and add delay to loader

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/encryption/EncryptionLockButtonView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/encryption/EncryptionLockButtonView.kt
@@ -26,7 +26,6 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
-import com.infomaniak.lib.core.utils.getAttributes
 import com.infomaniak.mail.R
 import com.infomaniak.mail.databinding.ViewEncryptionLockButtonBinding
 
@@ -49,41 +48,8 @@ class EncryptionLockButtonView @JvmOverloads constructor(
         set(value) {
             if (value == field) return
             field = value
-            setDisplayStyleUi()
+            setToolbarButtonUi()
         }
-
-    private var displayStyle: EncryptionDisplayStyle = EncryptionDisplayStyle.ToolbarButton
-
-    init {
-        attrs?.getAttributes(context, R.styleable.EncryptionLockButtonView) {
-            displayStyle = EncryptionDisplayStyle.entries[
-                getInteger(R.styleable.EncryptionLockButtonView_encryptionDisplayStyle, 0)
-            ]
-            setDisplayStyleUi()
-        }
-    }
-
-    private fun setDisplayStyleUi() = when (displayStyle) {
-        EncryptionDisplayStyle.ChipIcon -> setChipIconUi()
-        EncryptionDisplayStyle.ToolbarButton -> setToolbarButtonUi()
-    }
-
-    private fun setChipIconUi() {
-        when (encryptionStatus) {
-            EncryptionStatus.Unencrypted -> Unit // This case cannot happen
-            EncryptionStatus.PartiallyEncrypted -> setIconUi(
-                iconRes = R.drawable.ic_lock_open_filled,
-                iconTintRes = R.color.iconColor,
-                shouldDisplayPastille = true,
-            )
-            EncryptionStatus.Encrypted -> setIconUi(
-                iconRes = R.drawable.ic_lock_filled,
-                iconTintRes = R.color.encryptionIconColor,
-                shouldDisplayPastille = false,
-            )
-            EncryptionStatus.Loading -> Unit // This case cannot happen
-        }
-    }
 
     private fun setToolbarButtonUi() {
         when (encryptionStatus) {
@@ -132,9 +98,5 @@ class EncryptionLockButtonView @JvmOverloads constructor(
         }
 
         binding.unencryptedRecipientText.text = count
-    }
-
-    private enum class EncryptionDisplayStyle {
-        ChipIcon, ToolbarButton
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/encryption/EncryptionMessageManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/encryption/EncryptionMessageManager.kt
@@ -146,11 +146,7 @@ class EncryptionMessageManager @Inject constructor(
 
     fun observeEncryptionPassword() {
         newMessageViewModel.encryptionPassword.distinctUntilChanged().observeNotNull(viewLifecycleOwner) { password ->
-            val encryptionStatus = if (password.isBlank()) {
-                EncryptionStatus.PartiallyEncrypted
-            } else {
-                EncryptionStatus.Encrypted
-            }
+            val encryptionStatus = if (password.isBlank()) EncryptionStatus.PartiallyEncrypted else EncryptionStatus.Encrypted
             binding.encryptionLockButtonView.encryptionStatus = encryptionStatus
             applyEncryptionStyleOnRecipientFields(encryptionPassword = password)
 

--- a/app/src/main/res/layout/fragment_new_message.xml
+++ b/app/src/main/res/layout/fragment_new_message.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2022-2024 Infomaniak Network SA
+  ~ Copyright (C) 2022-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -691,9 +691,8 @@
                             android:id="@+id/encryptionLockButtonView"
                             android:layout_width="@dimen/newMessageToolbarItemWidth"
                             android:layout_height="match_parent"
-                            android:contentDescription="@string/encryptedProtectionAdDescription1"
+                            android:contentDescription="@string/encryptedStatePanelTitle"
                             android:visibility="gone"
-                            app:encryptionDisplayStyle="toolbarButton"
                             tools:visibility="visible" />
 
                         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -194,13 +194,6 @@
         <attr name="centerHorizontally" format="boolean" />
     </declare-styleable>
 
-    <declare-styleable name="EncryptionLockButtonView">
-        <attr name="encryptionDisplayStyle" format="enum">
-            <enum name="chipIcon" value="0" />
-            <enum name="toolbarButton" value="1" />
-        </attr>
-    </declare-styleable>
-
     <declare-styleable name="PrimaryPalette">
         <attr name="primary0" format="color" />
         <attr name="primary10" format="color" />


### PR DESCRIPTION
Depends on #2459 

Clean the code that was aiming to instanciate this view as chips, but is finally not used
Add a delay before displaying the loader to avoid having it blinking when we open a draft