### PR TITLE
fix: Make available the current user token on first login

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/MainApplication.kt
+++ b/app/src/main/java/com/infomaniak/mail/MainApplication.kt
@@ -71,11 +71,7 @@ import io.sentry.android.fragment.FragmentLifecycleIntegration
 import io.sentry.android.fragment.FragmentLifecycleState
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.mapLatest
-import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import splitties.init.injectAsAppCtx
@@ -283,10 +279,7 @@ open class MainApplication : Application(), ImageLoaderFactory, DefaultLifecycle
     }
 
     private fun tokenInterceptorListener() = object : TokenInterceptorListener {
-        @OptIn(ExperimentalCoroutinesApi::class)
-        val userTokenFlow = AppSettingsController.getCurrentUserIdFlow()
-            .mapLatest { id -> id?.let { AccountUtils.getUserById(it)?.apiToken } }
-            .shareIn(globalCoroutineScope, SharingStarted.Lazily, replay = 1)
+        val userTokenFlow by lazy { AppSettingsController.getCurrentUserIdFlow().mapToApiToken(globalCoroutineScope) }
 
         override suspend fun onRefreshTokenSuccess(apiToken: ApiToken) {
             if (AccountUtils.currentUser == null) AccountUtils.requestCurrentUser()

--- a/app/src/main/java/com/infomaniak/mail/data/cache/appSettings/AppSettingsController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/appSettings/AppSettingsController.kt
@@ -32,8 +32,8 @@ object AppSettingsController {
         return realm?.let(block) ?: RealmDatabase.appSettings().writeBlocking(block)
     }
 
-    fun getCurrentUserIdFlow(customRealm: MutableRealm? = null): Flow<Int?> {
-        val realm = customRealm ?: RealmDatabase.appSettings()
+    fun getCurrentUserIdFlow(): Flow<Int?> {
+        val realm = RealmDatabase.appSettings()
         return realm.query<AppSettings>().first().asFlow().map { it.obj?.currentUserId }
     }
     //endregion


### PR DESCRIPTION
Only init and start to collect the currentUserIdFlow when needed

Depends on https://github.com/Infomaniak/android-core/pull/427