### PR TITLE
chore: Fix inconsistent ending "." strings formatting

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -272,7 +272,7 @@
     <string name="encryptedProtectionAdDescription1">Der Betreff der Nachricht bleibt sichtbar, aber der Inhalt ist vollständig gesichert.</string>
     <string name="encryptedProtectionAdDescription1Bold">der Inhalt ist vollständig gesichert.</string>
     <string name="encryptedProtectionAdDescription2">Für Empfänger ausserhalb von Infomaniak wird ein Passwort benötigt.</string>
-    <string name="encryptedProtectionAdDescription2Bold">Empfänger ausserhalb von Infomaniak</string>
+    <string name="encryptedProtectionAdDescription2Bold">Empfänger ausserhalb von Infomaniak.</string>
     <string name="encryptedProtectionAdTitle">Verschlüsseln Sie Ihre vertraulichen Nachrichten</string>
     <string name="encryptedRecipientRequiringPasswordTitle">Empfänger mit Passwort (%d)</string>
     <string name="encryptedStatePanelEnable">Ihre Nachricht ist geschützt.</string>
@@ -316,7 +316,7 @@
     <string name="errorMoveDestinationNotFound">Der Zielordner besteht nicht</string>
     <string name="errorNewFolderAlreadyExists">Der Ordner besteht bereits</string>
     <string name="errorNewFolderInvalidCharacter">Der Ordnername enthält ungültige Zeichen</string>
-    <string name="errorNewFolderNameTooLong">Der Ordnername sollte nicht länger als 255 Zeichen sein.</string>
+    <string name="errorNewFolderNameTooLong">Der Ordnername sollte nicht länger als 255 Zeichen sein</string>
     <string name="errorRefusedRecipients">Der Server lehnt alle Empfänger ab</string>
     <string name="errorRefusedSender">Der Server lehnt den Absender ab</string>
     <string name="errorScheduleDelayTooShort">Wählen Sie ein zukünftiges Datum, das mindestens %d Minuten in der Zukunft liegt</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -579,7 +579,7 @@
     <string name="snackbarPhoneNumberCopiedToClipboard">Ο αριθμός αντιγράφηκε στο πρόχειρο</string>
     <string name="snackbarReportPhishingConfirmation">Η αναφορά ολοκληρώθηκε με επιτυχία</string>
     <string name="snackbarRestorationLaunched">Εκκίνηση επαναφοράς</string>
-    <string name="snackbarSaveInDraft">Το μήνυμα αποθηκεύτηκε στα πρόχειρα</string>
+    <string name="snackbarSaveInDraft">Το μήνυμα αποθηκεύτηκε στα πρόχειρα.</string>
     <string name="snackbarScheduleSaved">Το μήνυμα θα σταλεί στις %s</string>
     <string name="snackbarScheduling">Το μήνυμα προγραμματίζεται</string>
     <plurals name="snackbarSenderBlacklisted">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -94,7 +94,7 @@
     <string name="attachmentActionFile">Adjuntar un archivo</string>
     <string name="attachmentActionPhotoLibrary">Enviar una foto desde la fototeca</string>
     <string name="attachmentActionTitle">Añadir un archivo adjunto</string>
-    <string name="attachmentFileLimitReached">Los archivos que está intentando enviar superan el límite de archivos adjuntos de 25 MB.</string>
+    <string name="attachmentFileLimitReached">Los archivos que está intentando enviar superan el límite de archivos adjuntos de 25 MB</string>
     <plurals name="attachmentQuantity">
         <item quantity="one">%d anexo</item>
         <item quantity="other">%d archivos adjuntos</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -94,7 +94,7 @@
     <string name="attachmentActionFile">Allegare un file</string>
     <string name="attachmentActionPhotoLibrary">Inviare una foto dalla libreria fotografica</string>
     <string name="attachmentActionTitle">Aggiungere un allegato</string>
-    <string name="attachmentFileLimitReached">I file che si sta tentando di inviare superano il limite di 25 MB per gli allegati.</string>
+    <string name="attachmentFileLimitReached">I file che si sta tentando di inviare superano il limite di 25 MB per gli allegati</string>
     <plurals name="attachmentQuantity">
         <item quantity="one">%d allegato</item>
         <item quantity="other">%d allegati</item>
@@ -272,7 +272,7 @@
     <string name="encryptedProtectionAdDescription1">L’oggetto del messaggio rimane visibile, ma il contenuto è completamente protetto.</string>
     <string name="encryptedProtectionAdDescription1Bold">il contenuto è completamente protetto.</string>
     <string name="encryptedProtectionAdDescription2">Per i destinatari esterni a Infomaniak sarà necessaria una password.</string>
