### PR TITLE
feat: Remove refresh acknowledgement on click to use new flag in activities

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/extensions/MessageExtensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/extensions/MessageExtensions.kt
@@ -139,6 +139,8 @@ fun Message.updateFlags(flags: DefaultMessageFlags) {
     isForwarded = flags.isForwarded
     isScheduledMessage = flags.isScheduledMessage
 
+    if (flags.isAcknowledged) acknowledgeStatus = AcknowledgeStatus.Acknowledged
+
     if (flags.isSeen && snoozeState == SnoozeState.Unsnoozed) {
         snoozeState = null
         snoozeEndDate = null

--- a/app/src/main/java/com/infomaniak/mail/data/models/getMessages/DefaultMessageFlags.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/getMessages/DefaultMessageFlags.kt
@@ -34,4 +34,6 @@ data class DefaultMessageFlags(
     val isScheduledMessage: Boolean,
     @SerialName("seen")
     val isSeen: Boolean,
+    @SerialName("acknowledged")
+    val isAcknowledged: Boolean,
 ) : MessageFlags

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -62,7 +62,6 @@ import com.infomaniak.mail.data.models.extensions.calendarAttachment
 import com.infomaniak.mail.data.models.extensions.displayedName
 import com.infomaniak.mail.data.models.extensions.isInSpamFolder
 import com.infomaniak.mail.data.models.extensions.isMe
-import com.infomaniak.mail.data.models.extensions.isPendingAcknowledgementForMe
 import com.infomaniak.mail.data.models.extensions.isReplyAuthorized
 import com.infomaniak.mail.data.models.mailbox.Mailbox
 import com.infomaniak.mail.data.models.mailbox.SenderDetails
@@ -708,13 +707,6 @@ class ThreadAdapter(
                 isUnscheduledDraft -> threadAdapterCallbacks?.onDraftClicked?.invoke(message)
                 else -> {
                     isExpandedMap[message.uid] = true
-                    if (message.isPendingAcknowledgementForMe()) {
-                        threadAdapterCallbacks?.onMessageExpanded?.invoke(
-                            message.hasPendingAcknowledgement,
-                            message.uid,
-                            message.resource
-                        )
-                    }
                     onExpandOrCollapseMessage(message, shouldTrack = true)
                 }
             }
@@ -1399,7 +1391,6 @@ class ThreadAdapter(
         var navigateToDownloadProgressDialog: ((Attachment, AttachmentIntentType) -> Unit)? = null,
         var onUnsubscribeClicked: ((Message) -> Unit)? = null,
         var onAcknowledgeClicked: ((Message) -> Unit)? = null,
-        var onMessageExpanded: ((hasPendingAcknowledgement: Boolean, messageUid: String, resource: String) -> Unit)? = null,
         var moveMessageToSpam: ((String) -> Unit)? = null,
         var activateSpamFilter: (() -> Unit)? = null,
         var unblockMail: ((String) -> Unit)? = null,

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -416,7 +416,6 @@ class ThreadFragment : Fragment(), PickerEmojiObserver {
                 },
                 onUnsubscribeClicked = threadViewModel::unsubscribeMessage,
                 onAcknowledgeClicked = threadViewModel::acknowledgeMessage,
-                onMessageExpanded = threadViewModel::refreshMessageIfNeeded,
                 moveMessageToSpam = { messageUid ->
                     actionsViewModel.moveToSpamFolder(
                         messagesUid = listOf(messageUid),

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -113,7 +113,6 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.invoke
-import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -121,7 +120,6 @@ import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import splitties.coroutines.suspendLazy
 import splitties.experimental.ExperimentalSplittiesApi
-import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 
 /* Please note that, for the moment, the logic that uses this list assumes that the items are necessarily messages.
@@ -161,8 +159,6 @@ class ThreadViewModel @Inject constructor(
     ).mapNotNull { it.obj }
 
     private val currentMailboxLive = currentMailboxFlow.asLiveData()
-
-    private val refreshingAcknowledgeMessagesUids = ConcurrentHashMap<String, Job>()
 
     private val featureFlagsFlow = currentMailboxFlow.map { it.featureFlags }
 
@@ -275,13 +271,6 @@ class ThreadViewModel @Inject constructor(
                         val shouldExpand = message.shouldBeExpanded(index, displayedMessages.lastIndex)
                         threadState.isExpandedMap[message.uid] = shouldExpand
                         threadState.isThemeTheSameMap[message.uid] = true
-                        if (shouldExpand && message.isPendingAcknowledgementForMe()) {
-                            refreshMessageIfNeeded(
-                                message.hasPendingAcknowledgement,
-                                message.uid,
-                                message.resource
-                            )
-                        }
                     }
                 }
 
@@ -805,31 +794,6 @@ class ThreadViewModel @Inject constructor(
             snackbarManager.postValue(appContext.getString(R.string.snackbarAcknowledgementFailure))
             setAcknowledgeState(message, MessageUi.AcknowledgeState.Pending)
         }
-    }
-
-    fun refreshMessageIfNeeded(hasPendingAcknowledgement: Boolean, messageUid: String, resource: String) {
-        if (!hasPendingAcknowledgement) return
-
-        refreshingAcknowledgeMessagesUids[messageUid]?.cancel()
-
-        val job = viewModelScope.launch {
-            try {
-                val apiResponse = ApiRepository.getMessage(resource)
-                val responseMessage = apiResponse.data
-
-                if (apiResponse.isSuccess() && responseMessage != null) {
-                    mailboxContentRealm().write {
-                        MessageController.updateMessageBlocking(messageUid, realm = this) { localMessage ->
-                            localMessage?.acknowledgeStatus = responseMessage.acknowledgeStatus
-                        }
-                    }
-                }
-            } finally {
-                refreshingAcknowledgeMessagesUids.remove(messageUid, coroutineContext.job)
-            }
-        }
-
-        refreshingAcknowledgeMessagesUids[messageUid] = job
     }
 
     private fun setUnsubscribeState(message: Message, state: UnsubscribeState) {


### PR DESCRIPTION
Previously, messages with a pending read receipt needed a refresh every time they were opened to sync the status between web and mobile. This PR uses new backend activity notifications to update the status automatically, removing the need for extra refreshes.

