### PR TITLE
fix: Fix scheduled thread display in search

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -202,6 +202,10 @@ class Thread : RealmObject, Snoozable {
         }
     }
 
+    fun containsOnlyScheduledDrafts(featureFlags: Mailbox.FeatureFlagSet?, localSettings: LocalSettings): Boolean {
+        return getDisplayedMessages(featureFlags, localSettings).count() == numberOfScheduledDrafts
+    }
+
     /**
      * Only used for when the api tells us we're trying to automatically unsnooze a thread that's not snoozed
      */
@@ -255,8 +259,8 @@ class Thread : RealmObject, Snoozable {
         return message.preview
     }
 
-    fun computeThreadListDateDisplay(folderRole: FolderRole?) = when {
-        numberOfScheduledDrafts > 0 && folderRole == FolderRole.SCHEDULED_DRAFTS -> ThreadListDateDisplay.Scheduled
+    fun computeThreadListDateDisplay(featureFlags: Mailbox.FeatureFlagSet?, localSettings: LocalSettings) = when {
+        containsOnlyScheduledDrafts(featureFlags, localSettings) -> ThreadListDateDisplay.Scheduled
         isSnoozed() -> ThreadListDateDisplay.Snoozed
         isUnsnoozed() -> ThreadListDateDisplay.Unsnoozed
         else -> ThreadListDateDisplay.Default

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -107,8 +107,10 @@ class Thread : RealmObject, Snoozable {
     // It's only used to filter locally the Threads' list.
     @Transient
     var isLocallyMovedOut: Boolean = false
+    // When deserializing threads from the api, this way of initializing the value will compute the correct
+    // numberOfScheduledDrafts right after deserialization
     @Transient
-    var numberOfScheduledDrafts: Int = 0
+    var numberOfScheduledDrafts: Int = messages.count { it.isScheduledDraft }
     @Transient
     var isLastInboxMessageSnoozed: Boolean = false
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -20,7 +20,6 @@ package com.infomaniak.mail.ui.main.folder
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Canvas
-import android.os.Build.VERSION.SDK_INT
 import android.text.Spannable
 import android.text.TextUtils.TruncateAt
 import android.view.HapticFeedbackConstants
@@ -38,22 +37,17 @@ import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
-import com.google.android.material.R as RMaterial
 import com.google.android.material.card.MaterialCardView
 import com.infomaniak.core.matomo.Matomo.TrackerAction
-import com.infomaniak.core.utils.FormatData
 import com.infomaniak.core.utils.format
-import com.infomaniak.core.utils.formatWithLocal
 import com.infomaniak.core.utils.isInTheFuture
+import com.infomaniak.core.utils.isThisMonth
+import com.infomaniak.core.utils.isThisWeek
 import com.infomaniak.core.utils.isThisYear
 import com.infomaniak.core.utils.isToday
-import com.infomaniak.core.utils.isThisWeek
-import com.infomaniak.core.utils.isThisMonth
-import com.infomaniak.mail.utils.extensions.isLastWeek
 import com.infomaniak.core.utils.isYesterday
 import com.infomaniak.dragdropswiperecyclerview.DragDropSwipeAdapter
 import com.infomaniak.dragdropswiperecyclerview.DragDropSwipeRecyclerView
-import com.infomaniak.lib.core.R as RCore
 import com.infomaniak.lib.core.utils.capitalizeFirstChar
 import com.infomaniak.lib.core.utils.context
 import com.infomaniak.lib.core.utils.setMarginsRelative
@@ -81,17 +75,20 @@ import com.infomaniak.mail.utils.Utils.runCatchingRealm
 import com.infomaniak.mail.utils.extensions.formatSubject
 import com.infomaniak.mail.utils.extensions.getAttributeColor
 import com.infomaniak.mail.utils.extensions.isEmail
+import com.infomaniak.mail.utils.extensions.isLastWeek
 import com.infomaniak.mail.utils.extensions.postfixWithTag
 import com.infomaniak.mail.utils.extensions.toDate
 import dagger.hilt.android.qualifiers.ActivityContext
-import javax.inject.Inject
-import kotlin.math.abs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.invoke
 import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.math.abs
+import com.google.android.material.R as RMaterial
+import com.infomaniak.lib.core.R as RCore
 
 // TODO: Do we want to extract features from LoaderAdapter (in Core) and put them here? Same for all adapters in the app?
 class ThreadListAdapter @Inject constructor(
@@ -254,7 +251,7 @@ class ThreadListAdapter @Inject constructor(
             mailSubject.text = context.formatSubject(subject)
             mailBodyPreview.text = computePreview().ifBlank { context.getString(R.string.noBodyTitle) }
 
-            val dateDisplay = computeThreadListDateDisplay(folderRole)
+            val dateDisplay = computeThreadListDateDisplay(callbacks?.getFeatureFlags?.invoke(), localSettings)
             mailDate.text = dateDisplay.formatThreadDate(context, this)
             mailDateIcon.apply {
                 isVisible = dateDisplay.iconRes != null

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -522,8 +522,10 @@ class ThreadFragment : Fragment() {
                 iconTint = ColorStateList.valueOf(color)
             }
 
-            val messagesCount = thread.getDisplayedMessages(mainViewModel.featureFlagsLive.value, localSettings).size
-            val shouldDisplayScheduledDraftActions = thread.numberOfScheduledDrafts == messagesCount
+            val shouldDisplayScheduledDraftActions = thread.containsOnlyScheduledDrafts(
+                mainViewModel.featureFlagsLive.value,
+                localSettings,
+            )
             quickActionBar.init(if (shouldDisplayScheduledDraftActions) R.menu.scheduled_draft_menu else R.menu.message_menu)
 
             thread.snoozeEndDate?.let { snoozeEndDate ->


### PR DESCRIPTION
Scheduled threads in the search never had their `numberOfScheduledDrafts` computed and therefore were never treated as scheduled threads. Also, the condition to display a thread as scheduled in the thread list was limited to `FolderRole.SCHEDULED_DRAFTS` which also prevented from displaying them correctly in the search.

Now we use the same logic as iOS in this regard