### PR TITLE
feat: Encryption support more than 10 recipients in one check

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/encryption/EncryptionViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/encryption/EncryptionViewModel.kt
@@ -51,8 +51,15 @@ class EncryptionViewModel @Inject constructor(
     private val emailsBeingChecked: MutableList<String> = mutableListOf()
 
     fun checkIfEmailsCanBeEncrypted(emails: List<String>) {
+        // The infomaniak domains don't need to be checked because it can always be automatically encrypted
+        val infomaniakFilteredEmails = emails.filterNot { it.contains("@(ik.me|etik.com|ikmail.com|infomaniak.com)".toRegex()) }
+        if (infomaniakFilteredEmails.isEmpty()) {
+            unencryptableRecipients.postValue(unencryptableRecipients.value ?: emptyList())
+            return
+        }
+
         emailsCheckingJob?.cancel(AutoBulkCallCancellationException())
-        emailsBeingChecked.addAll(emails)
+        emailsBeingChecked.addAll(infomaniakFilteredEmails)
 
         emailsCheckingJob = viewModelScope.launch(ioDispatcher) {
             isCheckingEmails.postValue(true)

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/encryption/EncryptionViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/encryption/EncryptionViewModel.kt
@@ -53,15 +53,8 @@ class EncryptionViewModel @Inject constructor(
     private val emailsBeingChecked: MutableList<String> = mutableListOf()
 
     fun checkIfEmailsCanBeEncrypted(emails: List<String>) {
-        // The infomaniak domains don't need to be checked because it can always be automatically encrypted
-        val infomaniakFilteredEmails = emails.filterNot { it.contains("@(ik.me|etik.com|ikmail.com|infomaniak.com)".toRegex()) }
-        if (infomaniakFilteredEmails.isEmpty()) {
-            unencryptableRecipients.postValue(unencryptableRecipients.value ?: emptyList())
-            return
-        }
-
         emailsCheckingJob?.cancel(AutoBulkCallCancellationException())
-        emailsBeingChecked.addAll(infomaniakFilteredEmails)
+        emailsBeingChecked.addAll(emails)
 
         emailsCheckingJob = viewModelScope.launch(ioDispatcher) {
             isCheckingEmails.postValue(true)


### PR DESCRIPTION
- Parallelize the calls to the api to check if email are encryptable because it can only take 10 email per call or return error
- Also check locally if the emails are hosted by classic infomaniak domains to avoid calls to the api

Depends on #2452 