### PR TITLE
fix: Replace linkId with accessId in Mailbox model

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -188,8 +188,8 @@ object ApiRepository : ApiRepositoryCore() {
         return callApi(ApiRoutes.quotas(mailboxHostingId, mailboxName), GET)
     }
 
-    suspend fun getPermissions(mailboxLinkId: Int, mailboxHostingId: Int): ApiResponse<MailboxPermissions> {
-        return callApi(ApiRoutes.permissions(mailboxLinkId, mailboxHostingId), GET)
+    suspend fun getPermissions(mailboxAccessId: String, mailboxHostingId: Int): ApiResponse<MailboxPermissions> {
+        return callApi(ApiRoutes.permissions(mailboxAccessId, mailboxHostingId), GET)
     }
 
     //region Unsubscribe list diffusion

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRoutes.kt
@@ -129,8 +129,8 @@ object ApiRoutes {
         return "${mailbox()}?with=aliases,unseen"
     }
 
-    fun permissions(linkId: Int, mailboxHostingId: Int): String {
-        return "${mailbox()}/permissions?user_mailbox_id=$linkId&product_id=$mailboxHostingId"
+    fun permissions(accessId: String, mailboxHostingId: Int): String {
+        return "${mailbox()}/permissions?access_id=$accessId&product_id=$mailboxHostingId"
     }
 
     fun quotas(mailboxHostingId: Int, mailboxName: String): String {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -199,7 +199,7 @@ object RealmDatabase {
 
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 5L
-        const val MAILBOX_INFO_SCHEMA_VERSION = 17L
+        const val MAILBOX_INFO_SCHEMA_VERSION = 18L
         const val MAILBOX_CONTENT_SCHEMA_VERSION = 36L
         //endregion
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/mailbox/Mailbox.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/mailbox/Mailbox.kt
@@ -55,8 +55,8 @@ class Mailbox : RealmObject {
     var mailboxId: Int = -3 // AppSettings.DEFAULT_ID
     @SerialName("hosting_id")
     var hostingId: Int = 0
-    @SerialName("link_id")
-    var linkId: Int = 0
+    @SerialName("access_id")
+    var accessId: String = ""
     @SerialName("is_primary")
     var isPrimary: Boolean = false
     @SerialName("is_locked")

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -487,7 +487,7 @@ class MainViewModel @Inject constructor(
 
     private fun updatePermissions(mailbox: Mailbox) = viewModelScope.launch(ioCoroutineContext) {
         SentryLog.d(TAG, "Force refresh Permissions")
-        with(ApiRepository.getPermissions(mailbox.linkId, mailbox.hostingId)) {
+        with(ApiRepository.getPermissions(mailbox.accessId, mailbox.hostingId)) {
             if (isSuccess()) {
                 mailboxController.updateMailbox(mailbox.objectId) {
                     it.permissions = data


### PR DESCRIPTION
Replace the linkId field with accessId in the Mailbox data model to align with the updated API specification. The backend changed from using link_id (integer) to access_id (string) for mailbox permissions.

Update the permissions endpoint construction and increment the MailboxInfo Realm schema version to handle the data migration.

⚠️  Since the mailbox model has changed double check that the migration is correct 