### PR TITLE
fix: Fix wrong error code in emoji reaction error codes

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionNotAllowedReason.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/EmojiReactionNotAllowedReason.kt
@@ -40,10 +40,7 @@ enum class EmojiReactionNotAllowedReason(
         "message_in_reply_to_not_valid",
         R.string.errorEmojiReactionMessageInReplyToNotValid
     ),
-    EmojiReactionMessageInReplyToEncrypted(
-        "message_in_reply_to_not_valid",
-        R.string.errorEmojiReactionMessageInReplyEncrypted
-    ),
+    EmojiReactionMessageInReplyToEncrypted("message_in_reply_to_encrypted", R.string.errorEmojiReactionMessageInReplyEncrypted),
     EmojiReactionMaxRecipient("max_recipient", R.string.errorEmojiReactionMaxRecipient),
     EmojiReactionRecipientNotAllowed("recipient_not_allowed", R.string.errorEmojiReactionRecipientNotAllowed);
 


### PR DESCRIPTION
When comparing other things in these errors for iOS, we discovered one of the keys in our project was duplicated. This fixes the error key with the correct one as seen in the web's project:

``` js
// emoji reaction
const string EMOJI_REACTION_FOLDER_NOT_ALLOWED              = 'emoji_reaction__folder_not_allowed';
const string EMOJI_REACTION_MESSAGE_IN_REPLY_TO_ENCRYPTED   = 'emoji_reaction__message_in_reply_to_encrypted';
const string EMOJI_REACTION_MESSAGE_IN_REPLY_TO_NOT_ALLOWED = 'emoji_reaction__message_in_reply_to_not_allowed';
const string EMOJI_REACTION_RECIPIENT_NOT_ALLOWED           = 'emoji_reaction__recipient_not_allowed';
const string EMOJI_REACTION_MESSAGE_IN_REPLY_TO_NOT_VALID   = 'emoji_reaction__message_in_reply_to_not_valid';
const string EMOJI_REACTION_MAX_RECIPIENT                   = 'emoji_reaction__max_recipient';
const string EMOJI_REACTION_MAX_REACTION_REACHED            = 'emoji_reaction__max_reaction_reached';
const string EMOJI_REACTION_ALREADY_USED                    = 'emoji_reaction__already_used';
```