### PR TITLE
fix: Disable send button to prevent double sending

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -982,21 +982,19 @@ class NewMessageFragment : Fragment() {
             requireActivity().finishAppAndRemoveTaskIfNeeded()
         }
 
-        if (newMessageViewModel.isSending.value) return
-
-        newMessageViewModel.setSending(true)
+        if (!newMessageViewModel.tryStartSending()) return
 
         viewLifecycleOwner.lifecycleScope.launch {
             try {
-                if (isSubjectBlank() && showSubjectDialog(isScheduled)) return@launch
+                if (isSubjectBlank() && shouldCancelForEmptySubject(isScheduled)) return@launch
 
                 val body = binding.editorWebView.evaluateJs("getEditorBody()").removeSurrounding("\"")
                 val shouldShowAttachmentReminder = newMessageViewModel.shouldShowAttachmentReminder(body)
 
-                if (shouldShowAttachmentReminder && showAttachmentDialog(isScheduled)) return@launch
+                if (shouldShowAttachmentReminder && shouldCancelForAttachmentReminder(isScheduled)) return@launch
                 sendEmail()
             } finally {
-                newMessageViewModel.setSending(false)
+                newMessageViewModel.finishSending()
             }
         }
     }
@@ -1031,7 +1029,7 @@ class NewMessageFragment : Fragment() {
         return isSendingCanceled.await()
     }
 
-    private suspend fun showSubjectDialog(isScheduled: Boolean) = showConfirmationDialog(
+    private suspend fun shouldCancelForEmptySubject(isScheduled: Boolean) = showConfirmationDialog(
         titleRes = R.string.emailWithoutSubjectTitle,
         descriptionRes = R.string.emailWithoutSubjectDescription,
         trackEvent = MatomoName.SendWithoutSubject,
@@ -1039,7 +1037,7 @@ class NewMessageFragment : Fragment() {
         isScheduled = isScheduled,
     )
 
-    private suspend fun showAttachmentDialog(isScheduled: Boolean) = showConfirmationDialog(
+    private suspend fun shouldCancelForAttachmentReminder(isScheduled: Boolean) = showConfirmationDialog(
         titleRes = R.string.attachmentsReminderTitle,
         descriptionRes = R.string.attachmentsReminderDescription,
         trackEvent = MatomoName.SendWithoutAttachment,

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageFragment.kt
@@ -931,9 +931,13 @@ class NewMessageFragment : Fragment() {
     }
 
     private fun setupSendButtons(mailbox: Mailbox) = with(binding) {
-        newMessageViewModel.isSendingAllowed.observe(viewLifecycleOwner) {
-            scheduleButton.isEnabled = it
-            sendButton.isEnabled = it
+        viewLifecycleOwner.lifecycleScope.launch {
+            combine(newMessageViewModel.isSendingAllowed, newMessageViewModel.isSending) { isAllowed, isSending ->
+                isAllowed && !isSending
+            }.collect { isEnabled ->
+                scheduleButton.isEnabled = isEnabled
+                sendButton.isEnabled = isEnabled
+            }
         }
 
         scheduleButton.setOnClickListener {
@@ -978,14 +982,22 @@ class NewMessageFragment : Fragment() {
             requireActivity().finishAppAndRemoveTaskIfNeeded()
         }
 
+        if (newMessageViewModel.isSending.value) return
+
+        newMessageViewModel.setSending(true)
+
         viewLifecycleOwner.lifecycleScope.launch {
-            if (isSubjectBlank() && showSubjectDialog(isScheduled)) return@launch
+            try {
+                if (isSubjectBlank() && showSubjectDialog(isScheduled)) return@launch
 
-            val body = binding.editorWebView.evaluateJs("getEditorBody()").removeSurrounding("\"")
-            val shouldShowAttachmentReminder = newMessageViewModel.shouldShowAttachmentReminder(body)
+                val body = binding.editorWebView.evaluateJs("getEditorBody()").removeSurrounding("\"")
+                val shouldShowAttachmentReminder = newMessageViewModel.shouldShowAttachmentReminder(body)
 
-            if (shouldShowAttachmentReminder && showAttachmentDialog(isScheduled)) return@launch
-            sendEmail()
+                if (shouldShowAttachmentReminder && showAttachmentDialog(isScheduled)) return@launch
+                sendEmail()
+            } finally {
+                newMessageViewModel.setSending(false)
+            }
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -232,7 +232,15 @@ class NewMessageViewModel @Inject constructor(
     val encryptionPassword: SingleLiveEvent<String> = SingleLiveEvent("")
     //endregion
 
-    val isSendingAllowed = SingleLiveEvent(false)
+    private val _isSendingAllowed = MutableStateFlow(false)
+    val isSendingAllowed: StateFlow<Boolean> = _isSendingAllowed.asStateFlow()
+
+    private val _isSending = MutableStateFlow(false)
+    val isSending: StateFlow<Boolean> = _isSending.asStateFlow()
+
+    fun setSending(value: Boolean) {
+        _isSending.value = value
+    }
 
     // Boolean: For toggleable actions, `false` if the formatting has been removed and `true` if the formatting has been applied.
     val editorAction = SingleLiveEvent<Pair<EditorAction, Boolean?>>()
@@ -885,7 +893,7 @@ class NewMessageViewModel @Inject constructor(
             null -> allRecipients
         }
 
-        isSendingAllowed.value = if (allDraftRecipients.isNotEmpty() && isEncryptionValid) {
+        _isSendingAllowed.value = if (allDraftRecipients.isNotEmpty() && isEncryptionValid) {
             var size = 0L
             var isSizeCorrect = true
             for (attachment in attachments) {

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -238,9 +238,11 @@ class NewMessageViewModel @Inject constructor(
     private val _isSending = MutableStateFlow(false)
     val isSending: StateFlow<Boolean> = _isSending.asStateFlow()
 
-    fun setSending(value: Boolean) {
-        _isSending.value = value
+    fun finishSending() {
+        _isSending.value = false
     }
+
+    fun tryStartSending(): Boolean = _isSending.compareAndSet(expect = false, update = true)
 
     // Boolean: For toggleable actions, `false` if the formatting has been removed and `true` if the formatting has been applied.
     val editorAction = SingleLiveEvent<Pair<EditorAction, Boolean?>>()


### PR DESCRIPTION
Issue: It is theoretically possible to send the same email twice. This happened to me accidentally, but it is very difficult to reproduce.

This PR provides a fix, however, it could not be tested because the issue is not easily reproducible.