### PR TITLE
refactor: Remove now useless `targetSdk` in libraries

### DIFF
--- a/HtmlCleaner/build.gradle.kts
+++ b/HtmlCleaner/build.gradle.kts
@@ -13,7 +13,6 @@ android {
 
     defaultConfig {
         minSdk = appMinSdk
-        targetSdk = appCompileSdk
     }
 
     compileOptions {


### PR DESCRIPTION
Depends on https://github.com/Infomaniak/android-core/pull/527