### PR TITLE
fix: Correct archive threads from a custom folder

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ActionsViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ActionsViewModel.kt
@@ -472,7 +472,7 @@ class ActionsViewModel @Inject constructor(
     ) {
         if (messages.isEmpty()) return
         val roles = folderRoleUtils.getActionFolderRoles(messages)
-        val isFromArchive = roles.all { it == FolderRole.ARCHIVE }
+        val isFromArchive = roles.isNotEmpty() && roles.all { it == FolderRole.ARCHIVE }
         val destinationFolderRole = if (isFromArchive) FolderRole.INBOX else FolderRole.ARCHIVE
         val destinationFolder = folderController.getFolder(destinationFolderRole) ?: return
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/MultiSelectBottomSheetDialog.kt
@@ -131,7 +131,7 @@ class MultiSelectBottomSheetDialog : ActionsBottomSheetDialog() {
             val messages = threads.flatMap { it.messages }
             val messagesFolderRoles = folderRoleUtils.getActionFolderRoles(messages)
             val isFromArchive = mainViewModel.currentFolder.value?.role == FolderRole.ARCHIVE ||
-                    messagesFolderRoles.all { it == FolderRole.ARCHIVE }
+                    (messagesFolderRoles.isNotEmpty() && messagesFolderRoles.all { it == FolderRole.ARCHIVE })
             setupMainActions(threads, threadsUids, shouldRead, folderRole, messagesFolderRoles)
             setStateDependentUi(shouldRead, shouldFavorite, isFromArchive, threads)
         }


### PR DESCRIPTION
Custom folders have no FolderRole, so the empty roles list made `roles.all { it == FolderRole.ARCHIVE }` return true and the thread was moved to the Inbox instead of the Archive.