### PR TITLE
fix: Remove scroll jumps

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -437,6 +437,9 @@ class ThreadAdapter(
 
     private fun WebView.setupZoomListeners() {
         configureOnTouchListener(scaledTouchSlop)
+        setOnScrollChangeListener { _, _, scrollY, _, _ ->
+            if (scrollY != 0) scrollTo(0, 0)
+        }
     }
 
     private fun ItemMessageBinding.toggleFrameLayoutsTheme(isThemeTheSame: Boolean) {


### PR DESCRIPTION
**Problem**
The scroll jumps at the bottom of a long email.

**Technical root cause**
The email WebView accumulates internal vertical scroll instead of letting the parent NestedScrollView handle all vertical scrolling. When the user scrolls down with a finger on the WebView, it silently consumes part of the gesture. Once the WebView's internal scroll is exhausted, the remaining gesture is abruptly forwarded to the parent, causing a visible jump.

**Fix**
Force the WebView's scrollY to remain 0 so it never consumes vertical scroll, ensuring the parent NestedScrollView receives the full gesture from the start.