### PR TITLE
fix: Fix emoji picker not opening in the search

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -114,6 +114,8 @@ class ThreadListFragment : TwoPaneFragment() {
     private val navigationArgs: ThreadListFragmentArgs by navArgs()
     private val threadListViewModel: ThreadListViewModel by viewModels()
 
+    override val substituteClassName: String = javaClass.name
+
     private val threadListMultiSelection by lazy { ThreadListMultiSelection() }
 
     private var lastUpdatedDate: Date? = null

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/TwoPaneFragment.kt
@@ -69,6 +69,8 @@ abstract class TwoPaneFragment : Fragment() {
     @Inject
     lateinit var localSettings: LocalSettings
 
+    abstract val substituteClassName: String
+
     @ColorRes
     abstract fun getStatusBarColor(): Int
     abstract fun getLeftPane(): View?

--- a/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/search/SearchFragment.kt
@@ -77,6 +77,8 @@ class SearchFragment : TwoPaneFragment() {
 
     private val searchViewModel: SearchViewModel by viewModels()
 
+    override val substituteClassName: String = javaClass.name
+
     private val showLoadingTimer: CountDownTimer by lazy { Utils.createRefreshTimer(onTimerFinish = ::showRefreshLayout) }
 
     private val recentSearchAdapter by lazy {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -1062,6 +1062,14 @@ class ThreadFragment : Fragment() {
         return direction?.let { getNextThread(startingThreadIndex, direction) }
     }
 
+    private fun Fragment.navigateToEmojiPicker(messageUid: String) {
+        safelyNavigate(
+            resId = R.id.emojiPickerBottomSheetDialog,
+            args = EmojiPickerBottomSheetDialogArgs(messageUid).toBundle(),
+            substituteClassName = twoPaneFragment.substituteClassName,
+        )
+    }
+
     enum class HeaderState {
         ELEVATED,
         LOWERED,
@@ -1081,14 +1089,6 @@ class ThreadFragment : Fragment() {
         private fun allAttachmentsFileName(subject: String) = "infomaniak-mail-attachments-$subject.zip"
         private fun allSwissTransferFilesName(subject: String) = "infomaniak-mail-swisstransfer-$subject.zip"
     }
-}
-
-private fun Fragment.navigateToEmojiPicker(messageUid: String) {
-    safelyNavigate(
-        resId = R.id.emojiPickerBottomSheetDialog,
-        args = EmojiPickerBottomSheetDialogArgs(messageUid).toBundle(),
-        substituteClassName = ThreadListFragment::class.java.name,
-    )
 }
 
 private inline fun <reified T> Data.getSerializable(key: String): T? = getString(key)?.let { Json.decodeFromString(it) }


### PR DESCRIPTION
If the emoji picker button is clicked inside a Thread opened from within the search, the picker wouldn't open because safelyNavigate used a hardcoded substitue class name that did not take the SearchFragment into account