### PR TITLE
fix: Fix fourth onboarding animation sometime disappearing when swiping too quickly

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/login/components/OnboardingScreen.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/login/components/OnboardingScreen.kt
@@ -318,6 +318,9 @@ private fun Page.CustomRepeatableLottieIllustration(pagerState: PagerState, inde
         update = {
             // Avoid restarting the animation when there's a recomposition by taking isReadyToStart into account
             if (pagerState.currentPage == index && isReadyToStart) {
+                // Requesting layout here solves a bug where ~1/10 of the time, when you scroll to the 4th page quickly, the 4th
+                // animation is not displayed because it has a width of 0dp
+                it.requestLayout()
                 it.playAnimation()
                 isReadyToStart = false
             }


### PR DESCRIPTION
The view appears to be 0dp in width once in every 10 times or so when scrolling fast to the fourth page after having closed the app completely. Requesting layout again seems to prevent this somehow