### PR TITLE
fix(OnboardingPermission): Fix the app crashing when asking for permissions on API < 31

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
@@ -28,6 +28,7 @@ import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.graphics.Color
+import androidx.core.content.res.use
 import com.google.android.material.color.MaterialColors
 import com.infomaniak.core.auth.AccessTokenUsageInterceptor.ApiCallRecord
 import com.infomaniak.core.dotlottie.model.DotLottieTheme


### PR DESCRIPTION
Closes MAIL-ANDROID-SGK

Explanation : https://stackoverflow.com/questions/73502338/android-content-res-typedarray-cannot-be-cast-to-java-lang-autocloseable