### PR TITLE
fix(StorageQuotasBanner): Fix the banner appearing even when closed the first time and increase threshold

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/LocalSettings.kt
@@ -86,7 +86,8 @@ class LocalSettings private constructor(context: Context) : SharedValues {
 
     fun resetStorageBannerAppLaunches() {
         hasClosedStorageBanner = true
-        storageBannerDisplayAppLaunches = 0
+        // if put to 0, the banner appears after a background/foreground transition even if the user just closed it
+        storageBannerDisplayAppLaunches = 1
     }
 
     enum class EmailForwarding(@StringRes val localisedNameRes: Int) {

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -259,7 +259,7 @@ class MainViewModel @Inject constructor(
         val progress = quotas?.getProgress()
         when {
             quotas == null -> null
-            quotas.isFull -> StorageLevel.getFullStorageBanner(currentMailbox.value?.kSuite)
+            quotas.isFull -> currentMailbox.value?.let { StorageLevel.getFullStorageBanner(it.kSuite) }
             progress != null && progress > StorageLevel.WARNING_THRESHOLD -> {
                 if (!localSettings.hasClosedStorageBanner || localSettings.storageBannerDisplayAppLaunches % 10 == 0) {
                     localSettings.hasClosedStorageBanner = false

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -261,7 +261,7 @@ class MainViewModel @Inject constructor(
             quotas == null -> null
             quotas.isFull -> currentMailbox.value?.let { StorageLevel.getFullStorageBanner(it.kSuite) }
             progress != null && progress > StorageLevel.WARNING_THRESHOLD -> {
-                if (!localSettings.hasClosedStorageBanner || localSettings.storageBannerDisplayAppLaunches % 10 == 0) {
+                if (!localSettings.hasClosedStorageBanner || localSettings.storageBannerDisplayAppLaunches % 50 == 0) {
                     localSettings.hasClosedStorageBanner = false
                     if (currentMailbox.value?.kSuite is KSuite.Perso) StorageLevel.Warning.Perso else StorageLevel.Warning.Pro
                 } else {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -113,6 +113,7 @@ import com.infomaniak.mail.utils.extensions.safeArea
 import com.infomaniak.mail.utils.extensions.safeNavigateToNewMessageActivity
 import com.infomaniak.mail.utils.extensions.shareString
 import com.infomaniak.mail.utils.extensions.toDate
+import com.infomaniak.mail.views.itemViews.KSuiteStorageBanner
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -603,8 +604,9 @@ class ThreadListFragment : TwoPaneFragment(), PickerEmojiObserver {
 
     private fun setupStorageBanner() = with(localSettings) {
         mainViewModel.storageBannerStatus.observeNotNull(viewLifecycleOwner) { storageBannerStatus ->
-            if (localSettings.hasClosedStorageBanner) return@observeNotNull
-            
+            val isWarningStorage = storageBannerStatus is KSuiteStorageBanner.StorageLevel.Warning
+            if (localSettings.hasClosedStorageBanner && isWarningStorage) return@observeNotNull
+
             binding.storageBanner.apply {
                 storageLevel = storageBannerStatus
                 setupListener(

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListFragment.kt
@@ -603,6 +603,8 @@ class ThreadListFragment : TwoPaneFragment(), PickerEmojiObserver {
 
     private fun setupStorageBanner() = with(localSettings) {
         mainViewModel.storageBannerStatus.observeNotNull(viewLifecycleOwner) { storageBannerStatus ->
+            if (localSettings.hasClosedStorageBanner) return@observeNotNull
+            
             binding.storageBanner.apply {
                 storageLevel = storageBannerStatus
                 setupListener(

--- a/app/src/main/java/com/infomaniak/mail/views/itemViews/KSuiteStorageBanner.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/itemViews/KSuiteStorageBanner.kt
@@ -67,20 +67,20 @@ class KSuiteStorageBanner @JvmOverloads constructor(
 
     sealed interface StorageLevel {
 
-        data object Normal : StorageLevelData(
+        data object Normal : StorageLevel, StorageLevelData(
             iconColorRes = ResourcesCompat.ID_NULL,
             titleRes = ResourcesCompat.ID_NULL,
             descriptionRes = ResourcesCompat.ID_NULL,
         )
 
         sealed interface Warning : StorageLevel {
-            data object Perso : StorageLevelData(
+            data object Perso : Warning, StorageLevelData(
                 iconColorRes = R.color.orangeWarning,
                 titleRes = R.string.myKSuiteQuotasAlertTitle,
                 descriptionRes = R.string.myKSuiteQuotasAlertDescription,
             )
 
-            data object Pro : StorageLevelData(
+            data object Pro : Warning, StorageLevelData(
                 iconColorRes = R.color.orangeWarning,
                 titleRes = R.string.myKSuiteQuotasAlertTitle,
                 descriptionRes = R.string.kSuiteProQuotasAlertDescription,
@@ -88,19 +88,19 @@ class KSuiteStorageBanner @JvmOverloads constructor(
         }
 
         sealed interface Full : StorageLevel {
-            data object Perso : StorageLevelData(
+            data object Perso : Full, StorageLevelData(
                 iconColorRes = R.color.redDestructiveAction,
                 titleRes = R.string.myKSuiteQuotasAlertFullTitle,
                 descriptionRes = R.string.myKSuiteQuotasAlertFullDescription,
             )
 
-            data object Pro : StorageLevelData(
+            data object Pro : Full, StorageLevelData(
                 iconColorRes = R.color.redDestructiveAction,
                 titleRes = R.string.kSuiteProQuotasAlertFullTitle,
                 descriptionRes = R.string.kSuiteProQuotasAlertFullDescription,
             )
 
-            data object StarterPack : StorageLevelData(
+            data object StarterPack : Full, StorageLevelData(
                 iconColorRes = R.color.redDestructiveAction,
                 titleRes = R.string.mailPremiumUpgradeTitle,
                 descriptionRes = R.string.mailPremiumUpgradeDescription

--- a/app/src/main/java/com/infomaniak/mail/views/itemViews/KSuiteStorageBanner.kt
+++ b/app/src/main/java/com/infomaniak/mail/views/itemViews/KSuiteStorageBanner.kt
@@ -114,7 +114,7 @@ class KSuiteStorageBanner @JvmOverloads constructor(
                 is KSuite.Perso -> Full.Perso
                 KSuite.StarterPack -> Full.StarterPack
                 is KSuite.Pro -> Full.Pro
-                else -> Full.Pro // Should not happened but Fallback
+                else -> Full.Pro // Should not happen but Fallback
             }
         }
     }


### PR DESCRIPTION
This pull request makes several adjustments to the storage banner logic to improve user experience and reduce unnecessary banner displays. The main changes include modifying how the app tracks banner display counts, adjusting when the banner is shown, and preventing the banner from reappearing immediately after being closed.

**Storage banner logic improvements:**

* Changed `resetStorageBannerAppLaunches()` in `LocalSettings` to set `storageBannerDisplayAppLaunches` to 1 instead of 0, preventing the banner from reappearing immediately after being closed by the user.
* Updated the logic in `MainViewModel` so that the storage banner is shown less frequently by changing the display interval from every 10 launches to every 50 launches. Also, fixed a potential null pointer issue when displaying the full storage banner.
* In `ThreadListFragment`, added a check to prevent the storage banner from being shown if the user has closed it, further reducing unnecessary banner displays.

**Minor code quality improvement:**

* Fixed a typo in the fallback comment in `KSuiteStorageBanner` from "Should not happened" to "Should not happen".