### PR TITLE
fix: Hide "evolve" button when the user can't evolve his ksuite

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -882,14 +882,19 @@ class NewMessageFragment : Fragment() {
 
         if (isMailboxFull) {
             trackNewMessageEvent(MatomoName.TrySendingWithMailboxFull)
-            showSnackbar(R.string.myKSuiteSpaceFullAlert, actionButtonTitle = R.string.buttonUpgrade) {
-                val matomoName = MatomoKSuite.NOT_ENOUGH_STORAGE_UPGRADE_NAME
-                when (mailbox.kSuite) {
-                    KSuite.Perso.Free -> openMyKSuiteUpgradeBottomSheet(matomoName)
-                    KSuite.Pro.Free -> openKSuiteProBottomSheet(mailbox.kSuite, mailbox.isAdmin, matomoName)
-                    else -> Unit
-                }
+
+            val matomoName = MatomoKSuite.NOT_ENOUGH_STORAGE_UPGRADE_NAME
+            val onActionClicked: (() -> Unit)? = when (mailbox.kSuite) {
+                KSuite.Perso.Free -> fun() = openMyKSuiteUpgradeBottomSheet(matomoName)
+                KSuite.Pro.Free -> fun() = openKSuiteProBottomSheet(mailbox.kSuite, mailbox.isAdmin, matomoName)
+                else -> null
             }
+
+            showSnackbar(
+                R.string.myKSuiteSpaceFullAlert,
+                actionButtonTitle = R.string.buttonUpgrade,
+                onActionClicked = onActionClicked,
+            )
         }
 
         return !isMailboxFull


### PR DESCRIPTION
The "evolve" button was displayed in the snackbar notifying the user that he has no storage space left even when the user could not evolve his offer. Now the button is not displayed in this case.