### PR TITLE
fix: Add query param to receive emoji_reaction field from the search

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
@@ -167,8 +167,8 @@ object ApiRoutes {
         resource: String?,
     ): String {
         return if (resource.isNullOrBlank()) {
-            val hasDisplayModeThreadToOnOff = if (hasDisplayModeThread) "on" else "off"
-            "${folder(mailboxUuid, folderId)}/message?thread=${hasDisplayModeThreadToOnOff}&offset=0&$filters"
+            val threadMode = if (hasDisplayModeThread) "on" else "off"
+            "${folder(mailboxUuid, folderId)}/message?thread=${threadMode}&offset=0&$filters&with=emoji_reactions_per_message"
         } else {
             "${resource(resource)}&$filters"
         }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/ThreadRecomputations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/ThreadRecomputations.kt
@@ -159,7 +159,14 @@ object ThreadRecomputations {
         messagesWithContent.clear()
         allMessages.forEach { message ->
             reactionsPerMessageId[message.messageId]?.let { reactions ->
-                message.emojiReactions.overrideWith(reactions)
+                // When coming from the search, threads are not managed because they are remote threads we've just fetched and
+                // have not yet saved to realm. But when recomputing threads from the thread algorithm, the threads are already
+                // stored inside of realm and are therefore managed.
+                if (message.isManaged()) {
+                    message.emojiReactions.overrideWith(reactions)
+                } else {
+                    message.emojiReactions = reactions.values.toRealmList()
+                }
             }
 
             val targetMessageIds = message.inReplyTo ?: ""


### PR DESCRIPTION
The back did not send the `emoji_reaction` field in messages when querying them from the search which prevented hiding the emoji reactions from threads when searching for a specific folder.

This PR adds the new query param they just added to also get the required data when querying the search.

We never had any emojis so some code inside of recomputeMessagesWithContent() was never called for the search but now that it's possible the code needed to be adapted slightly as well