### PR TITLE
fix: Thread without folder on insert

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/DefaultRefreshStrategy.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/DefaultRefreshStrategy.kt
@@ -89,11 +89,10 @@ interface DefaultRefreshStrategy : RefreshStrategy {
         } else {
             remoteMessage.toThread()
         }
-        newThread?.let {
-            realm.putNewThreadInRealm(it)?.let { managedThread ->
-                impactedThreadsManaged += managedThread
-            }
-        }
+
+        newThread
+            ?.let { realm.putNewThreadInRealm(it) }
+            ?.let { impactedThreadsManaged += it }
     }
 
     private fun MutableRealm.handleAddedMessage(


### PR DESCRIPTION
When a thread is added to the database, it may not be immediately linked to a folder. In some cases (such as when creating a draft), you risk ending up with an empty backlink on an unmanaged discussion thread.

We make sure that the thread added to the database is present in a folder at the same time it is added.