### PR TITLE
fix: Prevent attachment error

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -285,6 +285,10 @@ class ThreadController @Inject constructor(private val mailboxContentRealm: Real
 
                     if (apiResponse.isSuccess()) {
                         apiResponse.data?.also { remoteMessage ->
+
+                            val freshLocalMessage = MessageController.getMessageBlocking(localMessage.uid, realm = this)
+                            if (freshLocalMessage?.isFullyDownloaded() == true) return@also
+
                             val swissTransferFiles = swissTransferContainer?.let { container ->
                                 SwissTransferContainerController.upsertSwissTransferContainer(container, realm = this)
                                 container.swissTransferFiles

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/ThreadController.kt
@@ -285,10 +285,6 @@ class ThreadController @Inject constructor(private val mailboxContentRealm: Real
 
                     if (apiResponse.isSuccess()) {
                         apiResponse.data?.also { remoteMessage ->
-
-                            val freshLocalMessage = MessageController.getMessageBlocking(localMessage.uid, realm = this)
-                            if (freshLocalMessage?.isFullyDownloaded() == true) return@also
-
                             val swissTransferFiles = swissTransferContainer?.let { container ->
                                 SwissTransferContainerController.upsertSwissTransferContainer(container, realm = this)
                                 container.swissTransferFiles

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -515,7 +515,13 @@ class ThreadViewModel @Inject constructor(
     fun fetchMessagesHeavyData(messages: List<Message>) {
         fetchMessagesJob?.cancel()
         fetchMessagesJob = viewModelScope.launch(ioCoroutineContext) {
-            val (deleted, failed) = ThreadController.fetchMessagesHeavyData(messages, mailboxContentRealm())
+            val realm = mailboxContentRealm()
+            val messagesToFetch = messages.filter { message ->
+                MessageController.getMessageBlocking(message.uid, realm)?.isFullyDownloaded() != true
+            }
+            if (messagesToFetch.isEmpty()) return@launch
+
+            val (deleted, failed) = ThreadController.fetchMessagesHeavyData(messagesToFetch, realm)
             if (deleted.isNotEmpty() || failed.isNotEmpty()) {
 
                 // TODO: A race condition exists between the two notify in the ThreadAdapter.


### PR DESCRIPTION
Issue: The call is executed twice in a specific scenario, causing an error when clicking on the attachment

Two solutions:

- **First solution** (from the first commit): During the write operation, check if the attachment already exists; if so, ignore the response from the second call.
- **Second solution** (from the second commit): Address the root cause more directly by preventing the second call from executing if the first one succeeds.