### PR TITLE
chore: Update .github/copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Infomaniak Mail for Android — full-featured email client. Hybrid UI (Jetpack C
 git submodule update --init --recursive   # pull Core submodule — required for Gradle settings plugin
 cp env.example.properties env.properties  # fill sentryAuthToken (use a dummy value locally)
 ```
-Missing `Core/` submodule → Gradle config phase fails. Missing `env.properties` only blocks *release* tasks (requires `sentryAuthToken`); debug builds work without it (the file is optional).
+Missing `Core/` submodule → Gradle config phase fails. `env.properties` is required for release variants (including `./gradlew build` as used in CI); debug-only tasks work without it.
 
 ## Build & Test (CI: `.github/workflows/android.yml`)
 CI runs on every non-draft PR:
@@ -30,14 +30,13 @@ Replicate locally with the same sequence. Use flavor-specific tasks when needed:
 ```
 app/src/main/java/com/infomaniak/mail/
 ├── MainApplication.kt        # Entry — configureInfomaniakCore()
-├── ui/
-│   └── MainActivity.kt       # Main coordinator (at app/src/main/java/com/infomaniak/mail/ui/)
+├── ui/                       # Compose + XML/ViewBinding screens (MainActivity and UI flows)
+│   └── MainActivity.kt       # Main coordinator
 ├── data/
 │   ├── cache/                # Realm controllers (RealmDatabase.kt — schema versions here)
 │   ├── models/               # Realm entities (Message, Thread, Draft, Mailbox…)
 │   └── api/                  # API service interfaces
 ├── di/                       # Hilt modules
-├── ui/                       # Compose + XML screens
 ├── views/                    # Custom Views + XML/ViewBinding components
 └── workers/                  # WorkManager tasks
 EmojiComponents/              # Custom emoji picker module

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,65 @@
-# Copilot Coding Agent Onboarding Guide for Infomaniak/android-kMail
+# Copilot Coding Agent Onboarding — android-kMail
 
-Before reading this file, please read AGENTS.md to learn more about the project context, structure, and conventions.
+> **Read `AGENTS.md`, `app/AGENTS.md`, and `Core/AGENTS.md`** for architecture, conventions, and module structure. This file covers build, CI, and critical validation rules.
 
-## Pull Request Review Instructions
+## Overview
+Infomaniak Mail for Android — full-featured email client. Hybrid UI (Jetpack Compose for new screens, XML/ViewBinding for existing). Hilt DI, Realm database (3 separate Realm instances), Ktor networking. Two build flavors: `standard` (Google Play, Firebase) and `fdroid`. Two internal modules: `EmojiComponents`, `HtmlCleaner`.
 
-- Ensure strings are localized via `strings.xml` resources.
-- When reviewing Realm model changes, check whether the persisted schema changed: added, removed, renamed, or type-changed persisted properties, changed optionality, lists, embedded objects, or object types.
-- If the persisted Realm schema changed, ensure the matching schema version constant (`USER_INFO_SCHEMA_VERSION`, `MAILBOX_INFO_SCHEMA_VERSION`, or `MAILBOX_CONTENT_SCHEMA_VERSION`) was incremented in `app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt`, and that the relevant migration block in `MailboxContentMigration.kt`, `MailboxInfoMigration.kt`, or `RealmMigrations.kt` is updated when existing data needs migration.
-- Ensure new UI written in Jetpack Compose uses Material3 components and follows the hybrid approach (Compose for new screens, XML with ViewBinding for existing, supports different screen sizes).
+## One-Time Environment Setup
+```bash
+git submodule update --init --recursive   # pull Core submodule — required for Gradle settings plugin
+cp env.example.properties env.properties  # fill sentryAuthToken (use a dummy value locally)
+```
+Missing `env.properties` or uninitialized submodule → Gradle config phase fails.
+
+## Build & Test (CI: `.github/workflows/android.yml`)
+CI runs on every non-draft PR:
+```bash
+./gradlew clean
+./gradlew build                         # all flavors
+./gradlew testDebugUnitTest --stacktrace
+```
+Replicate locally with the same sequence. Use flavor-specific tasks when needed:
+```bash
+./gradlew assembleStandardDebug
+./gradlew assembleFdroidDebug
+./gradlew testStandardDebugUnitTest
+```
+
+## Project Layout
+```
+app/src/main/java/com/infomaniak/mail/
+├── MainApplication.kt        # Entry — configureInfomaniakCore() (NetworkConfiguration + AuthConfiguration)
+├── MainActivity.kt           # Main coordinator
+├── data/
+│   ├── cache/                # Realm controllers (RealmDatabase.kt — schema versions here)
+│   ├── models/               # Realm entities (Message, Thread, Draft, Mailbox…)
+│   └── api/                  # API service interfaces
+├── di/                       # Hilt modules
+├── ui/                       # Compose + XML screens
+└── workers/                  # WorkManager tasks
+EmojiComponents/              # Custom emoji picker module
+HtmlCleaner/                  # HTML sanitization module
+Core/                         # Git submodule — Infomaniak shared library
+gradle/libs.versions.toml
+```
+
+## ⚠️ Realm Schema — Critical Rule
+Realm has **3 separate databases**, each with its own schema version constant in `RealmDatabase.kt`:
+- `USER_INFO_SCHEMA_VERSION`
+- `MAILBOX_INFO_SCHEMA_VERSION`
+- `MAILBOX_CONTENT_SCHEMA_VERSION`
+
+**When changing a persisted Realm model** (add/remove/rename property, change type, optionality, lists, embedded objects):
+1. Increment the matching schema version constant in `RealmDatabase.kt`.
+2. Add a migration block in the matching migration file: `RealmMigrations.kt`, `MailboxInfoMigration.kt`, or `MailboxContentMigration.kt`.
+
+Forgetting this causes a crash at runtime on user devices with existing data.
+
+## Key Rules
+- All user-visible strings in `res/values/strings.xml` — never hardcoded.
+- New UI must use **Jetpack Compose + Material3**; do not add new XML screens.
+- `standard` flavor only: Firebase, Google services (`standardImplementation`). fdroid builds must compile without them.
+- `isCoreLibraryDesugaringEnabled = true` — Java 8+ APIs are available via desugaring.
+- `env.properties` is git-ignored — never commit it.
+- When adding/removing a runtime dependency, update `LICENSES.md` at the repo root.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,8 +29,7 @@ Replicate locally with the same sequence. Use flavor-specific tasks when needed:
 ## Project Layout
 ```
 app/src/main/java/com/infomaniak/mail/
-├── MainApplication.kt        # Entry — configureInfomaniakCore() (NetworkConfiguration + AuthConfiguration)
-├── MainActivity.kt           # Main coordinator
+├── MainApplication.kt        # Entry — configureInfomaniakCore()
 ├── data/
 │   ├── cache/                # Realm controllers (RealmDatabase.kt — schema versions here)
 │   ├── models/               # Realm entities (Message, Thread, Draft, Mailbox…)
@@ -44,22 +43,11 @@ Core/                         # Git submodule — Infomaniak shared library
 gradle/libs.versions.toml
 ```
 
-## ⚠️ Realm Schema — Critical Rule
-Realm has **3 separate databases**, each with its own schema version constant in `RealmDatabase.kt`:
-- `USER_INFO_SCHEMA_VERSION`
-- `MAILBOX_INFO_SCHEMA_VERSION`
-- `MAILBOX_CONTENT_SCHEMA_VERSION`
+## PR Review Instructions
 
-**When changing a persisted Realm model** (add/remove/rename property, change type, optionality, lists, embedded objects):
-1. Increment the matching schema version constant in `RealmDatabase.kt`.
-2. Add a migration block in the matching migration file: `RealmMigrations.kt`, `MailboxInfoMigration.kt`, or `MailboxContentMigration.kt`.
-
-Forgetting this causes a crash at runtime on user devices with existing data.
-
-## Key Rules
-- All user-visible strings in `res/values/strings.xml` — never hardcoded.
-- New UI must use **Jetpack Compose + Material3**; do not add new XML screens.
-- `standard` flavor only: Firebase, Google services (`standardImplementation`). fdroid builds must compile without them.
-- `isCoreLibraryDesugaringEnabled = true` — Java 8+ APIs are available via desugaring.
-- `env.properties` is git-ignored — never commit it.
+- Ensure strings are localized via `strings.xml` resources.
+- When reviewing Realm model changes, check whether the persisted schema changed: added, removed, renamed, or type-changed persisted properties, changed optionality, lists, embedded objects, or object types.
+- If the persisted Realm schema changed, ensure the matching schema version constant (`USER_INFO_SCHEMA_VERSION`, `MAILBOX_INFO_SCHEMA_VERSION`, or `MAILBOX_CONTENT_SCHEMA_VERSION`) was incremented in `app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt`, and that the relevant migration block in `MailboxContentMigration.kt`, `MailboxInfoMigration.kt`, or `RealmMigrations.kt` is updated when existing data needs migration.
+- Ensure new UI written in Jetpack Compose uses Material3 components and follows the hybrid approach (Compose for new screens, XML with ViewBinding for existing, supports different screen sizes).
+- `standard` flavor only: Firebase, Google services — fdroid builds must compile without them.
 - When adding/removing a runtime dependency, update `LICENSES.md` at the repo root.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Infomaniak Mail for Android — full-featured email client. Hybrid UI (Jetpack C
 git submodule update --init --recursive   # pull Core submodule — required for Gradle settings plugin
 cp env.example.properties env.properties  # fill sentryAuthToken (use a dummy value locally)
 ```
-Missing `env.properties` or uninitialized submodule → Gradle config phase fails.
+Missing `Core/` submodule → Gradle config phase fails. Missing `env.properties` only blocks *release* tasks (requires `sentryAuthToken`); debug builds work without it (the file is optional).
 
 ## Build & Test (CI: `.github/workflows/android.yml`)
 CI runs on every non-draft PR:
@@ -38,6 +38,7 @@ app/src/main/java/com/infomaniak/mail/
 │   └── api/                  # API service interfaces
 ├── di/                       # Hilt modules
 ├── ui/                       # Compose + XML screens
+├── views/                    # Custom Views + XML/ViewBinding components
 └── workers/                  # WorkManager tasks
 EmojiComponents/              # Custom emoji picker module
 HtmlCleaner/                  # HTML sanitization module

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,8 @@ Replicate locally with the same sequence. Use flavor-specific tasks when needed:
 ```
 app/src/main/java/com/infomaniak/mail/
 ├── MainApplication.kt        # Entry — configureInfomaniakCore()
+├── ui/
+│   └── MainActivity.kt       # Main coordinator (at app/src/main/java/com/infomaniak/mail/ui/)
 ├── data/
 │   ├── cache/                # Realm controllers (RealmDatabase.kt — schema versions here)
 │   ├── models/               # Realm entities (Message, Thread, Draft, Mailbox…)
@@ -45,7 +47,7 @@ gradle/libs.versions.toml
 
 ## PR Review Instructions
 
-- Ensure strings are localized via `strings.xml` resources.
+- Ensure strings are localized via `strings.xml` resources (located at `app/src/main/res/values/strings.xml`).
 - When reviewing Realm model changes, check whether the persisted schema changed: added, removed, renamed, or type-changed persisted properties, changed optionality, lists, embedded objects, or object types.
 - If the persisted Realm schema changed, ensure the matching schema version constant (`USER_INFO_SCHEMA_VERSION`, `MAILBOX_INFO_SCHEMA_VERSION`, or `MAILBOX_CONTENT_SCHEMA_VERSION`) was incremented in `app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt`, and that the relevant migration block in `MailboxContentMigration.kt`, `MailboxInfoMigration.kt`, or `RealmMigrations.kt` is updated when existing data needs migration.
 - Ensure new UI written in Jetpack Compose uses Material3 components and follows the hybrid approach (Compose for new screens, XML with ViewBinding for existing, supports different screen sizes).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Infomaniak Mail for Android — full-featured email client. Hybrid UI (Jetpack C
 git submodule update --init --recursive   # pull Core submodule — required for Gradle settings plugin
 cp env.example.properties env.properties  # fill sentryAuthToken (use a dummy value locally)
 ```
-Missing `Core/` submodule → Gradle config phase fails. `env.properties` is required for release variants (including `./gradlew build` as used in CI); debug-only tasks work without it.
+Missing `Core/` submodule → Gradle config phase fails. `env.properties` is required for explicit *Release* tasks (e.g. `assembleStandardRelease`, `bundleStandardRelease`); debug-only tasks work without it.
 
 ## Build & Test (CI: `.github/workflows/android.yml`)
 CI runs on every non-draft PR:


### PR DESCRIPTION
Expands the onboarding instructions to include:
- One-time environment setup (submodule init, env.properties)
- Build & test commands matching CI exactly
- Project layout with key paths
- Expanded Realm schema migration rules
- LICENSES.md maintenance reminder