### PR TITLE
feat: Add missing view composition strategy in emoji reaction feature

### DIFF
--- a/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/views/EmojiReactionsView.kt
+++ b/EmojiComponents/src/main/java/com/infomaniak/emojicomponents/views/EmojiReactionsView.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.vectorResource
 import com.infomaniak.core.compose.materialthemefromxml.MaterialThemeFromXml
 import com.infomaniak.emojicomponents.R
@@ -65,6 +66,8 @@ class EmojiReactionsView @JvmOverloads constructor(
             chipCornerRadius = getDimensionOrNull(R.styleable.EmojiReactionsView_chipCornerRadius)
             addReactionIconRes = getResourceIdOrNull(R.styleable.EmojiReactionsView_addReactionIcon)
             addReactionDisabledColor = getColorOrNull(R.styleable.EmojiReactionsView_addReactionDisabledColor)
+            val viewCompositionStrategyIndex = getInteger(R.styleable.EmojiReactionsView_viewCompositionStrategy, 0)
+            setViewCompositionStrategy(viewCompositionStrategyIndex.toViewCompositionStrategy())
             recycle()
         }
     }
@@ -140,6 +143,13 @@ class EmojiReactionsView @JvmOverloads constructor(
             )
         )
     )
+}
+
+private fun Int.toViewCompositionStrategy(): ViewCompositionStrategy {
+    return when(this) {
+        0 -> ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool
+        else -> error("Trying to set a ViewCompositionStrategy that has not been mapped to an instance")
+    }
 }
 
 @RequiresOptIn(

--- a/EmojiComponents/src/main/res/values/attrs.xml
+++ b/EmojiComponents/src/main/res/values/attrs.xml
@@ -21,6 +21,10 @@
         <attr name="chipCornerRadius" format="dimension" />
         <attr name="addReactionIcon" format="reference" />
         <attr name="addReactionDisabledColor" format="color" />
+        <!-- Add other view composition strategies when they will be needed -->
+        <attr name="viewCompositionStrategy" format="enum">
+            <enum name="disposeOnDetachedFromWindowOrReleasedFromPool" value="0" />
+        </attr>
     </declare-styleable>
 
 </resources>

--- a/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/components/MailBottomSheetScaffold.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.viewinterop.NoOpUpdate
 import com.infomaniak.mail.R
 import com.infomaniak.mail.databinding.ViewBottomSheetSeparatorBinding
 import splitties.systemservices.layoutInflater
@@ -66,7 +67,8 @@ fun MailBottomSheetScaffold(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(dimensionResource(R.dimen.bottomSheetDragHandleHeight)),
-                ) { /* No-op */ }
+                    update = NoOpUpdate,
+                )
             },
             content = {
                 title?.let {

--- a/app/src/main/java/com/infomaniak/mail/ui/components/views/MailBottomSheetScaffoldComposeView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/components/views/MailBottomSheetScaffoldComposeView.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.infomaniak.core.compose.materialthemefromxml.MaterialThemeFromXml
 import com.infomaniak.mail.ui.components.MailBottomSheetScaffold
 import kotlinx.coroutines.launch
@@ -52,6 +53,10 @@ abstract class MailBottomSheetScaffoldComposeView @JvmOverloads constructor(
 
     protected fun hideBottomSheet() {
         startHidingAnimation = true
+    }
+
+    init {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     }
 
     @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -601,6 +601,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/quoteButtonFrameLayout"
+            app:viewCompositionStrategy="disposeOnDetachedFromWindowOrReleasedFromPool"
             tools:visibility="visible" />
 
         <androidx.constraintlayout.widget.Group


### PR DESCRIPTION
ViewCompositionStrategy were missing from the AbstractComposeView used for the emoji reaction feature. This PR adds them.

To not forget to adapt the ViewCompositionStrategy of EmojiReactionsView correctly when used in other situations, I made it necessary to be provided whenever EmojiReactionsView is defined inside of XML