### PR TITLE
feat: Update the automatic expand on empty folders code because of FolderUi and improve it

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -216,12 +216,6 @@ class FolderController @Inject constructor(
                 folder.isCollapsed = false
             }
         }
-
-        fun hide(folderId: String, realm: MutableRealm) {
-            realm.updateFolder(folderId) { folder ->
-                folder.isHidden = true
-            }
-        }
         //endregion
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -196,10 +196,6 @@ class FolderController @Inject constructor(
             realm.write { getFolderBlocking(id, realm = this)?.let { onUpdate(this, it) } }
         }
 
-        private fun MutableRealm.updateFolder(id: String, onUpdate: (Folder) -> Unit) {
-            getFolderBlocking(id, realm = this)?.let { onUpdate(it) }
-        }
-
         fun deleteSearchFolderData(realm: MutableRealm) = with(getOrCreateSearchFolder(realm)) {
             threads.clear()
         }
@@ -215,6 +211,10 @@ class FolderController @Inject constructor(
             realm.updateFolder(folderId) { folder ->
                 folder.isCollapsed = false
             }
+        }
+
+        private fun MutableRealm.updateFolder(id: String, onUpdate: (Folder) -> Unit) {
+            getFolderBlocking(id, realm = this)?.let { onUpdate(it) }
         }
         //endregion
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -581,17 +581,17 @@ class MainViewModel @Inject constructor(
     private suspend fun updateFoldersCollapsedState() {
         val folders = displayedFoldersFlow.first()
         mailboxContentRealm().write {
-            folders.custom.updateState(realm = this)
-            folders.default.updateState(realm = this)
+            folders.custom.updateCollapsedState(realm = this)
+            folders.default.updateCollapsedState(realm = this)
         }
     }
 
-    private fun List<FolderUi>.updateState(realm: MutableRealm) {
-        forEachNestedItem { folder, _ ->
-            if (folder.isRoot) {
+    private fun List<FolderUi>.updateCollapsedState(realm: MutableRealm) {
+        forEachNestedItem { folderUi, _ ->
+            if (folderUi.isRoot) {
                 // If we detect that a folder doesn't have any children anymore, if it was collapsed, automatically expand it
-                val collapseStateNeedsReset = folder.children.isEmpty()
-                if (collapseStateNeedsReset) FolderController.expand(folder.folder.id, realm)
+                val collapseStateNeedsReset = folderUi.children.isEmpty()
+                if (collapseStateNeedsReset) FolderController.expand(folderUi.folder.id, realm)
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -570,7 +570,7 @@ class MainViewModel @Inject constructor(
         ApiRepository.getFolders(mailbox.uuid).data?.let { folders ->
             if (!mailboxContentRealm().isClosed()) {
                 folderController.update(mailbox, folders, mailboxContentRealm())
-                updateFoldersCollapsedState()
+                expandRootFoldersWithoutChildren()
             }
         }
     }
@@ -578,7 +578,7 @@ class MainViewModel @Inject constructor(
     /**
      *  Recomputes the [Folder.isCollapsed] state so a parent which has no more children is correctly expanded.
      */
-    private suspend fun updateFoldersCollapsedState() {
+    private suspend fun expandRootFoldersWithoutChildren() {
         val folders = displayedFoldersFlow.first()
         mailboxContentRealm().write {
             folders.custom.updateCollapsedState(realm = this)


### PR DESCRIPTION
This check needs to be updated to take into account the new visual structure added with FolderUi when selecting who to expand automatically. 

This was the opportunity to take this code out of the FolderController which was too much logic heavy to be inside of FolderController.upsertFolders().

At the same time I added the fix for the case where all children of a parent have been removed and at least a new child has been added to the parent. Previously the new children would remain visible even though the parent would be collapsed. Now their state is update to match the one of the parent.

Depends on #2637 