### PR TITLE
fix(webview): use evaluateJavascript in MessageDisplayWebViewClient

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/webViewClient/MessageDisplayWebViewClient.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/webViewClient/MessageDisplayWebViewClient.kt
@@ -87,7 +87,7 @@ class MessageDisplayWebViewClient(
                 }
             }
             val escapedMessageUid = looselyEscapeAsStringLiteralForJs(messageUid)
-            webView.loadUrl("javascript:removeAllProperties(); normalizeMessageWidth($widthInDp, $escapedMessageUid)")
+            webView.evaluateJavascript("removeAllProperties(); normalizeMessageWidth($widthInDp, $escapedMessageUid)", null)
             onPageFinished?.invoke()
         }
     }


### PR DESCRIPTION
Closes #2906.

`MessageDisplayWebViewClient.onPageFinished` runs:


`webView.loadUrl(\"javascript:removeAllProperties(); normalizeMessageWidth(\$widthInDp, \$escapedMessageUid)\")`


`loadUrl("javascript:...")` is the legacy WebView path: it records a synthetic history entry (so `goBack()` can land on it) and discards any return value because there is no callback. `WebView.evaluateJavascript` was added in API 19, which is well below the project's minSdk, and does neither of those.

### Change


`- webView.loadUrl("javascript:removeAllProperties(); normalizeMessageWidth(\$widthInDp, \$escapedMessageUid)\")`
`+ webView.evaluateJavascript("removeAllProperties(); normalizeMessageWidth(\$widthInDp, \$escapedMessageUid)\", null)`


No callback is added because the existing call already discards the result. Same script, same effect, no history pollution.