### PR TITLE
feat: Remove yes, no and maybe from the app and use the shared ones from core

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/TitleAlertDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/alertDialogs/TitleAlertDialog.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak Mail - Android
- * Copyright (C) 2023-2024 Infomaniak Network SA
+ * Copyright (C) 2023-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@ package com.infomaniak.mail.ui.alertDialogs
 
 import android.content.Context
 import androidx.annotation.StringRes
-import com.infomaniak.mail.R
+import com.infomaniak.core.common.R
 import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
 import javax.inject.Inject

--- a/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/menuDrawer/MenuDrawerFragment.kt
@@ -79,6 +79,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import com.infomaniak.core.common.R as RCore
 
 @AndroidEntryPoint
 class MenuDrawerFragment : Fragment() {
@@ -223,8 +224,8 @@ class MenuDrawerFragment : Fragment() {
                     confirmDeleteFolderDialog.show(
                         title = requireContext().getString(R.string.deleteFolderDialogTitle),
                         description = getStringWithBoldArg(R.string.deleteFolderDialogDescription, folderName),
-                        positiveButtonText = R.string.buttonYes,
-                        negativeButtonText = R.string.buttonNo,
+                        positiveButtonText = RCore.string.buttonYes,
+                        negativeButtonText = RCore.string.buttonNo,
                         onPositiveButtonClicked = {
                             trackManageFolderEvent(MatomoName.DeleteConfirm)
                             mainViewModel.deleteFolder(folderId)

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/AiPropositionFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/AiPropositionFragment.kt
@@ -264,7 +264,7 @@ class AiPropositionFragment : Fragment() {
                 displayLoader = false,
                 displayCancelButton = true,
                 positiveButtonText = R.string.aiReplacementDialogPositiveButton,
-                negativeButtonText = R.string.buttonNo,
+                negativeButtonText = RCore.string.buttonNo,
                 onPositiveButtonClicked = {
                     trackAiWriterEvent(MatomoName.ReplaceSubjectConfirm)
                     applyProposition(subject, content)

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Kursiv</string>
     <string name="buttonLoadMore">Indlæs flere samtaler</string>
     <string name="buttonLogInDifferentAccount">Log ind med en anden konto</string>
-    <string name="buttonMaybe">Måske</string>
     <string name="buttonModify">Ændr</string>
     <string name="buttonMore">Mere</string>
     <string name="buttonNewMessage">Ny besked</string>
-    <string name="buttonNo">Nej</string>
     <string name="buttonOpenMyCalendar">Åbn i min kalender</string>
     <string name="buttonRefuse">Afvis</string>
     <string name="buttonReschedule">Omlæg</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Ingen</string>
     <string name="buttonUpgrade">Opgrader</string>
     <string name="buttonValid">Bekræft</string>
-    <string name="buttonYes">Ja</string>
     <string name="calendarAllDayLong">Hele dagen</string>
     <string name="calendarNotInvited">Du er ikke inviteret</string>
     <string name="calendarOrganizerName">%s (Arrangør)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Kursiv</string>
     <string name="buttonLoadMore">Mehr Unterhaltungen laden</string>
     <string name="buttonLogInDifferentAccount">Mit einem anderen Konto anmelden</string>
-    <string name="buttonMaybe">Vielleicht</string>
     <string name="buttonModify">Ändern</string>
     <string name="buttonMore">Mehr</string>
     <string name="buttonNewMessage">Neue Nachricht</string>
-    <string name="buttonNo">Nein</string>
     <string name="buttonOpenMyCalendar">In meinem Kalender öffnen</string>
     <string name="buttonRefuse">Abfälle</string>
     <string name="buttonReschedule">Neu planen</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Keine</string>
     <string name="buttonUpgrade">Upgrade</string>
     <string name="buttonValid">Validieren Sie</string>
-    <string name="buttonYes">Ja</string>
     <string name="calendarAllDayLong">Gesamter Tag</string>
     <string name="calendarNotInvited">Sie zählen nicht zu den eingeladenen Personen</string>
     <string name="calendarOrganizerName">%s (Organisator)</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Πλάγια</string>
     <string name="buttonLoadMore">Φόρτωση περισσότερων συζητήσεων</string>
     <string name="buttonLogInDifferentAccount">Σύνδεση με άλλο λογαριασμό</string>
-    <string name="buttonMaybe">Ίσως</string>
     <string name="buttonModify">Τροποποίηση</string>
     <string name="buttonMore">Περισσότερα</string>
     <string name="buttonNewMessage">Νέο μήνυμα</string>
-    <string name="buttonNo">Όχι</string>
     <string name="buttonOpenMyCalendar">Άνοιγμα στο ημερολόγιό μου</string>
     <string name="buttonRefuse">Απόρριψη</string>
     <string name="buttonReschedule">Επαναπρογραμματισμός</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Κανένα</string>
     <string name="buttonUpgrade">Αναβάθμιση</string>
     <string name="buttonValid">Επικύρωση</string>
-    <string name="buttonYes">Ναι</string>
     <string name="calendarAllDayLong">Όλη την ημέρα</string>
     <string name="calendarNotInvited">Δεν είστε προσκεκλημένος</string>
     <string name="calendarOrganizerName">%s (Διοργανωτής)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Cursiva</string>
     <string name="buttonLoadMore">Cargar más conversaciones</string>
     <string name="buttonLogInDifferentAccount">Conectarse con otra cuenta</string>
-    <string name="buttonMaybe">Quizás</string>
     <string name="buttonModify">Modificar</string>
     <string name="buttonMore">Más</string>
     <string name="buttonNewMessage">Nuevo mensaje</string>
-    <string name="buttonNo">No</string>
     <string name="buttonOpenMyCalendar">Abrir en mi calendario</string>
     <string name="buttonRefuse">Desechos</string>
     <string name="buttonReschedule">Reprogramar</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Ninguno</string>
     <string name="buttonUpgrade">Mejorar</string>
     <string name="buttonValid">Validar</string>
-    <string name="buttonYes">Sí</string>
     <string name="calendarAllDayLong">Todo el día</string>
     <string name="calendarNotInvited">No estás invitado</string>
     <string name="calendarOrganizerName">%s (Organizador)</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Kursiivi</string>
     <string name="buttonLoadMore">Lataa lisää keskusteluja</string>
     <string name="buttonLogInDifferentAccount">Kirjaudu sisään toisella tilillä</string>
-    <string name="buttonMaybe">Ehkä</string>
     <string name="buttonModify">Muokkaa</string>
     <string name="buttonMore">Lisää</string>
     <string name="buttonNewMessage">Uusi viesti</string>
-    <string name="buttonNo">Ei</string>
     <string name="buttonOpenMyCalendar">Avaa kalenterissani</string>
     <string name="buttonRefuse">Hylkää</string>
     <string name="buttonReschedule">Aikatauluta uudelleen</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Ei mitään</string>
     <string name="buttonUpgrade">Päivitä</string>
     <string name="buttonValid">Vahvista</string>
-    <string name="buttonYes">Kyllä</string>
     <string name="calendarAllDayLong">Koko päivä</string>
     <string name="calendarNotInvited">Et ole kutsuttu</string>
     <string name="calendarOrganizerName">%s (Järjestäjä)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Italique</string>
     <string name="buttonLoadMore">Charger plus de conversations</string>
     <string name="buttonLogInDifferentAccount">Me connecter avec un autre compte</string>
-    <string name="buttonMaybe">Peut-être</string>
     <string name="buttonModify">Modifier</string>
     <string name="buttonMore">Plus</string>
     <string name="buttonNewMessage">Nouveau message</string>
-    <string name="buttonNo">Non</string>
     <string name="buttonOpenMyCalendar">Ouvrir dans mon calendrier</string>
     <string name="buttonRefuse">Refuser</string>
     <string name="buttonReschedule">Reprogrammer</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Aucun</string>
     <string name="buttonUpgrade">Évoluer</string>
     <string name="buttonValid">Valider</string>
-    <string name="buttonYes">Oui</string>
     <string name="calendarAllDayLong">Toute la journée</string>
     <string name="calendarNotInvited">Vous ne faites pas partie des invités</string>
     <string name="calendarOrganizerName">%s (Organisateur)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Corsivo</string>
     <string name="buttonLoadMore">Carica altre conversazioni</string>
     <string name="buttonLogInDifferentAccount">Accedi con un altro account</string>
-    <string name="buttonMaybe">Forse</string>
     <string name="buttonModify">Modificare</string>
     <string name="buttonMore">Altro</string>
     <string name="buttonNewMessage">Nuovo messaggio</string>
-    <string name="buttonNo">No</string>
     <string name="buttonOpenMyCalendar">Apri nel mio calendario</string>
     <string name="buttonRefuse">Rifiuta</string>
     <string name="buttonReschedule">Riprogrammare</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Nessuno</string>
     <string name="buttonUpgrade">Aggiornamento</string>
     <string name="buttonValid">Convalidare</string>
-    <string name="buttonYes">Sì</string>
     <string name="calendarAllDayLong">Tutta la giornata</string>
     <string name="calendarNotInvited">Non fai parte degli invitati</string>
     <string name="calendarOrganizerName">%s (Organizzatore)</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Kursiv</string>
     <string name="buttonLoadMore">Last flere samtaler</string>
     <string name="buttonLogInDifferentAccount">Logg inn med en annen konto</string>
-    <string name="buttonMaybe">Kanskje</string>
     <string name="buttonModify">Endre</string>
     <string name="buttonMore">Mer</string>
     <string name="buttonNewMessage">Ny melding</string>
-    <string name="buttonNo">Nei</string>
     <string name="buttonOpenMyCalendar">Åpne i kalenderen min</string>
     <string name="buttonRefuse">Avslå</string>
     <string name="buttonReschedule">Endre timeplan</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Ingen</string>
     <string name="buttonUpgrade">Oppgrader</string>
     <string name="buttonValid">Bekreft</string>
-    <string name="buttonYes">Ja</string>
     <string name="calendarAllDayLong">Hele dagen</string>
     <string name="calendarNotInvited">Du er ikke invitert</string>
     <string name="calendarOrganizerName">%s (Arrangør)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Cursief</string>
     <string name="buttonLoadMore">Meer gesprekken laden</string>
     <string name="buttonLogInDifferentAccount">Inloggen met een ander account</string>
-    <string name="buttonMaybe">Misschien</string>
     <string name="buttonModify">Wijzigen</string>
     <string name="buttonMore">Meer</string>
     <string name="buttonNewMessage">Nieuw bericht</string>
-    <string name="buttonNo">Nee</string>
     <string name="buttonOpenMyCalendar">Openen in mijn agenda</string>
     <string name="buttonRefuse">Weigeren</string>
     <string name="buttonReschedule">Herschikken</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Geen</string>
     <string name="buttonUpgrade">Upgraden</string>
     <string name="buttonValid">Valideren</string>
-    <string name="buttonYes">Ja</string>
     <string name="calendarAllDayLong">De hele dag</string>
     <string name="calendarNotInvited">U bent niet uitgenodigd</string>
     <string name="calendarOrganizerName">%s (Organisator)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -154,11 +154,9 @@
     <string name="buttonItalic">Kursywa</string>
     <string name="buttonLoadMore">Załaduj więcej rozmów</string>
     <string name="buttonLogInDifferentAccount">Zaloguj się innym kontem</string>
-    <string name="buttonMaybe">Może</string>
     <string name="buttonModify">Modyfikuj</string>
     <string name="buttonMore">Więcej</string>
     <string name="buttonNewMessage">Nowa wiadomość</string>
-    <string name="buttonNo">Nie</string>
     <string name="buttonOpenMyCalendar">Otwórz w moim kalendarzu</string>
     <string name="buttonRefuse">Odmów</string>
     <string name="buttonReschedule">Przełóż</string>
@@ -180,7 +178,6 @@
     <string name="buttonUnselectAll">Nic</string>
     <string name="buttonUpgrade">Ulepsz</string>
     <string name="buttonValid">Zatwierdź</string>
-    <string name="buttonYes">Tak</string>
     <string name="calendarAllDayLong">Cały dzień</string>
     <string name="calendarNotInvited">Nie jesteś zaproszony</string>
     <string name="calendarOrganizerName">%s (Organizator)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Itálico</string>
     <string name="buttonLoadMore">Carregar mais conversas</string>
     <string name="buttonLogInDifferentAccount">Iniciar sessão com outra conta</string>
-    <string name="buttonMaybe">Talvez</string>
     <string name="buttonModify">Modificar</string>
     <string name="buttonMore">Mais</string>
     <string name="buttonNewMessage">Nova mensagem</string>
-    <string name="buttonNo">Não</string>
     <string name="buttonOpenMyCalendar">Abrir no meu calendário</string>
     <string name="buttonRefuse">Recusar</string>
     <string name="buttonReschedule">Reagendar</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Nenhum</string>
     <string name="buttonUpgrade">Atualizar</string>
     <string name="buttonValid">Validar</string>
-    <string name="buttonYes">Sim</string>
     <string name="calendarAllDayLong">O dia todo</string>
     <string name="calendarNotInvited">Não foi convidado</string>
     <string name="calendarOrganizerName">%s (Organizador)</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -148,11 +148,9 @@
     <string name="buttonItalic">Kursiv</string>
     <string name="buttonLoadMore">Ladda fler konversationer</string>
     <string name="buttonLogInDifferentAccount">Logga in med ett annat konto</string>
-    <string name="buttonMaybe">Kanske</string>
     <string name="buttonModify">Ändra</string>
     <string name="buttonMore">Mer</string>
     <string name="buttonNewMessage">Nytt meddelande</string>
-    <string name="buttonNo">Nej</string>
     <string name="buttonOpenMyCalendar">Öppna i min kalender</string>
     <string name="buttonRefuse">Avböj</string>
     <string name="buttonReschedule">Schemalägg om</string>
@@ -174,7 +172,6 @@
     <string name="buttonUnselectAll">Ingen</string>
     <string name="buttonUpgrade">Uppgradera</string>
     <string name="buttonValid">Validera</string>
-    <string name="buttonYes">Ja</string>
     <string name="calendarAllDayLong">Hela dagen</string>
     <string name="calendarNotInvited">Du är inte inbjuden</string>
     <string name="calendarOrganizerName">%s (Arrangör)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,11 +152,9 @@
     <string name="buttonItalic">Italic</string>
     <string name="buttonLoadMore">Load more conversations</string>
     <string name="buttonLogInDifferentAccount">Log in with another account</string>
-    <string name="buttonMaybe">Maybe</string>
     <string name="buttonModify">Modify</string>
     <string name="buttonMore">More</string>
     <string name="buttonNewMessage">New message</string>
-    <string name="buttonNo">No</string>
     <string name="buttonOpenMyCalendar">Open in my calendar</string>
     <string name="buttonRefuse">Refuse</string>
     <string name="buttonReschedule">Reschedule</string>
@@ -178,7 +176,6 @@
     <string name="buttonUnselectAll">None</string>
     <string name="buttonUpgrade">Upgrade</string>
     <string name="buttonValid">Validate</string>
-    <string name="buttonYes">Yes</string>
     <string name="calendarAllDayLong">All day long</string>
     <string name="calendarNotInvited">You are not invited</string>
     <string name="calendarOrganizerName">%s (Organizer)</string>


### PR DESCRIPTION
"yes" and "no" were already defined inside of core and "maybe" just got moved to core, so none of the three are needed anymore. We removed them from mail to use the shared one instead