### PR TITLE
fix: Open intents in a new task rather than the current task

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/MessageWebViewClient.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/MessageWebViewClient.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -95,7 +95,9 @@ class MessageWebViewClient(
             }
 
             runCatching {
-                context.startActivity(Intent(Intent.ACTION_VIEW, uri))
+                val intent = Intent(Intent.ACTION_VIEW, uri)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
             }.onFailure {
                 context.showToast(R.string.startActivityCantHandleAction)
             }


### PR DESCRIPTION
We received feedbacks showing that some links that automatically open inside other apps would use the current task to open the app instead of creating a new task. This forces the new task creation in all situations