### PR TITLE
fix: Correctly load user avatars in cross app login

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,7 +114,6 @@ dependencies {
     implementation project(':Core:MyKSuite')
     implementation project(':Core:Network')
     implementation project(':Core:Sentry')
-    implementation project(':Core:UserAvatar')
     implementation project(':EmojiComponents')
     implementation project(':HtmlCleaner')
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,5 @@ include ':app',
         ':Core:Network',
         ':Core:Network:Models',
         ':Core:Sentry',
-        ':Core:UserAvatar',
         ':EmojiComponents',
         ':HtmlCleaner'


### PR DESCRIPTION
Use the updated and fixed core for displaying the user avatars in the cross app login. With this core bump, we can now remove the module UserAvatar from the app as it has been deleted entirely.

Depends on https://github.com/Infomaniak/android-core/pull/461