### PR TITLE
fix: Fix network check race condition

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -137,6 +137,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.invoke
@@ -294,18 +295,13 @@ class MainViewModel @Inject constructor(
 
     val currentThreadsLive = MutableLiveData<ResultsChange<Thread>>()
 
-    val isNetworkAvailable = NetworkAvailability().isNetworkAvailable.stateIn(viewModelScope, SharingStarted.Eagerly, true)
+    val isNetworkAvailable = NetworkAvailability().isNetworkAvailable.onEach {
+        SentryLog.d("Internet availability", if (it) "Available" else "Unavailable")
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
     val hasNetwork: Boolean by isNetworkAvailable::value
 
     private var currentThreadsLiveJob: Job? = null
-
-    init {
-        viewModelScope.launch {
-            isNetworkAvailable.collect {
-                SentryLog.d("Internet availability", if (it) "Available" else "Unavailable")
-            }
-        }
-    }
 
     fun reassignCurrentThreadsLive() {
         currentThreadsLiveJob?.cancel()

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -138,6 +138,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.invoke
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -293,9 +294,8 @@ class MainViewModel @Inject constructor(
 
     val currentThreadsLive = MutableLiveData<ResultsChange<Thread>>()
 
-    val isNetworkAvailable = NetworkAvailability(appContext).isNetworkAvailable
-    var hasNetwork: Boolean = true
-        private set
+    val isNetworkAvailable = NetworkAvailability().isNetworkAvailable.stateIn(viewModelScope, SharingStarted.Eagerly, true)
+    val hasNetwork: Boolean by isNetworkAvailable::value
 
     private var currentThreadsLiveJob: Job? = null
 
@@ -303,7 +303,6 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             isNetworkAvailable.collect {
                 SentryLog.d("Internet availability", if (it) "Available" else "Unavailable")
-                hasNetwork = it
             }
         }
     }


### PR DESCRIPTION
In some cases, the hasNetwork property was read on isNetworkAvailable emission before it was set.

It was also much more likely to happen since the flow was activated twice. Now it's shared, and we read the value from a single place.