### PR TITLE
chore: Fix leading space in threadListDeletionConfirmationAlertTitle

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -16,10 +16,6 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
-    <plurals name="threadListDeletionConfirmationAlertTitle">
-        <item quantity="one">%d Konversation löschen</item>
-        <item quantity="other">%d Konversationen löschen</item>
-    </plurals>
     <string name="accentColorBlueTitle">Blau</string>
     <string name="accentColorPinkTitle">Rosa</string>
     <string name="accentColorSystemTitle">Farbe des Systems</string>
@@ -644,6 +640,10 @@
     <plurals name="threadListDeletionConfirmationAlertDescription">
         <item quantity="one">Sind Sie sicher, dass Sie diese Konversation endgültig löschen wollen?</item>
         <item quantity="other">Sind Sie sicher, dass Sie diese Konversationen endgültig löschen wollen?</item>
+    </plurals>
+    <plurals name="threadListDeletionConfirmationAlertTitle">
+        <item quantity="one">%d Konversation löschen</item>
+        <item quantity="other">%d Konversationen löschen</item>
     </plurals>
     <string name="threadListEmptyFolderAlertDescription">Sind Sie sicher, dass Sie alle Nachrichten in diesem Ordner dauerhaft löschen wollen?</string>
     <string name="threadListEmptySpamButton">Spam leeren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -16,10 +16,6 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
-    <plurals name="threadListDeletionConfirmationAlertTitle">
-        <item quantity="one">Borrar %d conversación</item>
-        <item quantity="other">Borrar %d conversaciones</item>
-    </plurals>
     <string name="accentColorBlueTitle">Azul</string>
     <string name="accentColorPinkTitle">Rosa</string>
     <string name="accentColorSystemTitle">Color del sistema</string>
@@ -644,6 +640,10 @@
     <plurals name="threadListDeletionConfirmationAlertDescription">
         <item quantity="one">¿Estás seguro de que quieres borrar este conversación permanentemente?</item>
         <item quantity="other">¿Estás seguro de que quieres borrar estos conversaciones permanentemente?</item>
+    </plurals>
+    <plurals name="threadListDeletionConfirmationAlertTitle">
+        <item quantity="one">Borrar %d conversación</item>
+        <item quantity="other">Borrar %d conversaciones</item>
     </plurals>
     <string name="threadListEmptyFolderAlertDescription">¿Estás seguro de que quieres borrar definitivamente todos los mensajes de esta carpeta?</string>
     <string name="threadListEmptySpamButton">Spam vacío</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -16,11 +16,6 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="ImpliedQuantity">
-    <plurals name="threadListDeletionConfirmationAlertTitle">
-        <item quantity="one">Supprimer %d conversation</item>
-        <item quantity="other">Supprimer %d conversations</item>
-        <item quantity="many">Supprimer %d de conversations</item>
-    </plurals>
     <string name="accentColorBlueTitle">Bleu</string>
     <string name="accentColorPinkTitle">Rose</string>
     <string name="accentColorSystemTitle">Couleur du système</string>
@@ -662,6 +657,11 @@
         <item quantity="one">Êtes-vous sûr de vouloir supprimer cette conversation définitivement ?</item>
         <item quantity="other">Êtes-vous sûr de vouloir supprimer ces conversations définitivement ?</item>
         <item quantity="many">Êtes-vous sûr de vouloir supprimer ces conversations définitivement ?</item>
+    </plurals>
+    <plurals name="threadListDeletionConfirmationAlertTitle">
+        <item quantity="one">Supprimer %d conversation</item>
+        <item quantity="other">Supprimer %d conversations</item>
+        <item quantity="many">Supprimer %d de conversations</item>
     </plurals>
     <string name="threadListEmptyFolderAlertDescription">Êtes-vous sûr de vouloir supprimer définitivement tous les messages de ce dossier ?</string>
     <string name="threadListEmptySpamButton">Vider les spams</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -16,10 +16,6 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <resources>
-    <plurals name="threadListDeletionConfirmationAlertTitle">
-        <item quantity="one">Cancella %d conversazione</item>
-        <item quantity="other">Cancella %d conversazioni</item>
-    </plurals>
     <string name="accentColorBlueTitle">Blu</string>
     <string name="accentColorPinkTitle">Rosa</string>
     <string name="accentColorSystemTitle">Colore del sistema</string>
@@ -644,6 +640,10 @@
     <plurals name="threadListDeletionConfirmationAlertDescription">
         <item quantity="one">Sei sicuro di voler cancellare questo conversazione in modo permanente?</item>
         <item quantity="other">Sei sicuro di voler cancellare questi conversazioni in modo permanente?</item>
+    </plurals>
+    <plurals name="threadListDeletionConfirmationAlertTitle">
+        <item quantity="one">Cancella %d conversazione</item>
+        <item quantity="other">Cancella %d conversazioni</item>
     </plurals>
     <string name="threadListEmptyFolderAlertDescription">Sei sicuro di voler eliminare definitivamente tutti i messaggi in questa cartella?</string>
     <string name="threadListEmptySpamButton">Cartella Spam vuota</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,10 +22,6 @@
     <string name="notification_channel_id_general" translatable="false">general_channel_id</string>
     <string name="notification_channel_id_sync_messages_service" translatable="false">sync_messages_service_channel_id</string>
 
-    <plurals name="threadListDeletionConfirmationAlertTitle">
-        <item quantity="one">Delete %d conversation</item>
-        <item quantity="other">Delete %d conversations</item>
-    </plurals>
     <string name="accentColorBlueTitle">Blue</string>
     <string name="accentColorPinkTitle">Pink</string>
     <string name="accentColorSystemTitle">System color</string>
@@ -650,6 +646,10 @@
     <plurals name="threadListDeletionConfirmationAlertDescription">
         <item quantity="one">Are you sure you want to delete this conversation permanently?</item>
         <item quantity="other">Are you sure you want to delete these conversations permanently?</item>
+    </plurals>
+    <plurals name="threadListDeletionConfirmationAlertTitle">
+        <item quantity="one">Delete %d conversation</item>
+        <item quantity="other">Delete %d conversations</item>
     </plurals>
     <string name="threadListEmptyFolderAlertDescription">Are you sure you want to permanently delete all the messages in this folder?</string>
     <string name="threadListEmptySpamButton">Empty spam</string>


### PR DESCRIPTION
On the remote, the string had a leading space causing the string to be sorted at the very top even if in the export the string had no more leading space. I removed the leading space from the remote and imported the string again