### PR TITLE
fix: Resolve crash when removing unknown recipient chip from mailto

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/RecipientFieldView.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/RecipientFieldView.kt
@@ -288,6 +288,7 @@ class RecipientFieldView @JvmOverloads constructor(
                 updateCollapsedChipValues(isCollapsed = true)
             }
             contactPopupWindow.dismiss()
+            focusTextField()
         }
     }
 


### PR DESCRIPTION
the mailto to create the crash :
mailto:a@ik.me?subject=Test%20chip%20Crash&body=Delete%20chip%20using%20deleteContactButton%20instead%20of%20backspace