### PR TITLE
feat: Handle plural forms in reaction notifications

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
@@ -278,9 +278,14 @@ class MessageController @Inject constructor(
             return thread?.messages?.query("${Message::folderId.name} == $0", thread.folderId)?.findSuspend()?.lastOrNull()
         }
 
-        suspend fun getUnreadReactionCountByEmoji(threadUid: String, realm: TypedRealm, emoji: String): Long? {
-            val thread = ThreadController.getThread(threadUid, realm)
-            return thread?.messages?.query("${Message::emojiReaction.name} == $0 AND ${Message::isSeen.name} == false", emoji)?.count()?.findSuspend()
+        suspend fun getUnreadReactionCountByEmoji(threadUid: String, realm: TypedRealm, emoji: String?): Int {
+            if (emoji == null) return 0
+            val threadUidName = "${Message::threads.name}.${Thread::uid.name}"
+            return realm.query<Message>(
+                "$threadUidName=$0 AND ${Message::emojiReaction.name} == $1 AND ${Message::isSeen.name} == false",
+                threadUid,
+                emoji
+            ).count().findSuspend().toInt()
         }
 
         suspend fun doesMessageExist(uid: String, realm: TypedRealm): Boolean {

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
@@ -278,6 +278,11 @@ class MessageController @Inject constructor(
             return thread?.messages?.query("${Message::folderId.name} == $0", thread.folderId)?.findSuspend()?.lastOrNull()
         }
 
+        suspend fun getUnreadReactionCountByEmoji(threadUid: String, realm: TypedRealm, emoji: String): Long? {
+            val thread = ThreadController.getThread(threadUid, realm)
+            return thread?.messages?.query("${Message::emojiReaction.name} == $0 AND ${Message::isSeen.name} == false", emoji)?.count()?.findSuspend()
+        }
+
         suspend fun doesMessageExist(uid: String, realm: TypedRealm): Boolean {
             return getMessagesQuery(uid, realm).count().findSuspend() > 0
         }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/MessageController.kt
@@ -282,7 +282,7 @@ class MessageController @Inject constructor(
             if (emoji == null) return 0
             val threadUidName = "${Message::threads.name}.${Thread::uid.name}"
             return realm.query<Message>(
-                "$threadUidName=$0 AND ${Message::emojiReaction.name} == $1 AND ${Message::isSeen.name} == false",
+                "$threadUidName == $0 AND ${Message::emojiReaction.name} == $1 AND ${Message::isSeen.name} == false",
                 threadUid,
                 emoji
             ).count().findSuspend().toInt()

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -417,8 +417,14 @@ class Message : RealmObject, Snoozable {
         snoozeEndDate = flags.snoozeEndDate.toRealmInstant()
     }
 
-    fun getFormattedPreview(context: Context): FormatedPreview = when {
+    fun getFormattedPreview(context: Context, totalUnseenReactionOnLastEmoji: Int = 0 ): FormatedPreview = when {
         isEncrypted -> FormatedPreview.Encryption(context.getString(R.string.encryptedMessageHeader))
+        isReaction && totalUnseenReactionOnLastEmoji > 1 -> FormatedPreview.Reaction(context.resources.getQuantityString(
+            R.plurals.previewMultiReaction,
+            (totalUnseenReactionOnLastEmoji - 1),
+            emojiReaction,
+            from.firstOrNull()?.name.orEmpty(),
+            (totalUnseenReactionOnLastEmoji - 1)))
         isReaction -> FormatedPreview.Reaction(context.getString(R.string.previewReaction, from.first().name, emojiReaction))
         preview.isBlank() -> FormatedPreview.Empty(context.getString(R.string.noBodyDescription))
         else -> FormatedPreview.Body(preview.trim())

--- a/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
@@ -210,7 +210,8 @@ class FetchMessagesManager @Inject constructor(
             return@let cleanedDocument.wholeText().trim()
         }
 
-        fun Message.getNotificationPreview(): String = getFormattedPreview(appContext).content
+        fun Message.getNotificationPreview(totalUnseenReactionOnLastEmoji: Int): String =
+            getFormattedPreview(appContext, totalUnseenReactionOnLastEmoji).content
 
         ThreadController.fetchMessagesHeavyData(getDisplayedMessages(mailbox.featureFlags, localSettings), realm, okHttpClient)
 
@@ -223,36 +224,10 @@ class FetchMessagesManager @Inject constructor(
         // We can leave safely.
         if (message.isSeen) return true
 
-        var notificationBody = message.getNotificationBody() ?: message.getNotificationPreview()
+        val totalUnseenReactionOnLastEmoji =
+            MessageController.getUnreadReactionCountByEmoji(uid, realm, message.emojiReaction)
 
-        // // Update notification body to handle plural forms when multiple people react
-        if (message.isReaction) {
-            val targetMessageIds = message.inReplyTo?.parseMessagesIds().orEmpty()
-
-            this.messages.firstOrNull { it.messageId in targetMessageIds }?.let { targetMessage ->
-                val lastReaction = targetMessage.emojiReactions.lastOrNull()
-
-                lastReaction?.let {
-                    val lastReactionEmoji = it.emoji
-
-                    val totalUnseenReactionOnLastEmoji =
-                        MessageController.getUnreadReactionCountByEmoji(uid, realm, lastReactionEmoji) ?: 0
-
-                    if (totalUnseenReactionOnLastEmoji > 1) {
-                        val lastReactorName = message.from.firstOrNull()?.name.orEmpty()
-                        val otherPeopleCount = (totalUnseenReactionOnLastEmoji - 1).toInt()
-
-                        notificationBody = appContext.resources.getQuantityString(
-                            R.plurals.previewMultiReaction,
-                            otherPeopleCount,
-                            lastReactionEmoji,
-                            lastReactorName,
-                            otherPeopleCount
-                        )
-                    }
-                }
-            }
-        }
+        val notificationBody = message.getNotificationBody() ?: message.getNotificationPreview(totalUnseenReactionOnLastEmoji)
 
         val subject = appContext.formatSubject(message.subject).take(MAX_CHAR_LIMIT)
         val formattedBody = notificationBody.replace("\\n+\\s*".toRegex(), " ") // Ignore multiple/start whitespaces

--- a/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/FetchMessagesManager.kt
@@ -33,6 +33,7 @@ import com.infomaniak.mail.data.cache.mailboxContent.ThreadController
 import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.message.Message
+import com.infomaniak.mail.data.models.message.Message.Companion.parseMessagesIds
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.utils.NotificationPayload.NotificationBehavior
 import com.infomaniak.mail.utils.NotificationPayload.NotificationBehavior.NotificationType
@@ -222,7 +223,36 @@ class FetchMessagesManager @Inject constructor(
         // We can leave safely.
         if (message.isSeen) return true
 
-        val notificationBody = message.getNotificationBody() ?: message.getNotificationPreview()
+        var notificationBody = message.getNotificationBody() ?: message.getNotificationPreview()
+
+        // // Update notification body to handle plural forms when multiple people react
+        if (message.isReaction) {
+            val targetMessageIds = message.inReplyTo?.parseMessagesIds().orEmpty()
+
+            this.messages.firstOrNull { it.messageId in targetMessageIds }?.let { targetMessage ->
+                val lastReaction = targetMessage.emojiReactions.lastOrNull()
+
+                lastReaction?.let {
+                    val lastReactionEmoji = it.emoji
+
+                    val totalUnseenReactionOnLastEmoji =
+                        MessageController.getUnreadReactionCountByEmoji(uid, realm, lastReactionEmoji) ?: 0
+
+                    if (totalUnseenReactionOnLastEmoji > 1) {
+                        val lastReactorName = message.from.firstOrNull()?.name.orEmpty()
+                        val otherPeopleCount = (totalUnseenReactionOnLastEmoji - 1).toInt()
+
+                        notificationBody = appContext.resources.getQuantityString(
+                            R.plurals.previewMultiReaction,
+                            otherPeopleCount,
+                            lastReactionEmoji,
+                            lastReactorName,
+                            otherPeopleCount
+                        )
+                    }
+                }
+            }
+        }
 
         val subject = appContext.formatSubject(message.subject).take(MAX_CHAR_LIMIT)
         val formattedBody = notificationBody.replace("\\n+\\s*".toRegex(), " ") // Ignore multiple/start whitespaces

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Organisation: %s</string>
     <string name="otherOrganisation">Anden</string>
     <string name="pickerNoSelection">Intet valgt</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s og %3$s person har reageret</item>
+        <item quantity="other">%1$s %2$s og %3$s personer har reageret</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s reagerede</string>
     <string name="readFAQ">Læs FAQ</string>
     <string name="readMore">Læs mere</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Organisation: %s</string>
     <string name="otherOrganisation">Andere</string>
     <string name="pickerNoSelection">Keine Auswahl</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s und %3$s Person haben reagiert</item>
+        <item quantity="other">%1$s %2$s und %3$s Personen haben reagiert</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s reagierte</string>
     <string name="readFAQ">FAQ lesen</string>
     <string name="readMore">Mehr erfahren</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Οργάνωση: %s</string>
     <string name="otherOrganisation">Άλλο</string>
     <string name="pickerNoSelection">Καμία επιλογή</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s και %3$s άτομο αντέδρασαν</item>
+        <item quantity="other">%1$s %2$s και %3$s άτομα αντέδρασαν</item>
+    </plurals>
     <string name="previewReaction">%2$s αντέδρασε στο %1$s</string>
     <string name="readFAQ">Διαβάστε τις Συχνές Ερωτήσεις</string>
     <string name="readMore">Διαβάστε περισσότερα</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Organización: %s</string>
     <string name="otherOrganisation">Otros</string>
     <string name="pickerNoSelection">Sin selección</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s y %3$s persona reaccionaron</item>
+        <item quantity="other">%1$s %2$s y %3$s personas reaccionaron</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s reaccionó</string>
     <string name="readFAQ">Lea las preguntas frecuentes</string>
     <string name="readMore">Seguir leyendo</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Organisaatio: %s</string>
     <string name="otherOrganisation">Muu</string>
     <string name="pickerNoSelection">Ei valintaa</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s ja %3$s henkilö on reagoinut</item>
+        <item quantity="other">%1$s %2$s ja %3$s henkilöä on reagoinut</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s reagoi</string>
     <string name="readFAQ">Lue UKK</string>
     <string name="readMore">Lue lisää</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Organisation : %s</string>
     <string name="otherOrganisation">Autre</string>
     <string name="pickerNoSelection">Aucune sélection</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s et %3$s personne ont réagi</item>
+        <item quantity="other">%1$s %2$s et %3$s personnes ont réagi</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s a réagi</string>
     <string name="readFAQ">Consulter les FAQ</string>
     <string name="readMore">En savoir plus</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Organizzazione: %s</string>
     <string name="otherOrganisation">Altro</string>
     <string name="pickerNoSelection">Nessuna selezione</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s e %3$s persona hanno reagito</item>
+        <item quantity="other">%1$s %2$s e %3$s persone hanno reagito</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s ha reagito</string>
     <string name="readFAQ">Leggi le FAQ</string>
     <string name="readMore">Per saperne di più</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Organisasjon: %s</string>
     <string name="otherOrganisation">Annet</string>
     <string name="pickerNoSelection">Ingen valg</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s og %3$s person har reagert</item>
+        <item quantity="other">%1$s %2$s og %3$s personer har reagert</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s reagerte</string>
     <string name="readFAQ">Les FAQ</string>
     <string name="readMore">Les mer</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Organisatie: %s</string>
     <string name="otherOrganisation">Andere</string>
     <string name="pickerNoSelection">Geen selectie</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s en %3$s persoon hebben gereageerd</item>
+        <item quantity="other">%1$s %2$s en %3$s personen hebben gereageerd</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s heeft gereageerd</string>
     <string name="readFAQ">FAQ raadplegen</string>
     <string name="readMore">Meer informatie</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -457,6 +457,12 @@
     <string name="organizationName">Organizacja: %s</string>
     <string name="otherOrganisation">Inne</string>
     <string name="pickerNoSelection">Brak zaznaczenia</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s i %3$s osoba zareagowali</item>
+        <item quantity="few">%1$s %2$s i %3$s osoby zareagowali</item>
+        <item quantity="many">%1$s %2$s i %3$s osób zareagowało</item>
+        <item quantity="other">%1$s %2$s i %3$s osoby zareagowali</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s zareagował/a</string>
     <string name="readFAQ">Przeczytaj FAQ</string>
     <string name="readMore">Czytaj więcej</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Organização: %s</string>
     <string name="otherOrganisation">Outra</string>
     <string name="pickerNoSelection">Nenhuma seleção</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s e %3$s pessoa reagiram</item>
+        <item quantity="other">%1$s %2$s e %3$s pessoas reagiram</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s reagiu</string>
     <string name="readFAQ">Consultar as FAQ</string>
     <string name="readMore">Saber mais</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -441,6 +441,10 @@
     <string name="organizationName">Organisation: %s</string>
     <string name="otherOrganisation">Annan</string>
     <string name="pickerNoSelection">Inget val</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s och %3$s person reagerade</item>
+        <item quantity="other">%1$s %2$s och %3$s personer reagerade</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s reagerade</string>
     <string name="readFAQ">Läs FAQ</string>
     <string name="readMore">Läs mer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -447,6 +447,10 @@
     <string name="organizationName">Organization: %s</string>
     <string name="otherOrganisation">Other</string>
     <string name="pickerNoSelection">No selection</string>
+    <plurals name="previewMultiReaction">
+        <item quantity="one">%1$s %2$s and %3$s person have reacted</item>
+        <item quantity="other">%1$s %2$s and %3$s people have reacted</item>
+    </plurals>
     <string name="previewReaction">%2$s %1$s reacted</string>
     <string name="readFAQ">Read FAQ</string>
     <string name="readMore">Read more</string>


### PR DESCRIPTION
This PR implements notification handling for multiple reactions with the same emoji: when several people react with the same emoji, the system now tracks exactly how many people reacted, and only includes reactions that haven't been seen yet.