### PR TITLE
feat: Sync reminder icon visibility across devices and refresh message when the reminder is added by the backend

### DIFF
--- a/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/data/models/message/Message.kt
+++ b/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/data/models/message/Message.kt
@@ -144,6 +144,7 @@ class Message : RealmObject, Snoozable {
     var reminder: ReminderMessageInfo? = null
     @SerialName("reminder_action")
     var reminderAction: String? = null
+    // isReminder and displayReminder are provided by the backend only for messages that are hidden in the UI
     @SerialName("is_reminder")
     var isReminder: Boolean = false
     @SerialName("display_reminder")
@@ -180,6 +181,8 @@ class Message : RealmObject, Snoozable {
     var hasAttachable: Boolean = false
     @Transient
     var emojiReactions: RealmList<EmojiReactionState> = realmListOf()
+    @Transient
+    var shouldRefreshReminder: Boolean = false
     //endregion
 
     //region UI data (Transient & Ignore)
@@ -248,6 +251,7 @@ class Message : RealmObject, Snoozable {
         this.latestCalendarEventResponse = localValues.latestCalendarEventResponse
         this.swissTransferFiles.replaceContent(localValues.swissTransferFiles)
         this.emojiReactions = localValues.emojiReactions
+        this.shouldRefreshReminder = localValues.shouldRefreshReminder
 
         this.shortUid = uid.toShortUid()
         this.hasAttachable = hasAttachments || swissTransferUuid != null
@@ -263,6 +267,7 @@ class Message : RealmObject, Snoozable {
         latestCalendarEventResponse = latestCalendarEventResponse,
         swissTransferFiles = swissTransferFiles,
         emojiReactions = emojiReactions,
+        shouldRefreshReminder = shouldRefreshReminder,
     )
 
     private fun keepHeavyData(message: Message) {
@@ -337,6 +342,7 @@ class Message : RealmObject, Snoozable {
         val latestCalendarEventResponse: CalendarEventResponse? = null,
         val swissTransferFiles: RealmList<SwissTransferFile> = realmListOf(),
         val emojiReactions: RealmList<EmojiReactionState> = realmListOf(),
+        val shouldRefreshReminder: Boolean = false,
     )
 
     companion object {

--- a/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/data/models/message/Message.kt
+++ b/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/data/models/message/Message.kt
@@ -216,7 +216,7 @@ class Message : RealmObject, Snoozable {
 
     val isReaction get() = emojiReaction != null
 
-    val shouldHideReminder get() = isReminder && !displayReminder
+    val isReminderHidden get() = isReminder && !displayReminder
 
     val threads by backlinks(Thread::messages)
 

--- a/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/data/models/message/Message.kt
+++ b/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/data/models/message/Message.kt
@@ -216,7 +216,7 @@ class Message : RealmObject, Snoozable {
 
     val isReaction get() = emojiReaction != null
 
-    val isReminderHidden get() = isReminder && !displayReminder
+    val isHiddenReminder get() = isReminder && !displayReminder
 
     val threads by backlinks(Thread::messages)
 

--- a/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/data/models/message/Message.kt
+++ b/OldKotlin/realm-models/src/main/kotlin/com/infomaniak/mail/data/models/message/Message.kt
@@ -147,7 +147,7 @@ class Message : RealmObject, Snoozable {
     @SerialName("is_reminder")
     var isReminder: Boolean = false
     @SerialName("display_reminder")
-    var displayReminder: Boolean = false
+    var displayReminder: Boolean = true
     //endregion
 
     //region Local data (Transient)

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -206,7 +206,7 @@ object RealmDatabase {
         //region Configurations versions
         const val USER_INFO_SCHEMA_VERSION = 5L
         const val MAILBOX_INFO_SCHEMA_VERSION = 19L
-        const val MAILBOX_CONTENT_SCHEMA_VERSION = 40L
+        const val MAILBOX_CONTENT_SCHEMA_VERSION = 41L
         //endregion
 
         //region Configurations names

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/ThreadRecomputations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/ThreadRecomputations.kt
@@ -44,7 +44,7 @@ object ThreadRecomputations {
         val allMessages = messages
 
         val lastCurrentFolderMessage = allMessages.lastOrNull {
-            it.folderId == folderId && !(it.shouldHideReminder && it.isScheduledDraft)
+            it.folderId == folderId && !(it.isReminderHidden && it.isScheduledDraft)
         }
         val lastMessage = if (isFromSearch) {
             // In the search, some threads (such as threads from the snooze folder) won't have any messages with the same folderId
@@ -129,7 +129,7 @@ object ThreadRecomputations {
             isAnswered = false
         }
         if (message.hasAttachable) hasAttachable = true
-        if (message.isScheduledDraft && !message.shouldHideReminder) numberOfScheduledDrafts++
+        if (message.isScheduledDraft && !message.isReminderHidden) numberOfScheduledDrafts++
         updateSnoozeStatesBasedOn(message)
     }
 
@@ -181,7 +181,7 @@ object ThreadRecomputations {
 
             val targetMessageIds = message.inReplyTo ?: ""
             val isHiddenEmojiReaction = message.isReaction && isTargetMessageInThread(targetMessageIds, threadMessageIds)
-            val isHiddenReminder = message.shouldHideReminder
+            val isHiddenReminder = message.isReminderHidden
                     && (isTargetMessageInThread(targetMessageIds, threadMessageIds) || message.isScheduledDraft)
             if (isHiddenEmojiReaction.not() && isHiddenReminder.not()) messagesWithContent += message
         }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/ThreadRecomputations.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxContent/refreshStrategies/ThreadRecomputations.kt
@@ -44,7 +44,7 @@ object ThreadRecomputations {
         val allMessages = messages
 
         val lastCurrentFolderMessage = allMessages.lastOrNull {
-            it.folderId == folderId && !(it.isReminderHidden && it.isScheduledDraft)
+            it.folderId == folderId && !(it.isHiddenReminder && it.isScheduledDraft)
         }
         val lastMessage = if (isFromSearch) {
             // In the search, some threads (such as threads from the snooze folder) won't have any messages with the same folderId
@@ -129,7 +129,7 @@ object ThreadRecomputations {
             isAnswered = false
         }
         if (message.hasAttachable) hasAttachable = true
-        if (message.isScheduledDraft && !message.isReminderHidden) numberOfScheduledDrafts++
+        if (message.isScheduledDraft && !message.isHiddenReminder) numberOfScheduledDrafts++
         updateSnoozeStatesBasedOn(message)
     }
 
@@ -181,7 +181,7 @@ object ThreadRecomputations {
 
             val targetMessageIds = message.inReplyTo ?: ""
             val isHiddenEmojiReaction = message.isReaction && isTargetMessageInThread(targetMessageIds, threadMessageIds)
-            val isHiddenReminder = message.isReminderHidden
+            val isHiddenReminder = message.isHiddenReminder
                     && (isTargetMessageInThread(targetMessageIds, threadMessageIds) || message.isScheduledDraft)
             if (isHiddenEmojiReaction.not() && isHiddenReminder.not()) messagesWithContent += message
         }

--- a/app/src/main/java/com/infomaniak/mail/data/models/extensions/MessageExtensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/extensions/MessageExtensions.kt
@@ -140,7 +140,6 @@ fun Message.updateFlags(flags: DefaultMessageFlags) {
     isMessageWithSendDelay = flags.isMessageWithSendDelay
     if (flags.isAcknowledged) acknowledgeStatus = AcknowledgeStatus.Acknowledged
     shouldRefreshReminder = flags.hasReminder
-    isReminder = flags.hasReminder
     if (!flags.hasReminder) reminder = null
 
     if (flags.isSeen && snoozeState == SnoozeState.Unsnoozed) {

--- a/app/src/main/java/com/infomaniak/mail/data/models/extensions/MessageExtensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/extensions/MessageExtensions.kt
@@ -139,6 +139,7 @@ fun Message.updateFlags(flags: DefaultMessageFlags) {
     isForwarded = flags.isForwarded
     isMessageWithSendDelay = flags.isMessageWithSendDelay
     if (flags.isAcknowledged) acknowledgeStatus = AcknowledgeStatus.Acknowledged
+    shouldRefreshReminder = flags.hasReminder
     isReminder = flags.hasReminder
     if (!flags.hasReminder) reminder = null
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/extensions/MessageExtensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/extensions/MessageExtensions.kt
@@ -138,8 +138,9 @@ fun Message.updateFlags(flags: DefaultMessageFlags) {
     isAnswered = flags.isAnswered
     isForwarded = flags.isForwarded
     isMessageWithSendDelay = flags.isMessageWithSendDelay
-
     if (flags.isAcknowledged) acknowledgeStatus = AcknowledgeStatus.Acknowledged
+    isReminder = flags.hasReminder
+    if (!flags.hasReminder) reminder = null
 
     if (flags.isSeen && snoozeState == SnoozeState.Unsnoozed) {
         snoozeState = null

--- a/app/src/main/java/com/infomaniak/mail/data/models/getMessages/DefaultMessageFlags.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/getMessages/DefaultMessageFlags.kt
@@ -36,4 +36,6 @@ data class DefaultMessageFlags(
     val isSeen: Boolean,
     @SerialName("acknowledged")
     val isAcknowledged: Boolean,
+    @SerialName("has_reminder")
+    val hasReminder: Boolean,
 ) : MessageFlags

--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -816,7 +816,7 @@ class MainViewModel @Inject constructor(
         val currentIndex = thread.messages.indexOfFirst { it.uid == message.uid }
         if (currentIndex == -1) return false
         val messagesAfter = thread.messages.drop(currentIndex + 1)
-        return messagesAfter.isEmpty() || messagesAfter.all { it.isDraft }
+        return messagesAfter.isEmpty() || messagesAfter.all { it.isDraft || it.isHiddenReminder }
     }
 
     fun refreshDraftFolderWhenDraftArrives(scheduledMessageEtop: Long) = viewModelScope.launch(ioCoroutineContext) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -719,6 +719,7 @@ class ThreadAdapter(
                 else -> {
                     isExpandedMap[message.uid] = true
                     onExpandOrCollapseMessage(message, shouldTrack = true)
+                    threadAdapterCallbacks?.onMessageExpanded?.invoke(message)
                 }
             }
         }
@@ -1570,6 +1571,7 @@ class ThreadAdapter(
         var onModifyReminderClicked: ((Message) -> Unit)? = null,
         var onAddReminderClicked: ((Message) -> Unit)? = null,
         var onMarkAsDoneReminderClicked: ((Message) -> Unit)? = null,
+        var onMessageExpanded: ((Message) -> Unit)? = null,
         val getFeatureFlags: (() -> Mailbox.FeatureFlagSet?)? = null,
         var onAskEuriaClicked: ((message: Message) -> Unit)? = null,
     )

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -502,6 +502,7 @@ class ThreadFragment : Fragment(), PickerEmojiObserver {
                 onModifyReminderClicked = ::modifyReminder,
                 onAddReminderClicked = ::addReminder,
                 onMarkAsDoneReminderClicked = ::markAsDoneReminder,
+                onMessageExpanded = threadViewModel::refreshMessageIfNeeded,
                 onAskEuriaClicked = { message ->
                     trackMessageActionsEvent(MatomoName.AskEuriaQuickAction)
                     navigateToAskEuriaBottomSheet(message.uid)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -275,15 +275,18 @@ class ThreadViewModel @Inject constructor(
             threadFlow.filterNotNull().onEach { thread ->
                 val featureFlags = featureFlagsFlow.first()
 
+                val displayedMessages = thread.getDisplayedMessages(featureFlags, localSettings)
+
                 // These 2 will always be empty or not all together at the same time.
                 if (threadState.isExpandedMap.isEmpty() || threadState.isThemeTheSameMap.isEmpty()) {
-                    val displayedMessages = thread.getDisplayedMessages(featureFlags, localSettings)
                     displayedMessages.forEachIndexed { index, message ->
-                        val shouldExpand = message.shouldBeExpanded(index, displayedMessages.lastIndex)
-                        threadState.isExpandedMap[message.uid] = shouldExpand
+                        threadState.isExpandedMap[message.uid] = message.shouldBeExpanded(index, displayedMessages.lastIndex)
                         threadState.isThemeTheSameMap[message.uid] = true
-                        if (shouldExpand) refreshMessageIfNeeded(message)
                     }
+                }
+
+                displayedMessages.forEach { message ->
+                    if (threadState.isExpandedMap[message.uid] == true) refreshMessageIfNeeded(message)
                 }
 
                 if (threadState.isFirstOpening) {
@@ -996,7 +999,7 @@ class ThreadViewModel @Inject constructor(
         }
     }
 
-    private fun refreshMessageIfNeeded(message: Message) {
+    fun refreshMessageIfNeeded(message: Message) {
         if (!message.shouldRefreshReminder || !message.isFullyDownloaded()) return
 
         viewModelScope.launch(ioCoroutineContext) {

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadViewModel.kt
@@ -282,6 +282,7 @@ class ThreadViewModel @Inject constructor(
                         val shouldExpand = message.shouldBeExpanded(index, displayedMessages.lastIndex)
                         threadState.isExpandedMap[message.uid] = shouldExpand
                         threadState.isThemeTheSameMap[message.uid] = true
+                        if (shouldExpand) refreshMessageIfNeeded(message)
                     }
                 }
 
@@ -992,6 +993,28 @@ class ThreadViewModel @Inject constructor(
         } else {
             snackbarManager.postValue(appContext.getString(R.string.snackbarAcknowledgementFailure))
             setAcknowledgeState(message, MessageUi.AcknowledgeState.Pending)
+        }
+    }
+
+    private fun refreshMessageIfNeeded(message: Message) {
+        if (!message.shouldRefreshReminder || !message.isFullyDownloaded()) return
+
+        viewModelScope.launch(ioCoroutineContext) {
+            val apiResponse = ApiRepository.getMessage(message.resource)
+            val remoteMessage = apiResponse.data ?: return@launch
+            if (!apiResponse.isSuccess()) return@launch
+
+            updateMessageWithRefetchedData(message.uid, remoteMessage)
+        }
+    }
+
+    private suspend fun updateMessageWithRefetchedData(messageUid: String, remoteMessage: Message) {
+        mailboxContentRealm().write {
+            MessageController.getMessageBlocking(messageUid, realm = this)?.let { localMessage ->
+                remoteMessage.keepLocalValues(localMessage)
+                remoteMessage.shouldRefreshReminder = false
+                MessageController.upsertMessageBlocking(remoteMessage, realm = this)
+            }
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -1220,7 +1220,8 @@ class NewMessageViewModel @Inject constructor(
                 .mapTo(mutableSetOf()) { it.localUuid } &&
                     draftSnapshot.scheduleDate == getCurrentScheduleDate() &&
                     draftSnapshot.reminderDraftInfo?.reminderDelta == getCurrentReminderDelta() &&
-                    (draftSnapshot.reminderDraftInfo?.shouldRemindRecipient ?: DEFAULT_SHOULD_REMIND_RECIPIENT) == shouldRemindRecipient.value &&
+                    (draftSnapshot.reminderDraftInfo?.shouldRemindRecipient
+                        ?: DEFAULT_SHOULD_REMIND_RECIPIENT) == shouldRemindRecipient.value &&
                     draftSnapshot.shouldRequestAcknowledgment == shouldRequestAcknowledgment.value
         } ?: false
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/newMessage/NewMessageViewModel.kt
@@ -266,7 +266,7 @@ class NewMessageViewModel @Inject constructor(
     private val _reminderConfig = MutableStateFlow<ReminderConfig>(ReminderConfig.None)
     val reminderConfig: StateFlow<ReminderConfig> = _reminderConfig.asStateFlow()
 
-    private val _shouldRemindRecipient = MutableStateFlow(true)
+    private val _shouldRemindRecipient = MutableStateFlow(DEFAULT_SHOULD_REMIND_RECIPIENT)
     val shouldRemindRecipient: StateFlow<Boolean> = _shouldRemindRecipient.asStateFlow()
 
     private val _shouldRequestAcknowledgment = MutableStateFlow(localSettings.askEmailAcknowledgement)
@@ -1220,7 +1220,7 @@ class NewMessageViewModel @Inject constructor(
                 .mapTo(mutableSetOf()) { it.localUuid } &&
                     draftSnapshot.scheduleDate == getCurrentScheduleDate() &&
                     draftSnapshot.reminderDraftInfo?.reminderDelta == getCurrentReminderDelta() &&
-                    draftSnapshot.reminderDraftInfo?.shouldRemindRecipient == shouldRemindRecipient.value &&
+                    (draftSnapshot.reminderDraftInfo?.shouldRemindRecipient ?: DEFAULT_SHOULD_REMIND_RECIPIENT) == shouldRemindRecipient.value &&
                     draftSnapshot.shouldRequestAcknowledgment == shouldRequestAcknowledgment.value
         } ?: false
     }
@@ -1363,6 +1363,8 @@ class NewMessageViewModel @Inject constructor(
 
     companion object {
         private val TAG = NewMessageViewModel::class.java.simpleName
+
+        private const val DEFAULT_SHOULD_REMIND_RECIPIENT = true
 
         private const val ATTACHMENTS_MAX_SIZE = 25L * 1_024L * 1_024L // 25 MB
         private const val SUBJECT_MAX_LENGTH = 998

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -136,7 +136,7 @@ class SearchUtils @Inject constructor(
     }
 
     private fun Thread.removeHiddenReminders() {
-        messages.removeAll { it.isReminderHidden }
+        messages.removeAll { it.isHiddenReminder }
     }
 
     private fun Thread.setFolderId(filterFolder: Folder?) {

--- a/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/SearchUtils.kt
@@ -136,7 +136,7 @@ class SearchUtils @Inject constructor(
     }
 
     private fun Thread.removeHiddenReminders() {
-        messages.removeAll { it.shouldHideReminder }
+        messages.removeAll { it.isReminderHidden }
     }
 
     private fun Thread.setFolderId(filterFolder: Folder?) {

--- a/app/src/main/java/com/infomaniak/mail/utils/ThreadListUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ThreadListUtils.kt
@@ -57,6 +57,6 @@ object ThreadListUtils {
     }
 
     fun hasReminders(messages: List<Message>): Boolean = messages.any { message ->
-        (message.reminder != null || message.shouldRefreshReminder) && !message.isReminderHidden
+        (message.reminder != null || message.shouldRefreshReminder) && !message.isHiddenReminder
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/utils/ThreadListUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ThreadListUtils.kt
@@ -57,6 +57,6 @@ object ThreadListUtils {
     }
 
     fun hasReminders(messages: List<Message>): Boolean = messages.any { message ->
-        (message.reminder != null || message.shouldRefreshReminder) && !message.shouldHideReminder
+        (message.reminder != null || message.shouldRefreshReminder) && !message.isReminderHidden
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/utils/ThreadListUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ThreadListUtils.kt
@@ -57,6 +57,6 @@ object ThreadListUtils {
     }
 
     fun hasReminders(messages: List<Message>): Boolean = messages.any { message ->
-        (message.reminder != null || message.isReminder) && !message.shouldHideReminder
+        (message.reminder != null || message.shouldRefreshReminder) && !message.shouldHideReminder
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/utils/ThreadListUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/ThreadListUtils.kt
@@ -57,6 +57,6 @@ object ThreadListUtils {
     }
 
     fun hasReminders(messages: List<Message>): Boolean = messages.any { message ->
-        message.reminder != null && !message.shouldHideReminder
+        (message.reminder != null || message.isReminder) && !message.shouldHideReminder
     }
 }


### PR DESCRIPTION
Add a flag provided by an activity to display the icon when the reminder is created and remove the icon when the reminder is canceled on another device