-    <string name="encryptedProtectionAdDescription2Bold">i destinatari esterni a Infomaniak</string>
+    <string name="encryptedProtectionAdDescription2Bold">i destinatari esterni a Infomaniak.</string>
     <string name="encryptedProtectionAdTitle">Crittografia dei messaggi riservati</string>
     <string name="encryptedRecipientRequiringPasswordTitle">Destinatari con password (%d)</string>
     <string name="encryptedStatePanelEnable">Il tuo messaggio è protetto.</string>
@@ -495,7 +495,7 @@
     <string name="settingsAutoAdvancePreviousThreadDescription">Visualizzazione della discussione precedente quando si archivia o si elimina</string>
     <string name="settingsAutoAdvancePreviousThreadTitle">Discussione precedente</string>
     <string name="settingsAutoAdvanceTitle">Avanzamento automatico</string>
-    <string name="settingsCancellationPeriodDescription">Hai la possibilità di annullare l’invio delle email fino a 30 secondi.</string>
+    <string name="settingsCancellationPeriodDescription">Hai la possibilità di annullare l’invio delle email fino a 30 secondi</string>
     <string name="settingsCancellationPeriodTitle">Periodo di cancellazione dell’invio</string>
     <string name="settingsDefault">Predefinito</string>
     <string name="settingsDelaySeconds">%d secondi</string>
@@ -533,7 +533,7 @@
     <string name="settingsSecurityBlockedRecipients">Destinatari bloccati/autorizzati</string>
     <string name="settingsSecuritySpamFilter">Filtro antispam</string>
     <string name="settingsSelectDisplayModeDescription">Seleziona una modalità di visualizzazione</string>
-    <string name="settingsSendAcknowledgement">Richiedi una conferma di ricezione per ogni e-mail inviata.</string>
+    <string name="settingsSendAcknowledgement">Richiedi una conferma di ricezione per ogni e-mail inviata</string>
     <string name="settingsSendIncludeOriginalMessage">Includi il messaggio originale nella risposta</string>
     <string name="settingsSendTitle">Invia</string>
     <string name="settingsSignatureDescription">Seleziona una firma predefinita</string>
@@ -543,7 +543,7 @@
     <string name="settingsSwipeActionReadUnread">Letto / non letto</string>
     <string name="settingsSwipeActionToDefine">Per definire</string>
     <string name="settingsSwipeActionsTitle">Azioni di scorrimento</string>
-    <string name="settingsSwipeDescription">Scorri gli elementi nella tua casella di posta e accedi rapidamente alle azioni più frequenti.</string>
+    <string name="settingsSwipeDescription">Scorri gli elementi nella tua casella di posta e accedi rapidamente alle azioni più frequenti</string>
     <string name="settingsSwipeLeft">Scorrimento del dito a sinistra</string>
     <string name="settingsSwipeRight">Scorrimento del dito a destra</string>
     <string name="settingsThemeDescription">Scelta del tema</string>
@@ -554,7 +554,7 @@
     <string name="settingsThreadModeWarningTitle">Passa alla modalità %s?</string>
     <string name="settingsTitle">Impostazioni</string>
     <string name="settingsTransferAsAttachment">Come allegato</string>
-    <string name="settingsTransferEmailsDescription">Quando si inoltra un’e-mail, scegliere la modalità di visualizzazione più adatta.</string>
+    <string name="settingsTransferEmailsDescription">Quando si inoltra un’e-mail, scegliere la modalità di visualizzazione più adatta</string>
     <string name="settingsTransferEmailsTitle">Trasferimento di e-mail</string>
     <string name="settingsTransferInBody">Nel corpo del messaggio</string>
     <string name="shareEmail">Condividi e-mail</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -270,7 +270,7 @@
     <string name="encryptedPasswordProtectionTitle">Wachtwoordbeveiliging</string>
     <string name="encryptedProtectionAdDescription">Bescherm uw bericht tegen ongeautoriseerde toegang met Infomaniak-versleuteling.</string>
     <string name="encryptedProtectionAdDescription1">Het onderwerp van het bericht blijft zichtbaar, maar de inhoud is volledig beveiligd.</string>
-    <string name="encryptedProtectionAdDescription1Bold">is de inhoud volledig beveiligd</string>
+    <string name="encryptedProtectionAdDescription1Bold">is de inhoud volledig beveiligd.</string>
     <string name="encryptedProtectionAdDescription2">Een wachtwoord is vereist voor ontvangers buiten Infomaniak.</string>
     <string name="encryptedProtectionAdDescription2Bold">ontvangers buiten Infomaniak.</string>
     <string name="encryptedProtectionAdTitle">Versleutel uw vertrouwelijke berichten</string>


### PR DESCRIPTION
All strings must either end with a "." or end with no "." but it makes no sense to have it be mixed from one locale to the other