### PR TITLE
feat: Create a compose mail bottom sheet scaffold to contain future compose code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.dagger.hilt)
+    alias(core.plugins.compose.compiler)
     alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.jetbrains.kotlin.serialization)
     alias(libs.plugins.kapt)
@@ -71,6 +72,7 @@ android {
     buildFeatures {
         buildConfig true
         viewBinding true
+        compose true
     }
 
     flavorDimensions += 'distribution'
@@ -131,7 +133,11 @@ dependencies {
     coreLibraryDesugaring libs.desugar.jdk
 
     // Compose
+    implementation platform(core.compose.bom)
     implementation libs.compose.ui.android
+    implementation core.compose.runtime
+    implementation core.compose.material3
+    implementation core.compose.ui.tooling.preview
 
     // Test
     testImplementation libs.junit

--- a/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
@@ -25,8 +25,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
@@ -47,11 +49,13 @@ fun MailBottomSheetScaffold(
     isVisible: () -> Boolean,
     onDismissRequest: () -> Unit,
     title: String? = null,
+    sheetState: SheetState = rememberModalBottomSheetState(),
     content: @Composable (ColumnScope.() -> Unit),
 ) {
     if (isVisible()) {
         val bottomSheetCornerSize = dimensionResource(R.dimen.bottomSheetCornerSize)
         ModalBottomSheet(
+            sheetState = sheetState,
             onDismissRequest = onDismissRequest,
             shape = RoundedCornerShape(topStart = bottomSheetCornerSize, topEnd = bottomSheetCornerSize),
             containerColor = colorResource(R.color.bottomSheetBackgroundColor),
@@ -79,6 +83,7 @@ fun MailBottomSheetScaffold(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 private fun Preview() {

--- a/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
@@ -1,0 +1,78 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.ui.components
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.viewinterop.AndroidView
+import com.infomaniak.mail.R
+import com.infomaniak.mail.databinding.ViewBottomSheetSeparatorBinding
+import splitties.systemservices.layoutInflater
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MailBottomSheetScaffold(
+    isVisible: () -> Boolean,
+    onDismissRequest: () -> Unit,
+    content: @Composable (ColumnScope.() -> Unit),
+) {
+    if (isVisible()) {
+        val bottomSheetCornerSize = dimensionResource(R.dimen.bottomSheetCornerSize)
+        ModalBottomSheet(
+            onDismissRequest = onDismissRequest,
+            shape = RoundedCornerShape(topStart = bottomSheetCornerSize, topEnd = bottomSheetCornerSize),
+            containerColor = colorResource(R.color.bottomSheetBackgroundColor),
+            dragHandle = {
+                AndroidView(
+                    factory = { ViewBottomSheetSeparatorBinding.inflate(it.layoutInflater).root },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(dimensionResource(R.dimen.bottomSheetDragHandleHeight)),
+                ) { /* No-op */ }
+            },
+            content = content,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    MaterialTheme {
+        Surface {
+            MailBottomSheetScaffold(
+                isVisible = { true },
+                onDismissRequest = {},
+            ) {
+                Text("Hello world")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
@@ -31,7 +31,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.infomaniak.mail.R
 import com.infomaniak.mail.databinding.ViewBottomSheetSeparatorBinding
@@ -42,6 +46,7 @@ import splitties.systemservices.layoutInflater
 fun MailBottomSheetScaffold(
     isVisible: () -> Boolean,
     onDismissRequest: () -> Unit,
+    title: String? = null,
     content: @Composable (ColumnScope.() -> Unit),
 ) {
     if (isVisible()) {
@@ -59,6 +64,14 @@ fun MailBottomSheetScaffold(
                 ) { /* No-op */ }
             },
             content = {
+                title?.let {
+                    Text(
+                        it,
+                        style = TextStyle(fontWeight = FontWeight.Medium, fontSize = 16.sp),
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center,
+                    )
+                }
                 content()
                 Spacer(modifier = Modifier.height(dimensionResource(R.dimen.bottomSheetBottomPadding)))
             },
@@ -74,6 +87,7 @@ private fun Preview() {
             MailBottomSheetScaffold(
                 isVisible = { true },
                 onDismissRequest = {},
+                title = "This bottom sheet's title"
             ) {
                 Text("Hello world")
             }

--- a/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.ui.components
 
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -57,7 +58,10 @@ fun MailBottomSheetScaffold(
                         .height(dimensionResource(R.dimen.bottomSheetDragHandleHeight)),
                 ) { /* No-op */ }
             },
-            content = content,
+            content = {
+                content()
+                Spacer(modifier = Modifier.height(dimensionResource(R.dimen.bottomSheetBottomPadding)))
+            },
         )
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/components/views/MailBottomSheetScaffoldComposeView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/components/views/MailBottomSheetScaffoldComposeView.kt
@@ -1,0 +1,52 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.ui.components.views
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.AbstractComposeView
+import com.infomaniak.mail.ui.components.MailBottomSheetScaffold
+
+abstract class MailBottomSheetScaffoldComposeView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : AbstractComposeView(context, attrs, defStyleAttr) {
+
+    var isVisible by mutableStateOf(false)
+
+    @Composable
+    abstract fun BottomSheetContent()
+
+    protected fun showBottomSheet() {
+        isVisible = true
+    }
+
+    @Composable
+    final override fun Content() {
+        MailBottomSheetScaffold(
+            isVisible = { isVisible },
+            onDismissRequest = { isVisible = false },
+            content = { BottomSheetContent() }
+        )
+    }
+}

--- a/app/src/main/res/layout/view_bottom_sheet_scaffolding.xml
+++ b/app/src/main/res/layout/view_bottom_sheet_scaffolding.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2024 Infomaniak Network SA
+  ~ Copyright (C) 2024-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/marginStandardMedium">
+    android:paddingBottom="@dimen/bottomSheetBottomPadding">
 
     <include layout="@layout/view_bottom_sheet_separator" />
 

--- a/app/src/main/res/layout/view_bottom_sheet_separator.xml
+++ b/app/src/main/res/layout/view_bottom_sheet_separator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2022-2024 Infomaniak Network SA
+  ~ Copyright (C) 2022-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -18,7 +18,7 @@
 <com.google.android.material.bottomsheet.BottomSheetDragHandleView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="48dp"
+    android:layout_height="@dimen/bottomSheetDragHandleHeight"
     android:paddingTop="@dimen/marginStandardSmall"
     android:src="@drawable/bottom_sheet_drag_handle"
     app:tint="#cedae1" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -155,6 +155,7 @@
     <color name="newMessageBackgroundColor">@color/backgroundColor</color>
     <color name="toolbarLoweredColor">@color/backgroundColor</color>
     <color name="toolbarElevatedColor">@color/elevatedBackground</color>
+    <color name="bottomSheetBackgroundColor">@color/backgroundColorSecondary</color>
 
     <!-- Texts -->
     <color name="primaryTextColor">@color/orca</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -49,6 +49,7 @@
     <dimen name="newMessageToolbarHeight">48dp</dimen>
     <dimen name="bottomSheetCornerSize">10dp</dimen>
     <dimen name="bottomSheetDragHandleHeight">48dp</dimen>
+    <dimen name="bottomSheetBottomPadding">16dp</dimen>
 
     <!-- Menu Drawer -->
     <dimen name="decoratedItemViewHeight">48dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -47,6 +47,8 @@
     <dimen name="threadHorizontalMargin">@dimen/marginStandardMedium</dimen>
     <dimen name="newMessageToolbarItemWidth">64dp</dimen>
     <dimen name="newMessageToolbarHeight">48dp</dimen>
+    <dimen name="bottomSheetCornerSize">10dp</dimen>
+    <dimen name="bottomSheetDragHandleHeight">48dp</dimen>
 
     <!-- Menu Drawer -->
     <dimen name="decoratedItemViewHeight">48dp</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -405,15 +405,15 @@
     <style name="BottomSheetDialogTheme" parent="BottomSheetDialogThemeBase" />
 
     <style name="BottomSheetDialogThemeModalStyle" parent="Widget.Material3.BottomSheet">
-        <item name="backgroundTint">@color/backgroundColorSecondary</item>
+        <item name="backgroundTint">@color/bottomSheetBackgroundColor</item>
         <item name="shapeAppearanceOverlay">@style/BottomSheetDialogThemeShapeAppearanceOverlay</item>
     </style>
 
     <style name="BottomSheetDialogThemeShapeAppearanceOverlay">
         <item name="cornerSizeBottomLeft">0dp</item>
         <item name="cornerSizeBottomRight">0dp</item>
-        <item name="cornerSizeTopLeft">10dp</item>
-        <item name="cornerSizeTopRight">10dp</item>
+        <item name="cornerSizeTopLeft">@dimen/bottomSheetCornerSize</item>
+        <item name="cornerSizeTopRight">@dimen/bottomSheetCornerSize</item>
     </style>
 
     <style name="BottomSheetTitle" parent="BodyMedium" />


### PR DESCRIPTION
This new compose scaffold recreates the exact style of the mail bottom sheet but in compose. This compose version of the scaffold is needed to correctly handle nested scrolling with new compose components. This will notably be used for the emoji reactions feature