### PR TITLE
feat: Update emoji reaction model

### DIFF
--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/data/Reaction.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/data/Reaction.kt
@@ -17,7 +17,8 @@
  */
 package com.infomaniak.emojicomponents.data
 
-interface ReactionState {
+interface Reaction {
+    val emoji: String
     val count: Int
     val hasReacted: Boolean
 }

--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/views/EmojiReactionsView.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/views/EmojiReactionsView.kt
@@ -28,7 +28,7 @@ import androidx.compose.material3.InputChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
@@ -40,7 +40,7 @@ import com.infomaniak.emojicomponents.R
 import com.infomaniak.emojicomponents.components.AddReactionChipDefaults
 import com.infomaniak.emojicomponents.components.EmojiReactions
 import com.infomaniak.emojicomponents.components.EmojiReactionsDefaults
-import com.infomaniak.emojicomponents.data.ReactionState
+import com.infomaniak.emojicomponents.data.Reaction
 
 class EmojiReactionsView @JvmOverloads constructor(
     context: Context,
@@ -48,7 +48,7 @@ class EmojiReactionsView @JvmOverloads constructor(
     defStyleAttr: Int = 0,
 ) : AbstractComposeView(context, attrs, defStyleAttr) {
 
-    private val reactionsState = mutableStateMapOf<String, ReactionState>()
+    private val reactionsState = mutableStateListOf<Reaction>()
     private var isAddReactionEnabled by mutableStateOf(true)
 
     private var addReactionClickListener: (() -> Unit)? = null
@@ -116,9 +116,9 @@ class EmojiReactionsView @JvmOverloads constructor(
         onEmojiClickListener = listener
     }
 
-    fun setEmojiReactions(emojiReactions: Map<String, ReactionState>) {
+    fun setEmojiReactions(emojiReactions: List<Reaction>) {
         reactionsState.clear()
-        reactionsState.putAll(emojiReactions)
+        reactionsState.addAll(emojiReactions)
     }
 
     fun setAddReactionEnabledState(isEnabled: Boolean) {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -197,7 +197,7 @@ object RealmDatabase {
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 5L
         const val MAILBOX_INFO_SCHEMA_VERSION = 9L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 34L // Emoji reactions 2
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 35L // Emoji reactions 2
         //endregion
 
         //region Configurations names

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -40,6 +40,7 @@ import com.infomaniak.mail.data.models.mailbox.MailboxPermissions
 import com.infomaniak.mail.data.models.mailbox.SenderDetails
 import com.infomaniak.mail.data.models.mailbox.SendersRestrictions
 import com.infomaniak.mail.data.models.message.Body
+import com.infomaniak.mail.data.models.message.EmojiReactionAuthor
 import com.infomaniak.mail.data.models.message.EmojiReactionState
 import com.infomaniak.mail.data.models.message.Headers
 import com.infomaniak.mail.data.models.message.Message
@@ -242,6 +243,7 @@ object RealmDatabase {
             Attendee::class,
             Bimi::class,
             EmojiReactionState::class,
+            EmojiReactionAuthor::class,
         )
         //endregion
 

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/RefreshController.kt
@@ -57,7 +57,6 @@ import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
 import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.ext.copyFromRealm
-import io.realm.kotlin.ext.realmDictionaryOf
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.ext.toRealmList
 import io.sentry.Sentry
@@ -685,7 +684,7 @@ class RefreshController @Inject constructor(
             isDeletedOnApi = false,
             latestCalendarEventResponse = null,
             swissTransferFiles = realmListOf(),
-            emojiReactions = realmDictionaryOf(),
+            emojiReactions = realmListOf(),
         )
     }
     //endregion

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionAuthor.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionAuthor.kt
@@ -17,46 +17,33 @@
  */
 package com.infomaniak.mail.data.models.message
 
-import com.infomaniak.emojicomponents.data.Reaction
-import io.realm.kotlin.ext.realmListOf
+import com.infomaniak.mail.data.models.correspondent.Recipient
 import io.realm.kotlin.types.EmbeddedRealmObject
-import io.realm.kotlin.types.RealmList
-import io.realm.kotlin.types.annotations.Ignore
 
-class EmojiReactionState constructor() : Reaction, EmbeddedRealmObject {
-    override var emoji: String = ""
-    var authors: RealmList<EmojiReactionAuthor> = realmListOf()
-    override var hasReacted: Boolean = false
+class EmojiReactionAuthor constructor() : EmbeddedRealmObject {
+    var recipient: Recipient? = null
+    var sourceMessageUid: String = ""
 
-    @Ignore
-    override val count: Int by authors::size
-
-    constructor(emoji: String) : this() {
-        this.emoji = emoji
-    }
-
-    fun addAuthor(newAuthor: EmojiReactionAuthor) {
-        authors.add(newAuthor)
-        hasReacted = hasReacted || newAuthor.recipient?.isMe() == true
+    constructor(recipient: Recipient, sourceMessageUid: String) : this() {
+        this.recipient = recipient
+        this.sourceMessageUid = sourceMessageUid
     }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as EmojiReactionState
+        other as EmojiReactionAuthor
 
-        if (hasReacted != other.hasReacted) return false
-        if (emoji != other.emoji) return false
-        if (authors != other.authors) return false
+        if (recipient != other.recipient) return false
+        if (sourceMessageUid != other.sourceMessageUid) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = hasReacted.hashCode()
-        result = 31 * result + emoji.hashCode()
-        result = 31 * result + authors.hashCode()
+        var result = recipient?.hashCode() ?: 0
+        result = 31 * result + sourceMessageUid.hashCode()
         return result
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionAuthor.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionAuthor.kt
@@ -28,22 +28,4 @@ class EmojiReactionAuthor constructor() : EmbeddedRealmObject {
         this.recipient = recipient
         this.sourceMessageUid = sourceMessageUid
     }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as EmojiReactionAuthor
-
-        if (recipient != other.recipient) return false
-        if (sourceMessageUid != other.sourceMessageUid) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = recipient?.hashCode() ?: 0
-        result = 31 * result + sourceMessageUid.hashCode()
-        return result
-    }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionState.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionState.kt
@@ -17,19 +17,29 @@
  */
 package com.infomaniak.mail.data.models.message
 
-import com.infomaniak.emojicomponents.data.ReactionState
+import com.infomaniak.emojicomponents.data.Reaction
 import com.infomaniak.mail.data.models.correspondent.Recipient
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.types.EmbeddedRealmObject
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.annotations.Ignore
 
-class EmojiReactionState : ReactionState, EmbeddedRealmObject {
+class EmojiReactionState constructor() : Reaction, EmbeddedRealmObject {
+    override var emoji: String = ""
     var authors: RealmList<Recipient> = realmListOf()
     override var hasReacted: Boolean = false
 
     @Ignore
     override val count: Int by authors::size
+
+    constructor(emoji: String) : this() {
+        this.emoji = emoji
+    }
+
+    fun addAuthor(newAuthor: Recipient) {
+        authors.add(newAuthor)
+        hasReacted = hasReacted || newAuthor.isMe()
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -38,6 +48,7 @@ class EmojiReactionState : ReactionState, EmbeddedRealmObject {
         other as EmojiReactionState
 
         if (hasReacted != other.hasReacted) return false
+        if (emoji != other.emoji) return false
         if (authors != other.authors) return false
 
         return true
@@ -45,6 +56,7 @@ class EmojiReactionState : ReactionState, EmbeddedRealmObject {
 
     override fun hashCode(): Int {
         var result = hasReacted.hashCode()
+        result = 31 * result + emoji.hashCode()
         result = 31 * result + authors.hashCode()
         return result
     }

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionState.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionState.kt
@@ -18,11 +18,18 @@
 package com.infomaniak.mail.data.models.message
 
 import com.infomaniak.emojicomponents.data.ReactionState
+import com.infomaniak.mail.data.models.correspondent.Recipient
+import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.types.EmbeddedRealmObject
+import io.realm.kotlin.types.RealmList
+import io.realm.kotlin.types.annotations.Ignore
 
 class EmojiReactionState : ReactionState, EmbeddedRealmObject {
-    override var count: Int = 0
+    var authors: RealmList<Recipient> = realmListOf()
     override var hasReacted: Boolean = false
+
+    @Ignore
+    override val count: Int by authors::size
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -30,15 +37,15 @@ class EmojiReactionState : ReactionState, EmbeddedRealmObject {
 
         other as EmojiReactionState
 
-        if (count != other.count) return false
         if (hasReacted != other.hasReacted) return false
+        if (authors != other.authors) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = count
-        result = 31 * result + hasReacted.hashCode()
+        var result = hasReacted.hashCode()
+        result = 31 * result + authors.hashCode()
         return result
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionState.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionState.kt
@@ -37,6 +37,6 @@ class EmojiReactionState constructor() : Reaction, EmbeddedRealmObject {
 
     fun addAuthor(newAuthor: EmojiReactionAuthor) {
         authors.add(newAuthor)
-        hasReacted = hasReacted || newAuthor.recipient?.isMe() == true
+        if (hasReacted.not()) hasReacted = newAuthor.recipient?.isMe() == true
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionState.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionState.kt
@@ -39,24 +39,4 @@ class EmojiReactionState constructor() : Reaction, EmbeddedRealmObject {
         authors.add(newAuthor)
         hasReacted = hasReacted || newAuthor.recipient?.isMe() == true
     }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as EmojiReactionState
-
-        if (hasReacted != other.hasReacted) return false
-        if (emoji != other.emoji) return false
-        if (authors != other.authors) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = hasReacted.hashCode()
-        result = 31 * result + emoji.hashCode()
-        result = 31 * result + authors.hashCode()
-        return result
-    }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -43,11 +43,9 @@ import com.infomaniak.mail.utils.extensions.toRealmInstant
 import io.realm.kotlin.ext.backlinks
 import io.realm.kotlin.ext.copyFromRealm
 import io.realm.kotlin.ext.isManaged
-import io.realm.kotlin.ext.realmDictionaryOf
 import io.realm.kotlin.ext.realmListOf
 import io.realm.kotlin.ext.realmSetOf
 import io.realm.kotlin.serializers.RealmListKSerializer
-import io.realm.kotlin.types.RealmDictionary
 import io.realm.kotlin.types.RealmInstant
 import io.realm.kotlin.types.RealmList
 import io.realm.kotlin.types.RealmObject
@@ -185,7 +183,7 @@ class Message : RealmObject, Snoozable {
     @Transient
     var hasAttachable: Boolean = false
     @Transient
-    var emojiReactions: RealmDictionary<EmojiReactionState?> = realmDictionaryOf()
+    var emojiReactions: RealmList<EmojiReactionState> = realmListOf()
     //endregion
 
     //region UI data (Transient & Ignore)
@@ -339,7 +337,7 @@ class Message : RealmObject, Snoozable {
         isDeletedOnApi: Boolean,
         latestCalendarEventResponse: CalendarEventResponse?,
         swissTransferFiles: RealmList<SwissTransferFile>,
-        emojiReactions: RealmDictionary<EmojiReactionState?>,
+        emojiReactions: RealmList<EmojiReactionState>,
     ) {
         this.areHeavyDataFetched = areHeavyDataFetched
         this.isTrashed = isTrashed

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/ThreadEmojiReactionsComputation.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/ThreadEmojiReactionsComputation.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.mail.data.models.thread
 
+import com.infomaniak.mail.data.models.message.EmojiReactionAuthor
 import com.infomaniak.mail.data.models.message.EmojiReactionState
 import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.message.Message.Companion.parseMessagesIds
@@ -45,7 +46,12 @@ private fun MutableMap<String, MutableMap<String, EmojiReactionState>>.addReacti
             emojis[emoji] = EmojiReactionState(emoji)
         }
 
-        emojis[emoji]!!.addAuthor(newAuthor = message.from.firstOrNull() ?: continue)
+        emojis[emoji]!!.addAuthor(
+            newAuthor = EmojiReactionAuthor(
+                recipient = message.from.firstOrNull() ?: continue,
+                sourceMessageUid = message.uid,
+            )
+        )
     }
 }
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/ThreadEmojiReactionsComputation.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/ThreadEmojiReactionsComputation.kt
@@ -38,16 +38,17 @@ private fun MutableMap<String, MutableMap<String, EmojiReactionState>>.addReacti
     val emoji = message.emojiReaction ?: return
 
     val replyToIds = message.inReplyTo?.parseMessagesIds() ?: emptyList()
-    replyToIds.forEach { replyToId ->
+    for (replyToId in replyToIds) {
         val emojis = getOrPut(replyToId) { emptyEmojiReaction(emoji) }
 
         if (emojis.containsKey(emoji).not()) {
             emojis[emoji] = EmojiReactionState()
         }
 
+        val from = message.from.firstOrNull() ?: continue
         emojis[emoji]!!.apply {
-            count += 1
-            hasReacted = hasReacted || message.from.any { it.isMe() }
+            authors.add(from)
+            hasReacted = hasReacted || from.isMe()
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -30,7 +30,7 @@ import androidx.lifecycle.liveData
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.infomaniak.core.network.NetworkAvailability
-import com.infomaniak.emojicomponents.data.ReactionState
+import com.infomaniak.emojicomponents.data.Reaction
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.lib.core.utils.DownloadManagerUtils
@@ -1295,7 +1295,7 @@ class MainViewModel @Inject constructor(
      * If sending is allowed, the caller place can fake the emoji reaction locally thanks to [onAllowed].
      * If sending is not allowed, it will display the error directly to the user and avoid doing the api call.
      */
-    fun trySendEmojiReply(emoji: String, messageUid: String, reactions: Map<String, ReactionState>, onAllowed: () -> Unit) {
+    fun trySendEmojiReply(emoji: String, messageUid: String, reactions: Map<String, Reaction>, onAllowed: () -> Unit) {
         viewModelScope.launch {
             when (val status = reactions.getEmojiSendStatus(emoji)) {
                 EmojiSendStatus.Allowed -> {
@@ -1307,7 +1307,7 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    private fun Map<String, ReactionState>.getEmojiSendStatus(emoji: String): EmojiSendStatus = when {
+    private fun Map<String, Reaction>.getEmojiSendStatus(emoji: String): EmojiSendStatus = when {
         this[emoji]?.hasReacted == true -> EmojiSendStatus.NotAllowed.AlreadyUsed
         hasAvailableReactionSlot().not() -> EmojiSendStatus.NotAllowed.MaxReactionReached
         hasNetwork.not() -> EmojiSendStatus.NotAllowed.NoInternet

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -44,7 +44,7 @@ import com.infomaniak.core.utils.FORMAT_DATE_DAY_FULL_MONTH_YEAR_WITH_TIME
 import com.infomaniak.core.utils.FormatData
 import com.infomaniak.core.utils.format
 import com.infomaniak.core.utils.formatWithLocal
-import com.infomaniak.emojicomponents.data.ReactionState
+import com.infomaniak.emojicomponents.data.Reaction
 import com.infomaniak.emojicomponents.views.EmojiReactionsView
 import com.infomaniak.lib.core.utils.context
 import com.infomaniak.lib.core.utils.isNightModeEnabled
@@ -203,7 +203,7 @@ class ThreadAdapter(
         val canBeReactedTo by lazy { message.canBeReactedTo() }
 
         isVisible = message.isReactionsFeatureAvailable && (canBeReactedTo || message.hasEmojis())
-        setEmojiReactions(message.emojiReactionsState)
+        setEmojiReactions(message.emojiReactionsState.map { it.value })
 
         if (message.isReactionsFeatureAvailable) setAddReactionEnabledState(isEnabled = canBeReactedTo)
     }
@@ -954,7 +954,7 @@ class ThreadAdapter(
         }
 
         companion object {
-            fun Map<String, ReactionState?>.containsTheSameEmojiValuesAs(other: Map<String, ReactionState?>): Boolean {
+            fun Map<String, Reaction?>.containsTheSameEmojiValuesAs(other: Map<String, Reaction?>): Boolean {
                 if (this.size != other.size) return false
 
                 for ((emoji, state) in this) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -50,7 +50,7 @@ import com.infomaniak.mail.data.models.message.Message
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.SuperCollapsedBlock
-import com.infomaniak.mail.ui.main.thread.models.EmojiReactionAuthor
+import com.infomaniak.mail.ui.main.thread.models.EmojiReactionAuthorUi
 import com.infomaniak.mail.ui.main.thread.models.EmojiReactionStateUi
 import com.infomaniak.mail.ui.main.thread.models.MessageUi
 import com.infomaniak.mail.utils.AccountUtils
@@ -645,7 +645,7 @@ private fun RealmList<EmojiReactionState>.toFakedReactions(localReactions: Set<S
         if (emoji !in fakeReactions) {
             fakeReactions[emoji] = EmojiReactionStateUi(
                 emoji = emoji,
-                authors = listOf(EmojiReactionAuthor.FakeMe),
+                authors = listOf(EmojiReactionAuthorUi.FakeMe),
                 hasReacted = true,
             )
         }
@@ -657,10 +657,12 @@ private fun RealmList<EmojiReactionState>.toFakedReactions(localReactions: Set<S
 private fun fakeEmojiReactionState(state: EmojiReactionState, localReactions: Set<String>): EmojiReactionStateUi {
     val shouldFake = state.emoji in localReactions && !state.hasReacted
 
-    val authors = state.authors.mapTo(mutableListOf<EmojiReactionAuthor>(), EmojiReactionAuthor::Real)
+    val authors = state.authors.mapNotNullTo(mutableListOf<EmojiReactionAuthorUi>()) { author ->
+        author.recipient?.let(EmojiReactionAuthorUi::Real)
+    }
     val fakedReaction = EmojiReactionStateUi(
         emoji = state.emoji,
-        authors = if (shouldFake) authors + EmojiReactionAuthor.FakeMe else authors,
+        authors = if (shouldFake) authors + EmojiReactionAuthorUi.FakeMe else authors,
         hasReacted = state.hasReacted || shouldFake,
     )
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/EmojiReactionAuthor.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/EmojiReactionAuthor.kt
@@ -17,8 +17,9 @@
  */
 package com.infomaniak.mail.ui.main.thread.models
 
-import com.infomaniak.emojicomponents.data.ReactionState
+import com.infomaniak.mail.data.models.correspondent.Correspondent
 
-data class EmojiReactionStateUi(val authors: List<EmojiReactionAuthor>, override val hasReacted: Boolean) : ReactionState {
-    override val count: Int by authors::size
+sealed interface EmojiReactionAuthor {
+    data class Real(val correspondent: Correspondent) : EmojiReactionAuthor
+    data object FakeMe : EmojiReactionAuthor
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/EmojiReactionAuthorUi.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/EmojiReactionAuthorUi.kt
@@ -19,7 +19,7 @@ package com.infomaniak.mail.ui.main.thread.models
 
 import com.infomaniak.mail.data.models.correspondent.Correspondent
 
-sealed interface EmojiReactionAuthor {
-    data class Real(val correspondent: Correspondent) : EmojiReactionAuthor
-    data object FakeMe : EmojiReactionAuthor
+sealed interface EmojiReactionAuthorUi {
+    data class Real(val correspondent: Correspondent) : EmojiReactionAuthorUi
+    data object FakeMe : EmojiReactionAuthorUi
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/EmojiReactionStateUi.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/EmojiReactionStateUi.kt
@@ -17,14 +17,9 @@
  */
 package com.infomaniak.mail.ui.main.thread.models
 
-import com.infomaniak.mail.data.models.message.Message
-import com.infomaniak.mail.utils.EmojiReactionUtils.hasAvailableReactionSlot
+import com.infomaniak.emojicomponents.data.ReactionState
+import com.infomaniak.mail.data.models.correspondent.Correspondent
 
-data class MessageUi(
-    val message: Message,
-    val emojiReactionsState: Map<String, EmojiReactionStateUi>,
-    val isReactionsFeatureAvailable: Boolean,
-) {
-    fun hasEmojis(): Boolean = emojiReactionsState.isNotEmpty()
-    fun canBeReactedTo(): Boolean = message.isValidReactionTarget && emojiReactionsState.hasAvailableReactionSlot()
+data class EmojiReactionStateUi(val authors: List<Correspondent>, override val hasReacted: Boolean) : ReactionState {
+    override val count: Int by authors::size
 }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/EmojiReactionStateUi.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/EmojiReactionStateUi.kt
@@ -21,7 +21,7 @@ import com.infomaniak.emojicomponents.data.Reaction
 
 data class EmojiReactionStateUi(
     override val emoji: String,
-    val authors: List<EmojiReactionAuthor>,
+    val authors: List<EmojiReactionAuthorUi>,
     override val hasReacted: Boolean,
 ) : Reaction {
     override val count: Int by authors::size

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/EmojiReactionStateUi.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/models/EmojiReactionStateUi.kt
@@ -17,8 +17,12 @@
  */
 package com.infomaniak.mail.ui.main.thread.models
 
-import com.infomaniak.emojicomponents.data.ReactionState
+import com.infomaniak.emojicomponents.data.Reaction
 
-data class EmojiReactionStateUi(val authors: List<EmojiReactionAuthor>, override val hasReacted: Boolean) : ReactionState {
+data class EmojiReactionStateUi(
+    override val emoji: String,
+    val authors: List<EmojiReactionAuthor>,
+    override val hasReacted: Boolean,
+) : Reaction {
     override val count: Int by authors::size
 }

--- a/app/src/main/java/com/infomaniak/mail/utils/EmojiReactionUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/EmojiReactionUtils.kt
@@ -17,12 +17,12 @@
  */
 package com.infomaniak.mail.utils
 
-import com.infomaniak.emojicomponents.data.ReactionState
+import com.infomaniak.emojicomponents.data.Reaction
 
 object EmojiReactionUtils {
     private const val MAX_REACTION_PER_USER = 5
 
-    fun Map<String, ReactionState>.hasAvailableReactionSlot(): Boolean {
+    fun Map<String, Reaction>.hasAvailableReactionSlot(): Boolean {
         var usedReactionSlots = 0
         forEach { (_, state) ->
             if (state.hasReacted && ++usedReactionSlots == MAX_REACTION_PER_USER) return false

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -35,7 +35,6 @@ import com.infomaniak.mail.di.IoDispatcher
 import com.infomaniak.mail.ui.main.search.NamedFolder
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.realm.kotlin.Realm
-import io.realm.kotlin.ext.realmDictionaryOf
 import io.realm.kotlin.ext.realmListOf
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.currentCoroutineContext
@@ -149,7 +148,7 @@ class SearchUtils @Inject constructor(
                     isDeletedOnApi = false,
                     latestCalendarEventResponse = null,
                     swissTransferFiles = realmListOf(),
-                    emojiReactions = realmDictionaryOf(),
+                    emojiReactions = realmListOf(),
                 )
             } else {
                 remoteMessage.keepLocalValues(localMessage)

--- a/app/src/test/java/com/infomaniak/mail/EmojiReactionStateEqualityTest.kt
+++ b/app/src/test/java/com/infomaniak/mail/EmojiReactionStateEqualityTest.kt
@@ -17,8 +17,9 @@
  */
 package com.infomaniak.mail
 
-import com.infomaniak.mail.data.models.message.EmojiReactionState
 import com.infomaniak.mail.ui.main.thread.ThreadAdapter.MessageDiffCallback.Companion.containsTheSameEmojiValuesAs
+import com.infomaniak.mail.ui.main.thread.models.EmojiReactionAuthorUi
+import com.infomaniak.mail.ui.main.thread.models.EmojiReactionStateUi
 import io.realm.kotlin.ext.realmDictionaryOf
 import io.realm.kotlin.types.RealmDictionary
 import org.junit.Assert.assertFalse
@@ -28,12 +29,12 @@ class EmojiReactionStateEqualityTest {
 
     @Test
     fun equivalentEmojiReactionStates_areEqual() {
-        val dictionary1: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(
+        val dictionary1: RealmDictionary<EmojiReactionStateUi?> = realmDictionaryOf(
             checkEmojiReactionState,
             crossEmojiReactionState,
         )
 
-        val dictionary2: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(
+        val dictionary2: RealmDictionary<EmojiReactionStateUi?> = realmDictionaryOf(
             crossEmojiReactionState,
             checkEmojiReactionState,
         )
@@ -44,9 +45,9 @@ class EmojiReactionStateEqualityTest {
 
     @Test
     fun emojiReactionStates_withMissingEmoji_areNotEqual() {
-        val dictionary1: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(checkEmojiReactionState)
+        val dictionary1: RealmDictionary<EmojiReactionStateUi?> = realmDictionaryOf(checkEmojiReactionState)
 
-        val dictionary2: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(
+        val dictionary2: RealmDictionary<EmojiReactionStateUi?> = realmDictionaryOf(
             checkEmojiReactionState,
             crossEmojiReactionState,
         )
@@ -60,8 +61,8 @@ class EmojiReactionStateEqualityTest {
         val checkEmoji1 = "✅" to emojiReactionStateOf("✅", 2, false)
         val checkEmoji2 = "✅" to emojiReactionStateOf("✅", 3, false) // count changed
 
-        val dictionary1: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(checkEmoji1)
-        val dictionary2: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(checkEmoji2)
+        val dictionary1: RealmDictionary<EmojiReactionStateUi?> = realmDictionaryOf(checkEmoji1)
+        val dictionary2: RealmDictionary<EmojiReactionStateUi?> = realmDictionaryOf(checkEmoji2)
 
         assertFalse(dictionary1.containsTheSameEmojiValuesAs(dictionary2))
         assertFalse(dictionary2.containsTheSameEmojiValuesAs(dictionary1))
@@ -72,8 +73,8 @@ class EmojiReactionStateEqualityTest {
         val checkEmoji1 = "✅" to emojiReactionStateOf("✅", 2, false)
         val checkEmoji2 = "✅" to emojiReactionStateOf("✅", 2, true) // hasReacted changed
 
-        val dictionary1: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(checkEmoji1)
-        val dictionary2: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(checkEmoji2)
+        val dictionary1: RealmDictionary<EmojiReactionStateUi?> = realmDictionaryOf(checkEmoji1)
+        val dictionary2: RealmDictionary<EmojiReactionStateUi?> = realmDictionaryOf(checkEmoji2)
 
         assertFalse(dictionary1.containsTheSameEmojiValuesAs(dictionary2))
         assertFalse(dictionary2.containsTheSameEmojiValuesAs(dictionary1))
@@ -83,11 +84,11 @@ class EmojiReactionStateEqualityTest {
         private val checkEmojiReactionState = "✅" to emojiReactionStateOf("✅", 2, false)
         private val crossEmojiReactionState = "❌" to emojiReactionStateOf("❌", 1, true)
 
-        private fun emojiReactionStateOf(emoji: String, count: Int, hasReacted: Boolean): EmojiReactionState {
-            return EmojiReactionState(emoji).apply {
-                this.count = count
-                this.hasReacted = hasReacted
-            }
+        // This method need to return the same class (here: EmojiReactionStateUi) that is used where
+        // containsTheSameEmojiValuesAs() is called in the actual code of the app. This is needed so we can make sure that
+        // underlying equality checks used inside of containsTheSameEmojiValuesAs() are always correctly defined
+        private fun emojiReactionStateOf(emoji: String, count: Int, hasReacted: Boolean): EmojiReactionStateUi {
+            return EmojiReactionStateUi(emoji, List(count) { EmojiReactionAuthorUi.FakeMe }, hasReacted)
         }
     }
 }

--- a/app/src/test/java/com/infomaniak/mail/EmojiReactionStateEqualityTest.kt
+++ b/app/src/test/java/com/infomaniak/mail/EmojiReactionStateEqualityTest.kt
@@ -57,8 +57,8 @@ class EmojiReactionStateEqualityTest {
 
     @Test
     fun emojiReactionStates_withDifferentCount_areNotEqual() {
-        val checkEmoji1 = "✅" to emojiReactionStateOf(2, false)
-        val checkEmoji2 = "✅" to emojiReactionStateOf(3, false) // count changed
+        val checkEmoji1 = "✅" to emojiReactionStateOf("✅", 2, false)
+        val checkEmoji2 = "✅" to emojiReactionStateOf("✅", 3, false) // count changed
 
         val dictionary1: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(checkEmoji1)
         val dictionary2: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(checkEmoji2)
@@ -69,8 +69,8 @@ class EmojiReactionStateEqualityTest {
 
     @Test
     fun emojiReactionStates_withDifferentHasReacted_areNotEqual() {
-        val checkEmoji1 = "✅" to emojiReactionStateOf(2, false)
-        val checkEmoji2 = "✅" to emojiReactionStateOf(2, true) // hasReacted changed
+        val checkEmoji1 = "✅" to emojiReactionStateOf("✅", 2, false)
+        val checkEmoji2 = "✅" to emojiReactionStateOf("✅", 2, true) // hasReacted changed
 
         val dictionary1: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(checkEmoji1)
         val dictionary2: RealmDictionary<EmojiReactionState?> = realmDictionaryOf(checkEmoji2)
@@ -80,11 +80,11 @@ class EmojiReactionStateEqualityTest {
     }
 
     companion object {
-        private val checkEmojiReactionState = "✅" to emojiReactionStateOf(2, false)
-        private val crossEmojiReactionState = "❌" to emojiReactionStateOf(1, true)
+        private val checkEmojiReactionState = "✅" to emojiReactionStateOf("✅", 2, false)
+        private val crossEmojiReactionState = "❌" to emojiReactionStateOf("❌", 1, true)
 
-        private fun emojiReactionStateOf(count: Int, hasReacted: Boolean): EmojiReactionState {
-            return EmojiReactionState().apply {
+        private fun emojiReactionStateOf(emoji: String, count: Int, hasReacted: Boolean): EmojiReactionState {
+            return EmojiReactionState(emoji).apply {
                 this.count = count
                 this.hasReacted = hasReacted
             }


### PR DESCRIPTION
Update the data we store in realm to include from what author and message uid each emoji reaction comes from. This data is needed to display details of who used what emoji in a bottom sheet later on and also to be able to delete all messages that were emoji reactions alongside the target message deletion.

I also changed the data we store in realm and use in the compose code from unordered dictionaries/sets to ordered lists so the emojis are always ordered the way they were sent in the thread.

The method containsTheSameEmojiValuesAs() now checks for nullability for no reason even though we don't need it anymore because we're not using RealmDictionary anymore. The problem is fixed in the next PR because it make a lot of noise to fix it here. The tests associated with this method are also fixed there. 

Depends on #2437