### PR TITLE
fix: Workaround Realm related issue on logout

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2022-2025 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,11 +30,11 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle.State
 import androidx.lifecycle.asFlow
-import androidx.lifecycle.asLiveData
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.infomaniak.core.bugtracker.BugTrackerActivity
 import com.infomaniak.core.bugtracker.BugTrackerActivityArgs
+import com.infomaniak.core.common.launchInOnLifecycle
 import com.infomaniak.core.fragmentnavigation.safelyNavigate
 import com.infomaniak.core.legacy.utils.UtilsUi.openUrl
 import com.infomaniak.core.legacy.utils.safeNavigate
@@ -48,6 +48,7 @@ import com.infomaniak.mail.MatomoMail.trackMenuDrawerEvent
 import com.infomaniak.mail.MatomoMail.trackScreen
 import com.infomaniak.mail.MatomoMail.trackSyncAutoConfigEvent
 import com.infomaniak.mail.R
+import com.infomaniak.mail.data.models.FolderUi
 import com.infomaniak.mail.data.models.Quotas
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.mailbox.MailboxPermissions
@@ -69,10 +70,12 @@ import com.infomaniak.mail.utils.extensions.bindAlertToViewLifecycle
 import com.infomaniak.mail.utils.extensions.getStringWithBoldArg
 import com.infomaniak.mail.utils.extensions.launchSyncAutoConfigActivityForResult
 import com.infomaniak.mail.utils.extensions.observeNotNull
+import com.infomaniak.mail.utils.extensions.submitListAndAwaitCommit
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -333,8 +336,21 @@ class MenuDrawerFragment : Fragment() {
             .asFlow()
             .map(menuDrawerAdapter::formatList)
             .flowOn(Dispatchers.IO)
-            .asLiveData()
-            .observe(viewLifecycleOwner, menuDrawerAdapter::submitList)
+            .onEach { newList ->
+                val mustClearListFirst = Utils.runCatchingRealm {
+                    val firstFolderUiModelInPreviousList = menuDrawerAdapter.currentList.firstOrNull {
+                        it is FolderUi
+                    } as FolderUi?
+                    firstFolderUiModelInPreviousList?.folder?.id // Check we can access the folder id.
+                }.isFailure // If we can't, the previous models are no longer readable.
+
+                if (mustClearListFirst) {
+                    menuDrawerAdapter.submitListAndAwaitCommit(emptyList()) // Ensure we won't try to compare dead models.
+                }
+                menuDrawerAdapter.submitListAndAwaitCommit(newList)
+
+            }
+            .launchInOnLifecycle(viewLifecycleOwner)
     }
 
     private fun observeCurrentFolder() {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
@@ -73,6 +73,7 @@ import com.infomaniak.mail.utils.extensions.observeNotNull
 import com.infomaniak.mail.utils.extensions.submitListAndAwaitCommit
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -336,6 +337,7 @@ class MenuDrawerFragment : Fragment() {
             .asFlow()
             .map(menuDrawerAdapter::formatList)
             .flowOn(Dispatchers.IO)
+            .conflate()
             .onEach { newList ->
                 val mustClearListFirst = Utils.runCatchingRealm {
                     val firstFolderUiModelInPreviousList = menuDrawerAdapter.currentList.firstOrNull {

--- a/app/src/main/java/com/infomaniak/mail/utils/extensions/ListAdapterExtensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/extensions/ListAdapterExtensions.kt
@@ -1,0 +1,28 @@
+/*
+ * Infomaniak Mail - Android
+ * Copyright (C) 2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.utils.extensions
+
+import androidx.recyclerview.widget.ListAdapter
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+internal suspend fun <T> ListAdapter<T, *>.submitListAndAwaitCommit(newList: List<T>) {
+    suspendCancellableCoroutine { continuation ->
+        submitList(newList) { continuation.resume(Unit) }
+    }
+}


### PR DESCRIPTION
Avoids seemingly endless stream of dead Realm objects errors sent to `System.err`/logcat when logging out an account, where one account has many folders.