### PR TITLE
feat: Print thread algo crash logs in logcat

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -217,7 +217,7 @@ class RefreshController @Inject constructor(
                     FolderController.getFolder(role, realm = this)?.let {
                         refresh(scope, folder = it)
                     }
-                }.onFailure {
+                }.cancellable().onFailure {
                     throw ReturnThreadsException(impactedThreads, exception = it)
                 }
             }
@@ -283,7 +283,7 @@ class RefreshController @Inject constructor(
                     mainRefresh(scope, folder = it)
                 }
             }.cancellable().onFailure {
-                it.printStackTrace()
+                SentryLog.e(TAG, "Throwable during extraRefresh", it)
             }
         }
     }
@@ -708,7 +708,7 @@ class RefreshController @Inject constructor(
 
     //region Handle errors
     private fun handleAllExceptions(throwable: Throwable) {
-        throwable.printStackTrace()
+        SentryLog.w(TAG, "Throwable during thread algorithm", throwable)
 
         if (throwable is ApiErrorException) throwable.handleOtherApiErrors()
 
@@ -838,4 +838,8 @@ class RefreshController @Inject constructor(
         val onStart: (() -> Unit),
         val onStop: (() -> Unit),
     )
+
+    companion object {
+        private val TAG = RefreshController::class.java.simpleName
+    }
 }


### PR DESCRIPTION
During dev its common to create crashes but the whole thread algo being in a big runCatching prevents us from seeing what issue occurred because we catch them and that's all. This prints the stacktrace in logcat when such a throwable is detected to help find issues easily