### PR TITLE
fix: Copy all relations of nested folders not only the first level

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -225,7 +225,7 @@ class MainViewModel @Inject constructor(
     private val defaultFoldersFlow = _currentMailboxObjectId.filterNotNull().flatMapLatest {
         folderController
             .getMenuDrawerDefaultFoldersAsync()
-            .map { it.list.copyFromRealm(1u) }
+            .map { it.list.copyFromRealm() }
             .removeRolesThatHideWhenEmpty()
             .map { it.toFolderUiTree(isInDefaultFolderSection = true) }
     }
@@ -233,7 +233,7 @@ class MainViewModel @Inject constructor(
     private val customFoldersFlow = _currentMailboxObjectId.filterNotNull().flatMapLatest {
         folderController
             .getMenuDrawerCustomFoldersAsync()
-            .map { it.list.copyFromRealm(1u) }
+            .map { it.list.copyFromRealm() }
             .map { it.toFolderUiTree(isInDefaultFolderSection = false) }
     }
 


### PR DESCRIPTION
It it required to copy from realm with infinite depth so that if a user has 10 nested folders inside of each other the 10 will be copied from realm instead of juste copying the 2 levels