### PR TITLE
chore: Change realm version to the smallest possible version for the emoji reaction feature

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -198,7 +198,7 @@ object RealmDatabase {
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 5L
         const val MAILBOX_INFO_SCHEMA_VERSION = 9L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 35L // Emoji reactions 2
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 33L
         //endregion
 
         //region Configurations names


### PR DESCRIPTION
During the emoji reaction feature branch I had to bump the schema version multiple times. Here I downgrade it so the whole emoji reaction feature only bumped the schema version once