### PR TITLE
fix: Fix material dynamic colors

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/views/itemViews/SelectableItemView.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/itemViews/SelectableItemView.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,10 +18,14 @@
 package com.infomaniak.mail.views.itemViews
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.graphics.Color
 import android.util.AttributeSet
+import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
+import androidx.annotation.StyleRes
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.widget.TextViewCompat
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Folder
 import com.infomaniak.mail.utils.extensions.getAttributeColor
@@ -40,14 +44,29 @@ sealed class SelectableItemView @JvmOverloads constructor(
     }
 
     fun setSelectedState(isSelected: Boolean) = with(binding) {
-        val (color, textAppearance) = if (isSelected && itemStyle == SelectionStyle.MENU_DRAWER) {
-            context.getAttributeColor(RMaterial.attr.colorPrimaryContainer) to R.style.BodyMedium_Accent
+        val (backgroundColor, decoratorsColor, textColor, textAppearance) = if (isSelected && itemStyle == SelectionStyle.MENU_DRAWER) {
+            ColorState(
+                backgroundColor = context.getAttributeColor(RMaterial.attr.colorPrimaryContainer),
+                decoratorsColor = context.getAttributeColor(RMaterial.attr.colorOnPrimaryContainer),
+                textColor = context.getAttributeColor(RMaterial.attr.colorOnPrimaryContainer),
+                textAppearance = R.style.BodyMedium,
+            )
         } else {
-            Color.TRANSPARENT to if (textWeight == TextWeight.MEDIUM) R.style.BodyMedium else R.style.Body
+            ColorState(
+                backgroundColor = Color.TRANSPARENT,
+                decoratorsColor = context.getAttributeColor(RMaterial.attr.colorPrimary),
+                textColor = context.getColor(R.color.primaryTextColor),
+                textAppearance = if (textWeight == TextWeight.MEDIUM) R.style.BodyMedium else R.style.Body,
+            )
         }
 
-        root.setCardBackgroundColor(color)
+        root.setCardBackgroundColor(backgroundColor)
         itemName.setTextAppearance(textAppearance)
+        itemName.setTextColor(textColor)
+        val decoratorStateList = ColorStateList.valueOf(decoratorsColor)
+        TextViewCompat.setCompoundDrawableTintList(itemName, decoratorStateList)
+        endIcon.imageTintList = decoratorStateList
+        unreadCountChip.setTextColor(decoratorsColor)
 
         setEndIcon(if (isSelected) checkIcon else null, R.string.contentDescriptionSelectedItem)
     }
@@ -58,3 +77,10 @@ fun SelectableItemView.setFolderUi(folder: Folder, @DrawableRes iconId: Int, isS
     icon = AppCompatResources.getDrawable(context, iconId)
     setSelectedState(isSelected)
 }
+
+private data class ColorState(
+    @ColorInt val backgroundColor: Int,
+    @ColorInt val decoratorsColor: Int,
+    @ColorInt val textColor: Int,
+    @StyleRes val textAppearance: Int,
+)

--- a/app/src/main/res/color/button_toggle_text.xml
+++ b/app/src/main/res/color/button_toggle_text.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Infomaniak Mail - Android
+  ~ Copyright (C) 2022-2025 Infomaniak Network SA
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorOnPrimaryContainer" android:state_checked="true" />
+    <item android:color="@color/primaryTextColor" android:state_checked="false" />
+</selector>

--- a/app/src/main/res/color/chip_contact_text_color.xml
+++ b/app/src/main/res/color/chip_contact_text_color.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2023-2024 Infomaniak Network SA
+  ~ Copyright (C) 2023-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -17,5 +17,5 @@
   -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:color="?attr/colorOnPrimary" android:state_focused="true" />
-    <item android:color="?android:attr/colorPrimary" />
+    <item android:color="?attr/colorOnPrimaryContainer" />
 </selector>

--- a/app/src/main/res/layout/new_account_storage_chips.xml
+++ b/app/src/main/res/layout/new_account_storage_chips.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2023-2024 Infomaniak Network SA
+  ~ Copyright (C) 2023-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -55,7 +55,8 @@
             android:maxLines="2"
             android:minHeight="0dp"
             android:paddingHorizontal="@dimen/marginStandardSmall"
-            android:text="@string/newAccountStorageMail" />
+            android:text="@string/newAccountStorageMail"
+            android:textColor="?attr/colorOnPrimaryContainer" />
 
     </FrameLayout>
 
@@ -83,7 +84,8 @@
             android:maxLines="2"
             android:minHeight="0dp"
             android:paddingHorizontal="@dimen/marginStandardSmall"
-            android:text="@string/newAccountStorageDrive" />
+            android:text="@string/newAccountStorageDrive"
+            android:textColor="?attr/colorOnPrimaryContainer" />
 
     </FrameLayout>
 
@@ -108,7 +110,8 @@
             android:clickable="false"
             android:focusable="false"
             android:paddingHorizontal="@dimen/marginStandardSmall"
-            android:text="@string/newAccountStorageMail" />
+            android:text="@string/newAccountStorageMail"
+            android:textColor="?attr/colorOnPrimaryContainer" />
 
     </FrameLayout>
 
@@ -133,7 +136,8 @@
             android:clickable="false"
             android:focusable="false"
             android:paddingHorizontal="@dimen/marginStandardSmall"
-            android:text="@string/newAccountStorageDrive" />
+            android:text="@string/newAccountStorageDrive"
+            android:textColor="?attr/colorOnPrimaryContainer" />
 
     </FrameLayout>
 

--- a/app/src/main/res/layout/view_main_actions.xml
+++ b/app/src/main/res/layout/view_main_actions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak Mail - Android
-  ~ Copyright (C) 2022-2024 Infomaniak Network SA
+  ~ Copyright (C) 2022-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@
         android:padding="20dp"
         app:cornerRadius="8dp"
         app:iconSize="24dp"
-        app:iconTint="?android:attr/colorPrimary"
+        app:iconTint="?attr/colorOnPrimaryContainer"
         app:layout_constraintEnd_toStartOf="@id/button2"
         app:layout_constraintHorizontal_chainStyle="spread"
         app:layout_constraintStart_toStartOf="parent"
@@ -63,7 +63,7 @@
         android:padding="20dp"
         app:cornerRadius="8dp"
         app:iconSize="24dp"
-        app:iconTint="?android:attr/colorPrimary"
+        app:iconTint="?attr/colorOnPrimaryContainer"
         app:layout_constraintBottom_toBottomOf="@id/button1"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@id/button3"
@@ -95,7 +95,7 @@
         android:padding="20dp"
         app:cornerRadius="8dp"
         app:iconSize="24dp"
-        app:iconTint="?android:attr/colorPrimary"
+        app:iconTint="?attr/colorOnPrimaryContainer"
         app:layout_constraintBottom_toBottomOf="@id/button1"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toStartOf="@id/button4"
@@ -127,7 +127,7 @@
         android:padding="20dp"
         app:cornerRadius="8dp"
         app:iconSize="24dp"
-        app:iconTint="?android:attr/colorPrimary"
+        app:iconTint="?attr/colorOnPrimaryContainer"
         app:layout_constraintBottom_toBottomOf="@id/button1"
         app:layout_constraintDimensionRatio="1"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -22,12 +22,10 @@
     <color name="pinkMailInverse">@color/pink_mail_primary_light</color>
     <color name="pinkMailOnPrimary">@color/pink_mail_on_primary_dark</color>
     <color name="pinkMailContainer">@color/pink_mail_container_dark</color>
-    <color name="pinkOnboardingSecondaryBackground">@color/bat</color>
     <color name="blueMail">@color/blue_mail_primary_dark</color>
     <color name="blueMailInverse">@color/blue_mail_primary_light</color>
     <color name="blueMailOnPrimary">@color/blue_mail_on_primary_dark</color>
     <color name="blueMailContainer">@color/blue_mail_container_dark</color>
-    <color name="blueOnboardingSecondaryBackground">@color/bat</color>
 
     <!-- Context / errors -->
     <color name="greenSuccess">@color/grass_dark</color>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -172,6 +172,9 @@
     <color name="commonColor10">#E4E4E4</color>
     <color name="commonColor11">#626262</color>
 
+    <!-- Theme colors -->
+    <color name="customMaterialDynamicPrimaryContainer">@color/material_dynamic_primary20</color>
+
     <!-- Other -->
     <color name="textInputStrokeColor">@color/shark</color>
     <color name="toggleableTextFormatterBackgroundColor">@color/mouse</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -22,12 +22,10 @@
     <color name="pinkMailInverse">@color/pink_mail_primary_dark</color>
     <color name="pinkMailOnPrimary">@color/pink_mail_on_primary_light</color>
     <color name="pinkMailContainer">@color/pink_mail_container_light</color>
-    <color name="pinkOnboardingSecondaryBackground">@color/pinkMailContainer</color>
     <color name="blueMail">@color/primary</color>
     <color name="blueMailInverse">@color/blue_mail_primary_dark</color>
     <color name="blueMailOnPrimary">@color/blue_mail_on_primary_light</color>
     <color name="blueMailContainer">@color/blue_mail_container_light</color>
-    <color name="blueOnboardingSecondaryBackground">@color/blueMailContainer</color>
 
     <!-- Context / errors -->
     <color name="greenSuccess">@color/grass_light</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -296,6 +296,9 @@
     <color name="commonColor10">#F8F8F8</color>
     <color name="commonColor11">#D9D9D9</color>
 
+    <!-- Theme colors -->
+    <color name="customMaterialDynamicPrimaryContainer">@color/material_dynamic_primary90</color>
+
     <!-- Shortcut -->
     <color name="backgroundShortcut">#F5F5F5</color>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -439,7 +439,7 @@
         <item name="android:paddingEnd">0dp</item>
         <item name="android:paddingStart">0dp</item>
         <item name="android:textAllCaps">false</item>
-        <item name="android:textColor">@color/primaryTextColor</item>
+        <item name="android:textColor">@color/button_toggle_text</item>
         <item name="rippleColor">?attr/colorControlHighlight</item>
         <item name="strokeColor">?android:attr/colorPrimary</item>
         <item name="strokeWidth">1dp</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -50,6 +50,11 @@
         <item name="bottomSheetDialogTheme">@style/BottomSheetDialogTheme</item>
         <item name="collapsingToolbarLayoutStyle">@style/AppThemeCollapsingToolbarLayoutTheme</item>
         <item name="colorAccent">?attr/colorPrimary</item>
+        <!--Custom color to fix the material expressive palette. The tone has changed and the design of the pink and blue themes
+        expected a tone around 90/20 for light/dark. This modifies the material palette to adjust this color role which is used a
+        lot through the app-->
+        <item name="colorPrimaryContainer">@color/customMaterialDynamicPrimaryContainer</item>
+        <item name="colorOnPrimaryContainer">?attr/colorPrimary</item>
         <item name="colorControlHighlight">@color/color_primary_translucent_ripple</item>
         <item name="colorError">@color/redDestructiveAction</item>
         <item name="colorOnSurface">@color/onBottomSheetBackgroundColor</item> <!--Bottom sheet content color-->


### PR DESCRIPTION
Fixes all places in the code where we forgot to use `onPrimaryContainer` when drawing content on top of a `primaryContainer` surface.

Also adapts the material dynamic default palette by overriding the values for `primaryContainer` and `onPrimaryContainer` so they look and feel like the pink and blue themes.

This fixes the issue where the palette exposed through material expressive now has a much more vivid color for the primaryContainer color leading to other unusable contrasts, where as our pink and blue designs are designed with a faded color in mind.

I also removed the unused colors `pinkOnboardingSecondaryBackground` and `blueOnboardingSecondaryBackground` that I found by chance