### PR TITLE
fix: Wrap MailBottomSheetScaffoldComposeView into a FrameLayout to avoid animation crash

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/components/views/MailBottomSheetScaffoldComposeView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/components/views/MailBottomSheetScaffoldComposeView.kt
@@ -19,6 +19,7 @@ package com.infomaniak.mail.ui.components.views
 
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.FrameLayout
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -32,7 +33,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.Dp
 import com.infomaniak.core.compose.basics.bottomsheet.LocalBottomSheetTheme
@@ -46,7 +47,7 @@ abstract class MailBottomSheetScaffoldComposeView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
-) : AbstractComposeView(context, attrs, defStyleAttr) {
+) : FrameLayout(context, attrs, defStyleAttr) {
 
     private var isVisible by mutableStateOf(false)
     private var startHidingAnimation by mutableStateOf(false)
@@ -73,12 +74,17 @@ abstract class MailBottomSheetScaffoldComposeView @JvmOverloads constructor(
     protected open fun onDialogFragmentDismissRequest() = Unit
 
     init {
-        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        addView(
+            ComposeView(context, attrs, defStyleAttr).apply {
+                setContent { ComposeViewContent() }
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            }
+        )
     }
 
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
-    final override fun Content() {
+    private fun ComposeViewContent() {
         val sheetState = rememberModalBottomSheetState()
         val scope = rememberCoroutineScope()
 


### PR DESCRIPTION
The system seems to animate these custom views in some rare occasions which causes the TransitionManager to try and call addView() on the root View of the custom view. When using AbstractComposeView as the root view, calls to addView() crash because it's unsupported. To fix the issue, the root view was changed to a view that supports addView().

Fixes MAIL-ANDROID-P6M