### PR TITLE
fix: Fix missing contentColor due to hardcoded containerColor in MailBottomSheetScaffold

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,6 +89,7 @@ android {
 
 dependencies {
     implementation project(':Core')
+    implementation project(':Core:Compose:MaterialThemeFromXml')
     implementation project(':Core:FragmentNavigation')
     implementation project(':Core:Legacy')
     implementation project(':Core:Legacy:AppLock')

--- a/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
@@ -59,6 +59,7 @@ fun MailBottomSheetScaffold(
             onDismissRequest = onDismissRequest,
             shape = RoundedCornerShape(topStart = bottomSheetCornerSize, topEnd = bottomSheetCornerSize),
             containerColor = colorResource(R.color.bottomSheetBackgroundColor),
+            contentColor = colorResource(R.color.onBottomSheetBackgroundColor),
             dragHandle = {
                 AndroidView(
                     factory = { ViewBottomSheetSeparatorBinding.inflate(it.layoutInflater).root },

--- a/app/src/main/java/com/infomaniak/mail/ui/components/views/MailBottomSheetScaffoldComposeView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/components/views/MailBottomSheetScaffoldComposeView.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.AbstractComposeView
+import com.infomaniak.core.compose.materialthemefromxml.MaterialThemeFromXml
 import com.infomaniak.mail.ui.components.MailBottomSheetScaffold
 import kotlinx.coroutines.launch
 
@@ -68,11 +69,13 @@ abstract class MailBottomSheetScaffoldComposeView @JvmOverloads constructor(
             }
         }
 
-        MailBottomSheetScaffold(
-            isVisible = { isVisible },
-            onDismissRequest = { isVisible = false },
-            sheetState = sheetState,
-            content = { BottomSheetContent() }
-        )
+        MaterialThemeFromXml {
+            MailBottomSheetScaffold(
+                isVisible = { isVisible },
+                onDismissRequest = { isVisible = false },
+                sheetState = sheetState,
+                content = { BottomSheetContent() }
+            )
+        }
     }
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -167,6 +167,7 @@
     <color name="onColorfulBackground">@color/white</color>
     <color name="textDisabledPrimaryButton">@color/white</color>
     <color name="primaryTextColorDisabled">@color/shark</color>
+    <color name="onBottomSheetBackgroundColor">@color/primaryTextColor</color>
 
     <!-- Dividers -->
     <color name="dividerColor">@color/mouse</color>


### PR DESCRIPTION
The bottom sheet was missing a MaterialThemeFromXml and, more importantly, a contentColor because we've overridden containerColor with a custom non-token color