### PR TITLE
fix: Fix RealmInstant conversion precision

### DIFF
--- a/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/utils/extensions/RealmInstantConversion.kt
+++ b/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/utils/extensions/RealmInstantConversion.kt
@@ -20,10 +20,10 @@ package com.infomaniak.mail.utils.extensions
 import io.realm.kotlin.types.RealmInstant
 import java.util.Date
 
-fun RealmInstant.toDate(): Date = Date(epochSeconds * 1_000L + nanosecondsOfSecond / 1_000L)
+fun RealmInstant.toDate(): Date = Date(epochSeconds * 1_000L + nanosecondsOfSecond / 1_000_000L)
 
 fun Date.toRealmInstant(): RealmInstant {
     val seconds = time / 1_000L
-    val nanoseconds = (time - seconds * 1_000L).toInt()
+    val nanoseconds = (time - seconds * 1_000_000L).toInt()
     return RealmInstant.from(seconds, nanoseconds)
 }

--- a/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/utils/extensions/RealmInstantConversion.kt
+++ b/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/utils/extensions/RealmInstantConversion.kt
@@ -24,6 +24,6 @@ fun RealmInstant.toDate(): Date = Date(epochSeconds * 1_000L + nanosecondsOfSeco
 
 fun Date.toRealmInstant(): RealmInstant {
     val seconds = time / 1_000L
-    val nanoseconds = (time - seconds * 1_000_000L).toInt()
+    val nanoseconds = ((time - seconds * 1_000L) * 1_000_000L).toInt()
     return RealmInstant.from(seconds, nanoseconds)
 }

--- a/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/utils/extensions/RealmInstantConversion.kt
+++ b/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/utils/extensions/RealmInstantConversion.kt
@@ -24,6 +24,7 @@ fun RealmInstant.toDate(): Date = Date(epochSeconds * 1_000L + nanosecondsOfSeco
 
 fun Date.toRealmInstant(): RealmInstant {
     val seconds = time / 1_000L
-    val nanoseconds = ((time - seconds * 1_000L) * 1_000_000L).toInt()
+    val millisPart = time - seconds * 1_000L
+    val nanoseconds = (millisPart * 1_000_000L).toInt()
     return RealmInstant.from(seconds, nanoseconds)
 }

--- a/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/utils/extensions/RealmInstantConversion.kt
+++ b/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/utils/extensions/RealmInstantConversion.kt
@@ -19,12 +19,15 @@ package com.infomaniak.mail.utils.extensions
 
 import io.realm.kotlin.types.RealmInstant
 import java.util.Date
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 fun RealmInstant.toDate(): Date = Date(epochSeconds * 1_000L + nanosecondsOfSecond / 1_000_000L)
 
 fun Date.toRealmInstant(): RealmInstant {
-    val seconds = time / 1_000L
-    val millisPart = time - seconds * 1_000L
-    val nanoseconds = (millisPart * 1_000_000L).toInt()
-    return RealmInstant.from(seconds, nanoseconds)
+    time.milliseconds.also {
+        val secondsPart = it.inWholeSeconds
+        val nanosPart = it.inWholeNanoseconds - secondsPart.seconds.inWholeNanoseconds
+        return RealmInstant.from(secondsPart, nanosPart.toInt())
+    }
 }


### PR DESCRIPTION
Before, that, anything sub-second was incorrectly converted. It didn't have any noticeable impact because it affected only sub-second precision, which users rarely see.