### PR TITLE
chore: Clean useless matrices

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,10 +11,6 @@ jobs:
   instrumentation-tests:
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Android ]
-    strategy:
-      matrix:
-        api-level: [ 36 ]
-        target: [ google_apis ]
 
     steps:
       - name: Checkout the code

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -11,10 +11,6 @@ concurrency:
 jobs:
   instrumentation-tests:
     runs-on: [ self-hosted, Android ]
-    strategy:
-      matrix:
-        api-level: [ 36 ]
-        target: [ google_apis ]
 
     steps:
       - name: Checkout the code
@@ -54,4 +50,3 @@ jobs:
               title: 'UI tests failure',
               body: 'Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.',
             })
-


### PR DESCRIPTION
Matrices were used at some point in kDrive for ReactiveCircus/android-emulator-runner but the code is long gone and the matrices are not read anymore yet they are still in the code for no reason.