### PR TITLE
fix: Safely delete database when changing message display mode

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -174,7 +174,11 @@ object RealmDatabase {
 
     //region Delete Realm
     fun deleteMailboxContent(mailboxId: Int, userId: Int = AccountUtils.currentUserId) {
-        Realm.deleteRealm(RealmConfig.mailboxContent(userId, mailboxId))
+        try {
+            Realm.deleteRealm(RealmConfig.mailboxContent(userId, mailboxId))
+        } catch (e: IllegalStateException) {
+            Sentry.captureException(e)
+        }
     }
 
     fun removeUserData(context: Context, userId: Int) {


### PR DESCRIPTION
This change ensures that even if a background worker (like SyncMailboxesWorker or ProcessMessageNotificationsWorker) is still holding a reference to the mailbox content, the app won't crash when trying to clean up "outdated" mailboxes or when the user changes settings that require dropping the cache.