### PR TITLE
fix: Fix crash on selected item removal

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -724,7 +724,8 @@ class ThreadListFragment : TwoPaneFragment() {
             val previousThreads = threadListAdapter.dataSet.filterIsInstance<Thread>()
             var shouldPublish = false
             deletedIndices.forEach {
-                val isRemoved = mainViewModel.selectedThreads.remove(previousThreads[it])
+                val thread = previousThreads.getOrElse(it) { return@forEach }
+                val isRemoved = mainViewModel.selectedThreads.remove(thread)
                 if (isRemoved) shouldPublish = true
             }
             if (shouldPublish) publishSelectedItems()


### PR DESCRIPTION
Below is the stacktrace that would happen before when refreshes would be triggered while a removed item was selected.

It now works fine, the removed items are properly removed from the selection, and actions on other emails are performed as they should.

```stacktrace
java.lang.IndexOutOfBoundsException: Index 2 out of bounds for length 0
	at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.util.Objects.checkIndex(Objects.java:359)
	at java.util.ArrayList.get(ArrayList.java:434)
	at com.infomaniak.mail.ui.main.folder.ThreadListFragment.removeMultiSelectItems(ThreadListFragment.kt:727)
	at com.infomaniak.mail.ui.main.folder.ThreadListFragment.access$removeMultiSelectItems(ThreadListFragment.kt:108)
	at com.infomaniak.mail.ui.main.folder.ThreadListFragment$observeCurrentThreads$1$1$2.invoke(ThreadListFragment.kt:569)
	at com.infomaniak.mail.ui.main.folder.ThreadListFragment$observeCurrentThreads$1$1$2.invoke(ThreadListFragment.kt:569)
	at com.infomaniak.mail.utils.RealmChangesBinding.resultsChangeObserver$lambda$2$lambda$0(RealmChangesBinding.kt:101)
	at com.infomaniak.mail.utils.RealmChangesBinding.$r8$lambda$02Ir2YBIRMdG4SbKNxfo15ExdAI(Unknown Source:0)
	at com.infomaniak.mail.utils.RealmChangesBinding$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass:0)
	at com.infomaniak.mail.utils.RealmChangesBinding$observeWaiting$1.onChanged$lambda$0(RealmChangesBinding.kt:182)
	at com.infomaniak.mail.utils.RealmChangesBinding$observeWaiting$1.$r8$lambda$_KIL13n_vr4jMPoL9nKAF07KMc8(Unknown Source:0)
	at com.infomaniak.mail.utils.RealmChangesBinding$observeWaiting$1$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1406)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1415)
	at android.view.Choreographer.doCallbacks(Choreographer.java:1015)
	at android.view.Choreographer.doFrame(Choreographer.java:941)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1389)
	at android.os.Handler.handleCallback(Handler.java:959)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8705)
```