### PR TITLE
fix: Store .ik subfolders inside of realm and avoid access to closed realm

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/FolderController.kt
@@ -27,7 +27,6 @@ import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.utils.extensions.copyListToRealm
 import com.infomaniak.mail.utils.extensions.findSuspend
 import com.infomaniak.mail.utils.extensions.sortFolders
-import com.infomaniak.mail.utils.shouldBeExcluded
 import io.realm.kotlin.MutableRealm
 import io.realm.kotlin.Realm
 import io.realm.kotlin.TypedRealm
@@ -228,29 +227,10 @@ private tailrec fun formatFolderWithAllChildren(
     inputList: MutableList<Folder>,
     outputList: MutableList<Folder> = mutableListOf(),
 ): List<Folder> {
-
     val folder = inputList.removeAt(0)
 
-    /*
-    * There are two types of folders:
-    * - user's folders (with or without a role)
-    * - hidden IK folders (ScheduledDrafts, Snoozed, etc…)
-    *
-    * We want to display the user's folders, and also the IK folders for which we handle the role.
-    * IK folders where we don't handle the role are dismissed.
-    *
-    * I.e. hides all IK folders with no roles.
-    */
-    val shouldThisFolderBeAdded = folder.shouldBeExcluded(excludeRoleFolder = false).not()
-
-    val children = if (shouldThisFolderBeAdded) {
-        outputList.add(folder)
-        folder.children.sortFolders()
-    } else {
-        null
-    }
-
-    children?.let { inputList.addAll(index = 0, it) }
+    outputList.add(folder)
+    inputList.addAll(index = 0, folder.children.sortFolders())
 
     return if (inputList.isEmpty()) {
         outputList


### PR DESCRIPTION
The last PR that refactored the way menu drawer folders are displayed removed the copy from realm by mistake which lead to exceptions being thrown when a user disconnects from the app and the realm is closed.

Also, the method that would flatten folders received by the api to store them in realm would discard subfolders and only store root folders which is now fixed.